### PR TITLE
dev NirField fix du V-model

### DIFF
--- a/src/components/NirField/NirField.vue
+++ b/src/components/NirField/NirField.vue
@@ -45,6 +45,13 @@
 	const numberValue = ref('')
 	const keyValue = ref('')
 
+	const unmaskedNumberValue = computed(() => numberValue.value.replace(/\s/g, ''))
+
+	watch(() => props.modelValue, async (value) => {
+		numberValue.value = value?.slice(0, 13) ?? ''
+		keyValue.value = value?.slice(13, 15) ?? ''
+	}, { immediate: true })
+
 	// Etats d’erreur/succès
 	const errors = ref<string[]>([])
 	const successes = ref<string[]>([])
@@ -168,9 +175,11 @@
 		successes.value = Array.from(new Set(successes.value))
 	}
 
-	watch([numberValue, keyValue], () => {
+	watch([unmaskedNumberValue, keyValue], () => {
 		validateFields()
-		emit('update:modelValue', `${numberValue.value} ${keyValue.value}`)
+		if (unmaskedNumberValue.value + keyValue.value !== props.modelValue) {
+			emit('update:modelValue', `${unmaskedNumberValue.value}${keyValue.value}`)
+		}
 	})
 
 	function validateOnSubmit() {
@@ -212,7 +221,6 @@
 					{{ nirTooltip }}
 				</slot>
 			</VTooltip>
-
 			<SyTextField
 				v-model="numberValue"
 				v-maska="numberMask"


### PR DESCRIPTION
## Description

rendre dynamique les champs du nirField quand le modelValue est renseigné ou/et mis a jour

## Playground

```
<script setup lang="ts">
	import NirField from '@/components/NirField/NirField.vue'
	import { ref } from 'vue'

	const nir = ref('123456789012356')

	setTimeout(() => {
		nir.value = '987654321098765'
	}, 2000)

	setTimeout(() => {
		nir.value = '269054958815780'
	}, 4000)

	setTimeout(() => {
		nir.value = '098765432109876'
	}, 6000)

	const formIsValid = ref<boolean>()
</script>

<template>
	<div>
		{{ formIsValid }}
		<div>
			<VForm v-model="formIsValid">
				<NirField
					v-model="nir"
					@update:model-value="console.warn"
				/>
			</VForm>
		</div>
	</div>
</template>
```

## Type de changement

<!-- Supprimez les options non pertinentes. -->

- Refactoring

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [ ] Ma Pull Request pointe vers la bonne branche
- [ ] Le composant est conforme aux maquettes (tokens)
- [ ] Le composant est fonctionnel
- [ ] Le composant est responsive (mobile, tablet et desktop)
- [ ] Le composant répond aux critères d'accessibilité (test Tanaguru + A11y linter)
- [ ] J'ai effectué une review de mon propre code
- [ ] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai mis en place une stories pour ma fonctionnalité / fix /...
- [ ] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [ ] Les tests unitaires passent localement avec mes modifications
