### PR TITLE
SySelect permettre de récuperer seulement la valeur

### DIFF
--- a/src/components/Customs/SySelect/SySelect.stories.ts
+++ b/src/components/Customs/SySelect/SySelect.stories.ts
@@ -3,6 +3,7 @@ import SySelect from '@/components/Customs/SySelect/SySelect.vue'
 import SyAlert from '@/components/SyAlert/SyAlert.vue'
 import { VBtn, VMenu, VList, VListItem, VListItemTitle } from 'vuetify/components'
 import { ref } from 'vue'
+import { fn } from '@storybook/test'
 
 const meta: Meta<typeof SySelect> = {
 	title: 'Composants/Formulaires/SySelect',
@@ -17,6 +18,18 @@ const meta: Meta<typeof SySelect> = {
 		errorMessages: { control: 'object' },
 		required: { control: 'boolean' },
 		displayAsterisk: { control: 'boolean' },
+		textKey: {
+			control: 'text',
+			description: 'Nom de la propriété qui contient le texte à afficher',
+		},
+		valueKey: {
+			control: 'text',
+			description: 'Nom de la propriété qui contient la valeur à retourner',
+		},
+		returnObject: {
+			control: 'boolean',
+			description: 'Retourne l\'objet complet sélectionné',
+		},
 	},
 } as Meta<typeof SySelect>
 
@@ -53,10 +66,11 @@ export const Default: Story = {
 		],
 	},
 	args: {
-		items: [
+		'items': [
 			{ text: 'Option 1', value: '1' },
 			{ text: 'Option 2', value: '2' },
 		],
+		'onUpdate:modelValue': fn(),
 	},
 	render: (args) => {
 		return {
@@ -107,11 +121,12 @@ export const Required: Story = {
 		],
 	},
 	args: {
-		items: [
+		'items': [
 			{ text: 'Option 1', value: '1' },
 			{ text: 'Option 2', value: '2' },
 		],
-		required: true,
+		'required': true,
+		'onUpdate:modelValue': fn(),
 	},
 	render: (args) => {
 		return {
@@ -172,9 +187,10 @@ const items = [
 	},
 	args: {
 		...Default.args,
-		label: 'Sélectionnez une option',
-		required: true,
-		displayAsterisk: true,
+		'label': 'Sélectionnez une option',
+		'required': true,
+		'displayAsterisk': true,
+		'onUpdate:modelValue': fn(),
 	},
 	render: (args) => {
 		return {
@@ -236,10 +252,11 @@ export const withCustomError: Story = {
 		],
 	},
 	args: {
-		items: [
+		'items': [
 			{ text: 'Option 1', value: '1' },
 			{ text: 'Option 2', value: '2' },
 		],
+		'onUpdate:modelValue': fn(),
 	},
 	render: (args) => {
 		return {
@@ -300,10 +317,11 @@ export const withCustomKey: Story = {
 		],
 	},
 	args: {
-		items: [
+		'items': [
 			{ customKey: 'Choix 1', value: '1' },
 			{ customKey: 'Choix 2', value: '2' },
 		],
+		'onUpdate:modelValue': fn(),
 	},
 	render: (args) => {
 		return {

--- a/src/components/Customs/SySelect/SySelect.vue
+++ b/src/components/Customs/SySelect/SySelect.vue
@@ -48,6 +48,10 @@
 			type: Boolean,
 			default: false,
 		},
+		returnObject: {
+			type: Boolean,
+			default: false,
+		},
 	})
 
 	const emit = defineEmits(['update:modelValue'])
@@ -69,8 +73,14 @@
 
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- This is a generic type
 	const selectItem = (item: any) => {
-		selectedItem.value = item
-		emit('update:modelValue', item)
+		if (props.returnObject) {
+			selectedItem.value = item
+			emit('update:modelValue', item)
+		}
+		else {
+			selectedItem.value = item[props.valueKey]
+			emit('update:modelValue', item[props.valueKey])
+		}
 		isOpen.value = false
 	}
 
@@ -80,9 +90,12 @@
 	}
 
 	const selectedItemText = computed(() => {
-		if (selectedItem.value && typeof selectedItem.value === 'object') {
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- This is a generic type
-			return (selectedItem.value as Record<string, any>)[props.textKey]
+		if (selectedItem.value) {
+			if (props.returnObject) {
+				return (selectedItem.value as Record<string, unknown>)[props.textKey]
+			}
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			return props.items.find((item: any) => item[props.valueKey] === selectedItem.value)?.[props.textKey]
 		}
 		return ''
 	})

--- a/src/components/Customs/SySelect/tests/SySelect.spec.ts
+++ b/src/components/Customs/SySelect/tests/SySelect.spec.ts
@@ -190,4 +190,115 @@ describe('SySelect.vue', () => {
 		await wrapper.vm.closeList()
 		expect(wrapper.vm.isOpen).toBe(false)
 	})
+
+	it('emit the value when returnObject is false', async () => {
+		const wrapper = mount(SySelect, {
+			props: {
+				returnObject: false,
+				items: [{ text: 'Option 1', value: '1' }, { text: 'Option 2', value: '2' }],
+			},
+			global: {
+				plugins: [vuetify],
+			},
+		})
+		await wrapper.find('.sy-select').trigger('click')
+		const firstItem = wrapper.findAll('.v-list-item').at(0)
+		await firstItem!.trigger('click')
+		expect(wrapper.emitted()['update:modelValue'][0]).toEqual(['1'])
+
+		await wrapper.find('.sy-select').trigger('click')
+		const secondItem = wrapper.findAll('.v-list-item').at(1)
+		await secondItem!.trigger('click')
+		expect(wrapper.emitted()['update:modelValue'][1]).toEqual(['2'])
+	})
+
+	it('emit the object when returnObject is true', async () => {
+		const wrapper = mount(SySelect, {
+			props: {
+				returnObject: true,
+				items: [{ text: 'Option 1', value: '1' }, { text: 'Option 2', value: '2' }],
+			},
+			global: {
+				plugins: [vuetify],
+			},
+		})
+
+		await wrapper.find('.sy-select').trigger('click')
+		const firstItem = wrapper.findAll('.v-list-item').at(0)
+		await firstItem!.trigger('click')
+		expect(wrapper.emitted()['update:modelValue'][0]).toEqual([{ text: 'Option 1', value: '1' }])
+
+		await wrapper.find('.sy-select').trigger('click')
+		const secondItem = wrapper.findAll('.v-list-item').at(1)
+		await secondItem!.trigger('click')
+		expect(wrapper.emitted()['update:modelValue'][1]).toEqual([{ text: 'Option 2', value: '2' }])
+	})
+
+	it('emit the value when returnObject is false with textKey and keyValue set', async () => {
+		const wrapper = mount(SySelect, {
+			props: {
+				returnObject: false,
+				textKey: 'theText',
+				valueKey: 'theValue',
+				items: [{ theText: 'Option 1', theValue: '1' }, { theText: 'Option 2', theValue: '2' }],
+			},
+			global: {
+				plugins: [vuetify],
+			},
+		})
+		await wrapper.find('.sy-select').trigger('click')
+		const firstItem = wrapper.findAll('.v-list-item').at(0)
+		await firstItem!.trigger('click')
+		expect(wrapper.emitted()['update:modelValue'][0]).toEqual(['1'])
+
+		await wrapper.find('.sy-select').trigger('click')
+		const secondItem = wrapper.findAll('.v-list-item').at(1)
+		await secondItem!.trigger('click')
+		expect(wrapper.emitted()['update:modelValue'][1]).toEqual(['2'])
+	})
+
+	it('emit the object when returnObject is true with textKey and keyValue set', async () => {
+		const wrapper = mount(SySelect, {
+			props: {
+				returnObject: true,
+				textKey: 'theText',
+				valueKey: 'theValue',
+				items: [{ theText: 'Option 1', theValue: '1' }, { theText: 'Option 2', theValue: '2' }],
+			},
+			global: {
+				plugins: [vuetify],
+			},
+		})
+
+		await wrapper.find('.sy-select').trigger('click')
+		const firstItem = wrapper.findAll('.v-list-item').at(0)
+		await firstItem!.trigger('click')
+		expect(wrapper.emitted()['update:modelValue'][0]).toEqual([{ theText: 'Option 1', theValue: '1' }])
+
+		await wrapper.find('.sy-select').trigger('click')
+		const secondItem = wrapper.findAll('.v-list-item').at(1)
+		await secondItem!.trigger('click')
+		expect(wrapper.emitted()['update:modelValue'][1]).toEqual([{ theText: 'Option 2', theValue: '2' }])
+	})
+
+	it('emit the value when items is an array of string', async () => {
+		const wrapper = mount(SySelect, {
+			props: {
+				items: ['Option 1', 'Option 2'],
+			},
+			global: {
+				plugins: [vuetify],
+			},
+		})
+
+		await wrapper.find('.sy-select').trigger('click')
+		const firstItem = wrapper.findAll('.v-list-item').at(0)
+		await firstItem!.trigger('click')
+		expect(wrapper.emitted()['update:modelValue'][0]).toEqual(['Option 1'])
+
+		await wrapper.find('.sy-select').trigger('click')
+		const secondItem = wrapper.findAll('.v-list-item').at(1)
+		await secondItem!.trigger('click')
+		expect(wrapper.emitted()['update:modelValue'][1]).toEqual(['Option 2'])
+	})
 })


### PR DESCRIPTION
## Description

Modification du composant SySelect afin que son comportement se rapproche d'aventage du composant du vuetify 'VSelect': Ajout de la props 'return-object' pour permettre de retourné au choix l'object ou seulement la value.


## Type de changement

<!-- Supprimez les options non pertinentes. -->

- Changement cassant


## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Le composant est conforme aux maquettes (tokens)
- [x] Le composant est fonctionnel
- [ ] Le composant est responsive (mobile, tablet et desktop)
- [ ] Le composant répond aux critères d'accessibilité (test Tanaguru + A11y linter)
- [ ] J'ai effectué une review de mon propre code
- [ ] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai mis en place une stories pour ma fonctionnalité / fix /...
- [ ] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [ ] Les tests unitaires passent localement avec mes modifications
