### PR TITLE
filterInline support des VSelect

### DIFF
--- a/src/composables/useFilterable/useFilterable.ts
+++ b/src/composables/useFilterable/useFilterable.ts
@@ -28,8 +28,8 @@ export default function useFilterable(model: Ref<FilterProp>, emits) {
 		return slugify(name, { lower: true })
 	}
 
-	function getChips(toto: FilterItem): ChipItem[] {
-		const { value, formatChip } = toto
+	function getChips(filter: FilterItem): ChipItem[] {
+		const { value, formatChip } = filter
 
 		if (value !== undefined && formatChip) {
 			return formatChip(value)
@@ -63,7 +63,7 @@ export default function useFilterable(model: Ref<FilterProp>, emits) {
 				}
 
 				return {
-					text: item.text || item.value.toString(),
+					text: item.title || item.text || item.value.toString(),
 					value: item,
 				}
 			})
@@ -92,7 +92,8 @@ export default function useFilterable(model: Ref<FilterProp>, emits) {
 			return Object.keys(typedValue).map((key) => {
 				// Use text property if it exists, else use value property or default to key value
 				const text
-					= typedValue[key].text
+					= typedValue[key].title
+						|| typedValue[key].text
 						|| typedValue[key].value?.toString()
 						|| typedValue[key].toString()
 


### PR DESCRIPTION
## Description

Dans vuetify2 le label des VSelect était par défaut la propriété 'text' des items. Les composants de filtres géraient cette propriété pour l'afficher dans les chips a la place de la value (quand la props 'return-object' est a true donc)

Dans vutify3 le label dans Les VSelect est par défaut la propriété 'title'.

Cette PR a pour object de gérer la propriété 'title" de la même façon que la propriété 'text' l'était.

## Stories

<!-- Lien de la/les stories pour cette fonctionnalitée -->

## Type de changement

<!-- Supprimez les options non pertinentes. -->

- Maintenance

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Le composant est conforme aux maquettes (tokens)
- [x] Le composant est fonctionnel
- [x] Le composant est responsive (mobile, tablet et desktop)
- [x] Le composant répond aux critères d'accessibilité (test Tanaguru + A11y linter)
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai mis en place une stories pour ma fonctionnalité / fix /...
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
