### PR TITLE
fix de l'export des type

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "main": "./dist/design-system-v3.umd.cjs",
   "module": "./dist/design-system-v3.js",
-  "types": "./dist/src/main.d.ts",
+  "types": "./dist/main.d.ts",
   "exports": {
     ".": {
       "import": "./dist/design-system-v3.js",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -65,9 +65,9 @@ function generateVuetifyGlobals() {
 export default defineConfig({
 	plugins: [
 		dts({
-			exclude: ['**/*.stories.ts'],
+			exclude: ['**/*.stories.ts', '**/*.spec.ts'],
 			entryRoot: 'src',
-			outDir: 'dist/src',
+			outDir: 'dist',
 			tsconfigPath: 'tsconfig.app.json',
 			rollupTypes: false,
 			insertTypesEntry: true,


### PR DESCRIPTION
## Description
Nous avons constaté une erreure typescript lorsque la librairie était utilisé avec une propriété "moduleResolution" différente de "node" dans le fichier "tsconfig" du projet. Le fait de rendre disponible le fichier de déclaration de type a la racine du projet semble résoudre le problème

## Type de changement

<!-- Supprimez les options non pertinentes. -->

- Refactoring

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Le composant est conforme aux maquettes (tokens)
- [x] Le composant est fonctionnel
- [x] Le composant est responsive (mobile, tablet et desktop)
- [x] Le composant répond aux critères d'accessibilité (test Tanaguru + A11y linter)
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai mis en place une stories pour ma fonctionnalité / fix /...
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
