### PR TITLE
[DatePicker] Fix du problème d'ouverture du menu

### DIFF
--- a/src/components/DatePicker/DatePicker.vue
+++ b/src/components/DatePicker/DatePicker.vue
@@ -606,6 +606,7 @@
 						:bg-color="props.bgColor"
 						is-clearable
 						title="Date Picker"
+						@click="openDatePicker"
 						@focus="openDatePicker"
 						@update:model-value="updateSelectedDates"
 						@prepend-icon-click="openDatePicker"


### PR DESCRIPTION
## Description
Le menu doit s'ouvrir au clic sur le champ, même si celui-ci est déjà focalisé et que le menu a été fermé auparavant.

## Stories

<!-- Lien de la/les stories pour cette fonctonnalitée -->

## Type de changement

<!-- Supprimez les options non pertinentes. -->

- Correction de bug
