### PR TITLE
fix readonly and some fixes

### DIFF
--- a/src/components/Customs/SyInputSelect/SyInputSelect.stories.ts
+++ b/src/components/Customs/SyInputSelect/SyInputSelect.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/vue3'
 import SyInputSelect from './SyInputSelect.vue'
-import { VBtn, VMenu, VList, VListItem, VListItemTitle } from 'vuetify/components'
+import { VBtn, VMenu, VList, VListItem, VListItemTitle, VForm } from 'vuetify/components'
 import { ref } from 'vue'
 import SyAlert from '@/components/SyAlert/SyAlert.vue'
 
@@ -444,4 +444,158 @@ export const Info: Story = {
 		}
 	},
 	tags: ['!dev'],
+}
+
+export const FormValidation: Story = {
+	parameters: {
+		docs: {
+			description: {
+				story: 'Exemple d\'utilisation du SyInputSelect dans un formulaire avec validation.',
+			},
+		},
+		sourceCode: [
+			{
+				name: 'Template',
+				code: `
+<template>
+  <VForm ref="form" @submit.prevent="validateForm">
+    <SyInputSelect
+      ref="selectField"
+      v-model="formData.option"
+      :items="options"
+      label="Option"
+      required
+      display-asterisk
+      :error-messages="errorMessages"
+      class="mb-1"
+    />
+    <VBtn
+      type="submit"
+      color="primary"
+      class="mt-1"
+    >
+      Valider
+    </VBtn>
+  </VForm>
+  <div v-if="formSubmitted" class="mt-1 success--text">
+    Formulaire validé avec succès !
+  </div>
+</template>
+        `,
+			},
+			{
+				name: 'Script',
+				code: `
+<script setup lang="ts">
+import { ref } from 'vue'
+import SyInputSelect from '@cnamts/synapse'
+import { VBtn, VForm } from 'vuetify/components'
+
+const form = ref(null)
+const selectField = ref(null)
+const formData = ref({
+  option: ''
+})
+
+const errorMessages = ref([])
+const formSubmitted = ref(false)
+
+const options = [
+  { text: 'Option 1', value: '1' },
+  { text: 'Option 2', value: '2' },
+  { text: 'Option 3', value: '3' },
+]
+
+const validateForm = () => {
+  // Réinitialiser
+  formSubmitted.value = false
+  
+  // Valider le champ avec la méthode validateOnSubmit
+  const isValid = selectField.value.validateOnSubmit()
+  
+  if (!isValid) {
+    return
+  }
+  
+  // Si tout est valide
+  formSubmitted.value = true
+  console.log('Formulaire soumis:', formData.value)
+}
+</script>
+        `,
+			},
+		],
+	},
+	args: {
+		items: [
+			{ text: 'Option 1', value: '1' },
+			{ text: 'Option 2', value: '2' },
+			{ text: 'Option 3', value: '3' },
+		],
+		label: 'Option',
+		required: true,
+		displayAsterisk: true,
+	},
+	render: (args) => {
+		return {
+			components: { SyInputSelect, VBtn, VForm },
+			setup() {
+				const form = ref(null)
+				const selectField = ref<InstanceType<typeof SyInputSelect> | null>(null)
+				const formData = ref({
+					option: '',
+				})
+
+				const errorMessages = ref([])
+				const formSubmitted = ref(false)
+
+				const validateForm = () => {
+					// Réinitialiser
+					formSubmitted.value = false
+
+					// Vérifier que selectField n'est pas null avant d'appeler validateOnSubmit
+					if (!selectField.value) {
+						console.error('La référence au champ de sélection est nulle')
+						return
+					}
+
+					// Valider le champ avec la méthode validateOnSubmit
+					const isValid = selectField.value.validateOnSubmit()
+
+					if (!isValid) {
+						return
+					}
+
+					// Si tout est valide
+					formSubmitted.value = true
+					console.log('Formulaire soumis:', formData.value)
+				}
+
+				return { args, form, selectField, formData, errorMessages, formSubmitted, validateForm }
+			},
+			template: `
+				<div class="pa-4">
+					<VForm ref="form" @submit.prevent="validateForm">
+						<SyInputSelect
+							ref="selectField"
+							v-model="formData.option"
+							v-bind="args"
+							:error-messages="errorMessages"
+							class="mb-1"
+						/>
+						<VBtn
+							type="submit"
+							color="primary"
+							class="mt-1"
+						>
+							Valider
+						</VBtn>
+					</VForm>
+					<div v-if="formSubmitted" class="mt-1 success--text">
+						Formulaire validé avec succès !
+					</div>
+				</div>
+			`,
+		}
+	},
 }

--- a/src/components/Customs/SyInputSelect/tests/SyInputSelect.spec.ts
+++ b/src/components/Customs/SyInputSelect/tests/SyInputSelect.spec.ts
@@ -4,137 +4,417 @@ import SyInputSelect from '../SyInputSelect.vue'
 import { vuetify } from '@tests/unit/setup'
 
 describe('SyInputSelect', () => {
-	it('renders the component with default props', () => {
-		const wrapper = mount(SyInputSelect, {
-			global: {
-				plugins: [vuetify],
-			},
+	describe('Rendu et affichage', () => {
+		it('renders the component with default props', () => {
+			const wrapper = mount(SyInputSelect, {
+				global: {
+					plugins: [vuetify],
+				},
+			})
+			expect(wrapper.exists()).toBe(true)
+			expect(wrapper.find('.sy-input-select').text()).toBe('Sélectionnez une option')
 		})
-		expect(wrapper.exists()).toBe(true)
-		expect(wrapper.find('.sy-input-select').text()).toBe('Sélectionnez une option')
+
+		it('displays the selected item text', async () => {
+			const items = [{ text: 'Option 1', value: '1' }, { text: 'Option 2', value: '2' }]
+			const wrapper = mount(SyInputSelect, {
+				props: { items, modelValue: { text: 'Option 1', value: '1' } },
+				global: {
+					plugins: [vuetify],
+				},
+			})
+			expect(wrapper.find('.sy-input-select').text()).toContain('Option 1')
+		})
+
+		it('does not render error messages when not provided', () => {
+			const wrapper = mount(SyInputSelect, {
+				global: {
+					plugins: [vuetify],
+				},
+			})
+			expect(wrapper.find('.v-messages__message').exists()).toBe(false)
+		})
+
+		it('does not render the label when not provided', () => {
+			const wrapper = mount(SyInputSelect, {
+				global: {
+					plugins: [vuetify],
+				},
+			})
+			expect(wrapper.find('label').exists()).toBe(false)
+		})
+
+		it('formats items correctly', () => {
+			const items = ['Option 1', 'Option 2']
+			const wrapper = mount(SyInputSelect, {
+				props: { items, textKey: 'text', valueKey: 'value' },
+				global: {
+					plugins: [vuetify],
+				},
+			})
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- This is a generic type
+			const formattedItems = (wrapper.vm as any).formattedItems
+			expect(formattedItems).toEqual([
+				{ text: 'Option 1', value: 'Option 1' },
+				{ text: 'Option 2', value: 'Option 2' },
+			])
+		})
+
+		it('applies the correct button class when outlined is true', () => {
+			const wrapper = mount(SyInputSelect, {
+				props: { outlined: true },
+				global: {
+					plugins: [vuetify],
+				},
+			})
+			expect(wrapper.find('.sy-input-select').classes()).toContain('v-btn--variant-outlined')
+		})
+
+		it('toggles the menu when the button is clicked', async () => {
+			const wrapper = mount(SyInputSelect, {
+				global: {
+					plugins: [vuetify],
+				},
+			})
+			const button = wrapper.find('.sy-input-select')
+			await button.trigger('click')
+			expect(wrapper.vm.isOpen).toBe(true)
+			await button.trigger('click')
+			expect(wrapper.vm.isOpen).toBe(false)
+		})
+
+		it('use closeList method', async () => {
+			const wrapper = mount(SyInputSelect, {
+				global: {
+					plugins: [vuetify],
+				},
+			})
+			await wrapper.vm.closeList()
+			expect(wrapper.vm.isOpen).toBe(false)
+		})
+
+		it('selectItem method', async () => {
+			const wrapper = mount(SyInputSelect, {
+				global: {
+					plugins: [vuetify],
+				},
+			})
+			await wrapper.vm.selectItem({ text: 'Option 1', value: '1' })
+			expect(wrapper.vm.isOpen).toBe(false)
+			expect(wrapper.vm.selectedItem).toEqual({ text: 'Option 1', value: '1' })
+		})
+
+		it('getItemText method', async () => {
+			const wrapper = mount(SyInputSelect, {
+				global: {
+					plugins: [vuetify],
+				},
+			})
+			const item = { text: 'Option 1', value: '1' }
+			const text = wrapper.vm.getItemText(item)
+			expect(text).toBe('Option 1')
+		})
+
+		it('watch modelValue', async () => {
+			const wrapper = mount(SyInputSelect, {
+				props: { modelValue: { text: 'Option 1', value: '1' } },
+				global: {
+					plugins: [vuetify],
+				},
+			})
+			expect(wrapper.vm.selectedItem).toEqual({ text: 'Option 1', value: '1' })
+			await wrapper.setProps({ modelValue: { text: 'Option 2', value: '2' } })
+			expect(wrapper.vm.selectedItem).toEqual({ text: 'Option 2', value: '2' })
+		})
+
+		it('watch errorMessages', async () => {
+			const wrapper = mount(SyInputSelect, {
+				props: { errorMessages: ['Error message'] },
+				global: {
+					plugins: [vuetify],
+				},
+			})
+			expect(wrapper.find('.v-messages__message').exists()).toBe(true)
+			await wrapper.setProps({ errorMessages: [] })
+			expect(wrapper.find('.v-messages__message').exists()).toBe(false)
+		})
 	})
 
-	it('displays the selected item text', async () => {
-		const items = [{ text: 'Option 1', value: '1' }, { text: 'Option 2', value: '2' }]
-		const wrapper = mount(SyInputSelect, {
-			props: { items, modelValue: { text: 'Option 1', value: '1' } },
-			global: {
-				plugins: [vuetify],
-			},
+	describe('Validation', () => {
+		it('validateField valide correctement un champ requis avec une valeur', async () => {
+			const wrapper = mount(SyInputSelect, {
+				props: {
+					required: true,
+					modelValue: { text: 'Option 1', value: '1' },
+				},
+				global: {
+					plugins: [vuetify],
+				},
+			})
+
+			const result = wrapper.vm.validateField({ text: 'Option 1', value: '1' })
+			expect(result).toBe(true)
+			expect(wrapper.find('.v-messages__message').exists()).toBe(false)
 		})
-		expect(wrapper.find('.sy-input-select').text()).toContain('Option 1')
+
+		it('validateField échoue pour un champ requis sans valeur', async () => {
+			const wrapper = mount(SyInputSelect, {
+				props: {
+					required: true,
+					label: 'Test Label',
+					errorMessages: [],
+				},
+				global: {
+					plugins: [vuetify],
+				},
+			})
+
+			const result = wrapper.vm.validateField(null)
+			expect(result).toBe(false)
+
+			await wrapper.setProps({ errorMessages: ['Test Label est requis'] })
+			await wrapper.vm.$nextTick()
+
+			expect(wrapper.find('.v-messages__message').exists()).toBe(true)
+			expect(wrapper.find('.v-messages__message').text()).toContain('Test Label est requis')
+		})
+
+		it('validateOnSubmit retourne le résultat de validation', async () => {
+			const wrapper = mount(SyInputSelect, {
+				props: { required: true },
+				global: {
+					plugins: [vuetify],
+				},
+			})
+
+			const result = wrapper.vm.validateOnSubmit()
+			expect(result).toBe(false)
+
+			await wrapper.setProps({ modelValue: { text: 'Option 1', value: '1' } })
+			const resultWithValue = wrapper.vm.validateOnSubmit()
+			expect(resultWithValue).toBe(true)
+		})
+
+		it('vérifie que checkForErrors retourne le résultat de la validation', () => {
+			const wrapper1 = mount(SyInputSelect, {
+				props: {
+					required: true,
+					modelValue: null,
+				},
+				global: {
+					plugins: [vuetify],
+				},
+			})
+
+			const result1 = wrapper1.vm.checkForErrors()
+			expect(result1).toBe(false)
+
+			const wrapper2 = mount(SyInputSelect, {
+				props: {
+					required: true,
+					modelValue: { text: 'Option 1', value: '1' },
+				},
+				global: {
+					plugins: [vuetify],
+				},
+			})
+
+			const result2 = wrapper2.vm.checkForErrors()
+			expect(result2).toBe(true)
+		})
 	})
 
-	it('does not render error messages when not provided', () => {
-		const wrapper = mount(SyInputSelect, {
-			global: {
-				plugins: [vuetify],
-			},
+	describe('Mode readonly', () => {
+		it('désactive la validation en mode readonly', () => {
+			const wrapper = mount(SyInputSelect, {
+				props: {
+					readonly: true,
+					required: true,
+				},
+				global: {
+					plugins: [vuetify],
+				},
+			})
+
+			const result = wrapper.vm.validateField(null)
+			expect(result).toBe(true)
+			expect(wrapper.find('.v-messages__message').exists()).toBe(false)
 		})
-		expect(wrapper.find('.v-messages__message').exists()).toBe(false)
+
+		it('empêche l\'ouverture du menu en mode readonly', async () => {
+			const wrapper = mount(SyInputSelect, {
+				props: { readonly: true },
+				global: {
+					plugins: [vuetify],
+				},
+			})
+
+			const button = wrapper.find('.sy-input-select')
+			await button.trigger('click')
+			expect(wrapper.vm.isOpen).toBe(false)
+		})
 	})
 
-	it('does not render the label when not provided', () => {
-		const wrapper = mount(SyInputSelect, {
-			global: {
-				plugins: [vuetify],
-			},
+	describe('Option clearable', () => {
+		it('affiche l\'icône de suppression quand clearable est true et une valeur est sélectionnée', async () => {
+			const wrapper = mount(SyInputSelect, {
+				props: {
+					clearable: true,
+					modelValue: { text: 'Option 1', value: '1' },
+				},
+				global: {
+					plugins: [vuetify],
+				},
+			})
+
+			const clearIcon = wrapper.find('.sy-input-select .v-icon[aria-label="Supprimer"]')
+			expect(clearIcon.exists()).toBe(true)
 		})
-		expect(wrapper.find('label').exists()).toBe(false)
+
+		it('n\'affiche pas l\'icône de suppression quand clearable est false', async () => {
+			const wrapper = mount(SyInputSelect, {
+				props: {
+					clearable: false,
+					modelValue: { text: 'Option 1', value: '1' },
+				},
+				global: {
+					plugins: [vuetify],
+				},
+			})
+
+			const clearIcon = wrapper.find('.sy-input-select .v-icon[aria-label="Supprimer"]')
+			expect(clearIcon.exists()).toBe(false)
+		})
+
+		it('efface la valeur sélectionnée quand l\'icône de suppression est cliquée', async () => {
+			const wrapper = mount(SyInputSelect, {
+				props: {
+					clearable: true,
+					modelValue: { text: 'Option 1', value: '1' },
+				},
+				global: {
+					plugins: [vuetify],
+				},
+			})
+
+			const clearIcon = wrapper.find('.sy-input-select .v-icon[aria-label="Supprimer"]')
+			await clearIcon.trigger('click')
+			expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([null])
+		})
 	})
 
-	it('formats items correctly', () => {
-		const items = ['Option 1', 'Option 2']
-		const wrapper = mount(SyInputSelect, {
-			props: { items, textKey: 'text', valueKey: 'value' },
-			global: {
-				plugins: [vuetify],
-			},
+	describe('Affichage de l\'astérisque', () => {
+		it('affiche l\'astérisque quand displayAsterisk et required sont true', () => {
+			const wrapper = mount(SyInputSelect, {
+				props: {
+					displayAsterisk: true,
+					required: true,
+					label: 'Test Label',
+				},
+				global: {
+					plugins: [vuetify],
+				},
+			})
+
+			const html = wrapper.html()
+			expect(html).toContain('Test Label *')
 		})
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- This is a generic type
-		const formattedItems = (wrapper.vm as any).formattedItems
-		expect(formattedItems).toEqual([
-			{ text: 'Option 1', value: 'Option 1' },
-			{ text: 'Option 2', value: 'Option 2' },
-		])
+
+		it('n\'affiche pas l\'astérisque quand displayAsterisk est false', () => {
+			const wrapper = mount(SyInputSelect, {
+				props: {
+					displayAsterisk: false,
+					required: true,
+					label: 'Test Label',
+				},
+				global: {
+					plugins: [vuetify],
+				},
+			})
+
+			const html = wrapper.html()
+			expect(html).not.toContain('Test Label *')
+			expect(html).toContain('Test Label')
+		})
+
+		it('n\'affiche pas l\'astérisque quand required est false', () => {
+			const wrapper = mount(SyInputSelect, {
+				props: {
+					displayAsterisk: true,
+					required: false,
+					label: 'Test Label',
+				},
+				global: {
+					plugins: [vuetify],
+				},
+			})
+
+			const html = wrapper.html()
+			expect(html).not.toContain('Test Label *')
+			expect(html).toContain('Test Label')
+		})
 	})
 
-	it('applies the correct button class when outlined is true', () => {
-		const wrapper = mount(SyInputSelect, {
-			props: { outlined: true },
-			global: {
-				plugins: [vuetify],
-			},
+	describe('Événements émis', () => {
+		it('émet update:modelValue lors de la sélection d\'un élément', async () => {
+			const wrapper = mount(SyInputSelect, {
+				props: {
+					items: [{ text: 'Option 1', value: '1' }, { text: 'Option 2', value: '2' }],
+				},
+				global: {
+					plugins: [vuetify],
+				},
+			})
+
+			await wrapper.vm.selectItem({ text: 'Option 1', value: '1' })
+			expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([{ text: 'Option 1', value: '1' }])
 		})
-		expect(wrapper.find('.sy-input-select').classes()).toContain('v-btn--variant-outlined')
+
+		it('émet update:errorMessages après validation', async () => {
+			const wrapper = mount(SyInputSelect, {
+				props: {
+					required: true,
+					label: 'Test Label',
+				},
+				global: {
+					plugins: [vuetify],
+				},
+			})
+
+			await wrapper.vm.validateField(null)
+			await wrapper.vm.selectItem(null)
+
+			expect(wrapper.emitted('update:errorMessages')).toBeTruthy()
+			expect(wrapper.emitted('update:errorMessages')?.[0][0]).toContainEqual(expect.stringContaining('Test Label est requis'))
+		})
 	})
 
-	it('toggles the menu when the button is clicked', async () => {
-		const wrapper = mount(SyInputSelect, {
-			global: {
-				plugins: [vuetify],
-			},
-		})
-		const button = wrapper.find('.sy-input-select')
-		await button.trigger('click')
-		expect(wrapper.vm.isOpen).toBe(true)
-		await button.trigger('click')
-		expect(wrapper.vm.isOpen).toBe(false)
-	})
+	describe('Comportement du menu', () => {
+		it('ouvre le menu quand on clique sur le bouton', async () => {
+			const wrapper = mount(SyInputSelect, {
+				global: {
+					plugins: [vuetify],
+				},
+			})
 
-	it('use closeList method', async () => {
-		const wrapper = mount(SyInputSelect, {
-			global: {
-				plugins: [vuetify],
-			},
-		})
-		await wrapper.vm.closeList()
-		expect(wrapper.vm.isOpen).toBe(false)
-	})
+			const button = wrapper.find('.sy-input-select')
+			await button.trigger('click')
 
-	it('selectItem method', async () => {
-		const wrapper = mount(SyInputSelect, {
-			global: {
-				plugins: [vuetify],
-			},
+			expect(wrapper.find('.v-list').exists()).toBe(true)
 		})
-		await wrapper.vm.selectItem({ text: 'Option 1', value: '1' })
-		expect(wrapper.vm.isOpen).toBe(false)
-		expect(wrapper.vm.selectedItem).toEqual({ text: 'Option 1', value: '1' })
-	})
 
-	it('getItemText method', async () => {
-		const wrapper = mount(SyInputSelect, {
-			global: {
-				plugins: [vuetify],
-			},
-		})
-		const item = { text: 'Option 1', value: '1' }
-		const text = wrapper.vm.getItemText(item)
-		expect(text).toBe('Option 1')
-	})
+		it('applique des styles différents pour isHeaderToolbar', async () => {
+			const wrapper = mount(SyInputSelect, {
+				props: { isHeaderToolbar: true },
+				global: {
+					plugins: [vuetify],
+				},
+			})
 
-	it('watch modelValue', async () => {
-		const wrapper = mount(SyInputSelect, {
-			props: { modelValue: { text: 'Option 1', value: '1' } },
-			global: {
-				plugins: [vuetify],
-			},
-		})
-		expect(wrapper.vm.selectedItem).toEqual({ text: 'Option 1', value: '1' })
-		await wrapper.setProps({ modelValue: { text: 'Option 2', value: '2' } })
-		expect(wrapper.vm.selectedItem).toEqual({ text: 'Option 2', value: '2' })
-	})
+			const button = wrapper.find('.sy-input-select')
+			await button.trigger('click')
 
-	it('watch errorMessages', async () => {
-		const wrapper = mount(SyInputSelect, {
-			props: { errorMessages: ['Error message'] },
-			global: {
-				plugins: [vuetify],
-			},
+			expect(wrapper.find('.v-list').attributes('is-header-toolbar')).toBeTruthy()
 		})
-		expect(wrapper.find('.v-messages__message').exists()).toBe(true)
-		await wrapper.setProps({ errorMessages: [] })
-		expect(wrapper.find('.v-messages__message').exists()).toBe(false)
 	})
 })

--- a/src/components/Customs/SySelect/SySelect.stories.ts
+++ b/src/components/Customs/SySelect/SySelect.stories.ts
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/vue3'
 import SySelect from '@/components/Customs/SySelect/SySelect.vue'
 import SyAlert from '@/components/SyAlert/SyAlert.vue'
-import { VBtn, VMenu, VList, VListItem, VListItemTitle } from 'vuetify/components'
+import { VBtn, VMenu, VList, VListItem, VListItemTitle, VForm } from 'vuetify/components'
 import { ref } from 'vue'
 import { fn } from '@storybook/test'
 
@@ -361,9 +361,115 @@ export const Info: Story = {
 							<li>- Si les items sont un tableau de string, le composant les utilisera directement.</li>
 						</ul>
 					</template>
-				</SyAlert>
+					</SyAlert>
 			`,
 		}
 	},
 	tags: ['!dev'],
+}
+
+export const FormValidation: Story = {
+	parameters: {
+		docs: {
+			description: {
+				story: 'Exemple d\'utilisation du SySelect dans un formulaire.',
+			},
+		},
+		sourceCode: [
+			{
+				name: 'Template',
+				code: `
+<template>
+  <VForm @submit.prevent="submitForm">
+    <SySelect
+      v-model="formData.option"
+      :items="options"
+      label="Option"
+      required
+      display-asterisk
+      class="mb-4"
+    />
+    <VBtn
+      type="submit"
+      color="primary"
+      class="mt-4"
+    >
+      Soumettre
+    </VBtn>
+  </VForm>
+</template>
+        `,
+			},
+			{
+				name: 'Script',
+				code: `
+<script setup lang="ts">
+import { ref } from 'vue'
+import SySelect from '@cnamts/synapse'
+import { VBtn, VForm } from 'vuetify/components'
+
+const formData = ref({
+  option: ''
+})
+
+const options = [
+  { text: 'Option 1', value: '1' },
+  { text: 'Option 2', value: '2' },
+  { text: 'Option 3', value: '3' },
+]
+
+const submitForm = () => {
+  // Traitement du formulaire
+  console.log('Formulaire soumis:', formData.value)
+}
+</script>
+        `,
+			},
+		],
+	},
+	args: {
+		'items': [
+			{ text: 'Option 1', value: '1' },
+			{ text: 'Option 2', value: '2' },
+			{ text: 'Option 3', value: '3' },
+		],
+		'label': 'Option',
+		'required': true,
+		'displayAsterisk': true,
+		'onUpdate:modelValue': fn(),
+	},
+	render: (args) => {
+		return {
+			components: { SySelect, VBtn, VForm },
+			setup() {
+				const formData = ref({
+					option: '',
+				})
+
+				const submitForm = () => {
+					console.log('Formulaire soumis:', formData.value)
+				}
+
+				return { args, formData, submitForm }
+			},
+			template: `
+				<div class="pa-4">
+					<VForm @submit.prevent="submitForm">
+						<SySelect
+							v-model="formData.option"
+							v-bind="args"
+							class="mb-4"
+						/>
+						<VBtn
+							type="submit"
+							color="primary"
+							class="mt-4"
+						>
+							Soumettre
+						</VBtn>
+					</VForm>
+				</div>
+			`,
+		}
+	},
 }

--- a/src/components/Customs/SySelect/SySelect.vue
+++ b/src/components/Customs/SySelect/SySelect.vue
@@ -159,8 +159,8 @@
 	})
 
 	const isRequired = computed(() => {
-		// Si la gestion des erreurs est désactivée, on ne considère jamais le champ comme requis
 		if (props.disableErrorHandling) return false
+		if (props.readonly) return
 		return (props.required || props.errorMessages.length > 0) && !selectedItem.value
 	})
 
@@ -172,8 +172,7 @@
 
 	watch([isOpen, hasError], ([newIsOpen, newHasError]) => {
 		if (!newIsOpen) {
-			// Si la gestion des erreurs est désactivée, on ne met jamais hasError à true
-			if (props.disableErrorHandling) {
+			if (props.disableErrorHandling || props.readonly) {
 				hasError.value = false
 			}
 			else {
@@ -186,7 +185,6 @@
 	})
 
 	watch(() => props.errorMessages, (newValue) => {
-		// Si la gestion des erreurs est désactivée, on ne met jamais hasError à true
 		if (!props.disableErrorHandling) {
 			hasError.value = newValue.length > 0
 		}

--- a/src/components/Customs/SyTextField/SyTextField.vue
+++ b/src/components/Customs/SyTextField/SyTextField.vue
@@ -212,7 +212,11 @@
 	)
 
 	const validateField = (value: string | number | null) => {
-		// Si le champ est vide et non requis, on ne fait pas de validation
+		if (props.readonly) {
+			validation.clearValidation()
+			return true
+		}
+
 		if (!value && !props.required) {
 			validation.clearValidation()
 			return true
@@ -247,7 +251,6 @@
 		}
 	})
 
-	// Computed pour l'affichage des états
 	const hasError = computed(() => validation.hasError.value)
 	const hasWarning = computed(() => validation.hasWarning.value)
 	const hasSuccess = computed(() => validation.hasSuccess.value)
@@ -256,7 +259,6 @@
 	const warnings = computed(() => validation.warnings.value)
 	const successes = computed(() => validation.successes.value)
 
-	// Computed pour les icônes
 	const appendInnerIconColor = computed(() => {
 		if (props.appendInnerIcon === 'error') return 'error'
 		if (props.appendInnerIcon === 'success') return 'success'

--- a/src/components/DatePicker/DatePicker.vue
+++ b/src/components/DatePicker/DatePicker.vue
@@ -86,7 +86,15 @@
 		warningRules: props.customWarningRules,
 		disableErrorHandling: props.disableErrorHandling,
 	})
-	const { errors, warnings, successes, validateField, clearValidation } = validation
+	const { errors, warnings, successes, validateField, clearValidation } = !props.readonly
+		? validation
+		: {
+			errors: ref<string[]>([]),
+			warnings: ref<string[]>([]),
+			successes: ref<string[]>([]),
+			validateField: () => {},
+			clearValidation: () => {},
+		}
 
 	const errorMessages = errors
 	const warningMessages = warnings
@@ -114,6 +122,9 @@
 
 		// Vérifier si le champ est requis et vide
 		if ((forceValidation || !isUpdatingFromInternal.value) && props.required && (!selectedDates.value || (Array.isArray(selectedDates.value) && selectedDates.value.length === 0))) {
+			if (props.readonly) {
+				return
+			}
 			if (shouldDisplayErrors) {
 				errors.value.push('La date est requise.')
 			}

--- a/src/components/DatePicker/DateTextInput.vue
+++ b/src/components/DatePicker/DateTextInput.vue
@@ -64,11 +64,20 @@
 		hasError,
 		clearValidation,
 		validateField,
-	} = useValidation({
-		showSuccessMessages: props.showSuccessMessages,
-		fieldIdentifier: props.label || props.placeholder,
-		disableErrorHandling: props.disableErrorHandling,
-	})
+	} = !props.readonly
+		? useValidation({
+			showSuccessMessages: props.showSuccessMessages,
+			fieldIdentifier: props.label || props.placeholder,
+			disableErrorHandling: props.disableErrorHandling,
+		})
+		: {
+			errors: ref<string[]>([]),
+			warnings: ref<string[]>([]),
+			successes: ref<string[]>([]),
+			hasError: ref(false),
+			clearValidation: () => {},
+			validateField: () => {},
+		}
 
 	const errorMessages = errors
 	const warningMessages = warnings
@@ -114,6 +123,7 @@
 	}
 
 	const validateDateFormat = (dateStr: string): { isValid: boolean, message: string } => {
+		if (props.readonly) return { isValid: true, message: '' }
 		if (!dateStr) {
 			return {
 				isValid: !props.required || !hasInteracted.value || props.disableErrorHandling,
@@ -145,6 +155,7 @@
 		clearValidation()
 
 		if (!value && props.required && hasInteracted.value) {
+			if (props.readonly) return true
 			if (!props.disableErrorHandling) {
 				errors.value.push('La date est requise')
 			}

--- a/src/components/NirField/NirField.vue
+++ b/src/components/NirField/NirField.vue
@@ -165,7 +165,7 @@
 	// Règles de validation
 	const defaultNumberRules = computed(() => {
 		const rules: ValidationRule[] = []
-
+		if (props.readonly) return
 		if (props.required) {
 			rules.push({
 				type: 'required',
@@ -207,7 +207,7 @@
 
 	const defaultKeyRules = computed(() => {
 		const rules: ValidationRule[] = []
-
+		if (props.readonly) return
 		if (props.required) {
 			rules.push({
 				type: 'required',
@@ -324,7 +324,6 @@
 		return validateFields(true)
 	}
 
-	// Computed pour statut des champs
 	const hasNumberErrors = computed(() => numberValidation.hasError.value)
 	const hasNumberWarning = computed(() => !hasNumberErrors.value && numberValidation.hasWarning.value)
 	const hasNumberSuccess = computed(() => !hasNumberErrors.value && !hasNumberWarning.value && numberValidation.hasSuccess.value)
@@ -333,7 +332,6 @@
 	const hasKeyWarning = computed(() => !hasKeyErrors.value && keyValidation.hasWarning.value)
 	const hasKeySuccess = computed(() => !hasKeyErrors.value && !hasKeyWarning.value && keyValidation.hasSuccess.value)
 
-	// Labels avec astérisque si nécessaire
 	const numberLabelWithAsterisk = computed(() => {
 		return props.required && props.displayAsterisk ? `${props.numberLabel} *` : props.numberLabel
 	})
@@ -342,7 +340,6 @@
 		return props.required && props.displayAsterisk ? `${props.keyLabel} *` : props.keyLabel
 	})
 
-	// Gestion des événements
 	const handleNumberInput = () => {
 		emitValue()
 		validateFields()

--- a/src/components/PasswordField/PasswordField.stories.ts
+++ b/src/components/PasswordField/PasswordField.stories.ts
@@ -691,7 +691,7 @@ export const WithValidation: Story = {
 					:custom-success-rules="customSuccessRules"
 					:show-success-messages="true"
 					:display-asterisk="true"
-					:is-validate-on-blur="false"
+					:is-validate-on-blur="true"
 				/>
 				<div class="mt-4">
 					<p><strong>Conseils pour tester :</strong></p>

--- a/src/components/PasswordField/PasswordField.vue
+++ b/src/components/PasswordField/PasswordField.vue
@@ -101,16 +101,22 @@
 	})
 
 	// Initialisation du composable de validation
-	const { errors, warnings, successes, validateField } = useValidation({
-		customRules: defaultRules.value,
-		warningRules: props.customWarningRules || [],
-		successRules: props.customSuccessRules || [],
-		showSuccessMessages: props.showSuccessMessages,
-		fieldIdentifier: props.label || 'password',
-		disableErrorHandling: props.disableErrorHandling,
-	})
+	const { errors, warnings, successes, validateField } = !props.readonly
+		? useValidation({
+			customRules: defaultRules.value,
+			warningRules: props.customWarningRules || [],
+			successRules: props.customSuccessRules || [],
+			showSuccessMessages: props.showSuccessMessages,
+			fieldIdentifier: props.label || 'password',
+			disableErrorHandling: props.disableErrorHandling,
+		})
+		: {
+			errors: ref<string[]>([]),
+			warnings: ref<string[]>([]),
+			successes: ref<string[]>([]),
+			validateField: () => {},
+		}
 
-	// Computed pour les états de validation
 	const hasError = computed(() => errors.value.length > 0)
 	const hasWarning = computed(() => warnings.value.length > 0)
 	const hasSuccess = computed(() => successes.value.length > 0 && props.showSuccessMessages)
@@ -149,6 +155,7 @@
 	}, { immediate: true })
 
 	watch(() => password.value, () => {
+		if (props.readonly) return
 		validateField(password.value, [...defaultRules.value, ...(props.customRules || [])], props.customWarningRules || [], props.customSuccessRules || [])
 		emit('update:modelValue', password.value)
 	})
@@ -160,6 +167,7 @@
 	}
 
 	const validateOnSubmit = () => {
+		if (props.readonly) return
 		validateField(password.value, [...defaultRules.value, ...(props.customRules || [])], props.customWarningRules || [], props.customSuccessRules || [])
 		const isValid = errors.value.length === 0
 		if (isValid) {
@@ -199,7 +207,7 @@
 		:rules="[...defaultRules, ...props.customRules]"
 		class="vd-password"
 		:validate-on="props.isValidateOnBlur ? 'blur lazy' : 'lazy'"
-		@blur="props.isValidateOnBlur ? validateField(password, [...defaultRules, ...(props.customRules || [])], props.customWarningRules || [], props.customSuccessRules || []) : () => {}"
+		@blur="props.isValidateOnBlur && !props.readonly ? validateField(password, [...defaultRules, ...(props.customRules || [])], props.customWarningRules || [], props.customSuccessRules || []) : () => {}"
 		@keydown="handleKeydown"
 	>
 		<template #append-inner>

--- a/src/components/PasswordField/tests/PasswordField.spec.ts
+++ b/src/components/PasswordField/tests/PasswordField.spec.ts
@@ -94,7 +94,6 @@ describe('PasswordField.vue', () => {
 		expect(result).toBe(false)
 		expect(vm.errors).toContain('Le mot de passe est requis')
 
-		// Test avec un mot de passe valide
 		await wrapper.setProps({ modelValue: 'valid-password' })
 		const validResult = vm.validateOnSubmit()
 		expect(validResult).toBe(true)
@@ -114,10 +113,9 @@ describe('PasswordField.vue', () => {
 		})
 
 		const messages = wrapper.findAll('.v-messages__message')
-		expect(messages.length).toBe(1) // SyTextField affiche soit les warnings, soit les succès
+		expect(messages.length).toBe(1)
 		expect(messages[0].text()).toBe('Attention: mot de passe court')
 
-		// Simuler la suppression du warning pour voir le message de succès
 		await wrapper.setProps({ warningMessages: [] })
 		const successMessages = wrapper.findAll('.v-messages__message')
 		expect(successMessages.length).toBe(1)
@@ -157,17 +155,14 @@ describe('PasswordField.vue', () => {
 
 		const vm = wrapper.vm as unknown as PasswordFieldVM
 
-		// Forcer la validation initiale
 		await wrapper.find('input').trigger('blur')
 		expect(vm.errors).toContain('Le mot de passe doit contenir au moins 8 caractères')
 
-		// Mettons un mot de passe plus long mais sans majuscule -> warning
 		await wrapper.setProps({ modelValue: 'testpassword' })
 		await wrapper.find('input').trigger('blur')
 		const messages = wrapper.findAll('.v-messages__message')
 		expect(messages[0].text()).toBe('Le mot de passe pourrait être plus fort')
 
-		// Mettons un mot de passe fort -> succès
 		await wrapper.setProps({ modelValue: 'TestPassword123' })
 		await wrapper.find('input').trigger('blur')
 		const successMessages = wrapper.findAll('.v-messages__message')
@@ -205,19 +200,15 @@ describe('PasswordField.vue', () => {
 			},
 		})
 
-		// Forcer la validation initiale
 		await wrapper.find('input').trigger('blur')
 
-		// État d'erreur
 		const vm = wrapper.vm as unknown as PasswordFieldVM
 		expect(vm.hasError).toBe(true)
 
-		// État d'avertissement
 		await wrapper.setProps({ modelValue: 'testpassword' })
 		await wrapper.find('input').trigger('blur')
 		expect(vm.hasWarning).toBe(true)
 
-		// État de succès
 		await wrapper.setProps({ modelValue: 'TestPassword123' })
 		await wrapper.find('input').trigger('blur')
 		expect(vm.hasSuccess).toBe(true)

--- a/src/components/PhoneField/PhoneField.stories.ts
+++ b/src/components/PhoneField/PhoneField.stories.ts
@@ -1,5 +1,6 @@
 import type { StoryObj, Meta } from '@storybook/vue3'
 import PhoneField from './PhoneField.vue'
+import { ref } from 'vue'
 import { indicatifs } from './indicatifs'
 
 const meta = {
@@ -34,6 +35,7 @@ const meta = {
 		displayAsterisk: { control: 'boolean' },
 		disableErrorHandling: { control: 'boolean' },
 		disabled: { control: 'boolean' },
+		readonly: { control: 'boolean' },
 	},
 } satisfies Meta<typeof PhoneField>
 
@@ -1256,6 +1258,147 @@ export const DisabledErrorHandling: Story = {
 							:disabled="args.disabled"
 							:bg-color="args.bgColor"
 						/>
+					</div>
+				</div>
+			`,
+		}
+	},
+}
+
+export const FormValidation: Story = {
+	parameters: {
+		sourceCode: [
+			{
+				name: 'Template',
+				code: `
+				<template>
+					<form @submit.prevent="submitForm" class="d-flex flex-column">
+						<PhoneField
+							ref="phoneFieldRef"
+							v-model="phoneNumber"
+							:required="true"
+							:outlined="true"
+							:outlinedIndicatif="true"
+							:withCountryCode="true"
+							:country-code-required="true"
+							:isValidatedOnBlur="false"
+							:readonly="readonly"
+							:disabled="disabled"
+						/>
+						<v-btn type="submit" color="primary" class="mt-4" style="width: 200px;">Soumettre le formulaire</v-btn>
+						<div v-if="formSubmitted" class="mt-4 pa-2" :class="{ 'bg-success': formIsValid, 'bg-error': !formIsValid }" style="width: fit-content;">
+							<p v-if="formIsValid" class="text-white">Formulaire valide !</p>
+							<p v-else class="text-white">Formulaire invalide !</p>
+						</div>
+					</form>
+				</template>
+				`,
+			},
+			{
+				name: 'Script',
+				code: `
+				<script setup lang="ts">
+					import { ref } from 'vue'
+					import { PhoneField } from '@cnamts/synapse'
+					
+					const phoneFieldRef = ref(null)
+					const phoneNumber = ref('')
+					const formSubmitted = ref(false)
+					const formIsValid = ref(false)
+					const readonly = ref(false)
+					const disabled = ref(false)
+					
+					const submitForm = async () => {
+						formSubmitted.value = true
+						// Validation du champ téléphone
+						let isValid = false
+						if (phoneFieldRef.value) {
+							// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Nécessaire pour accéder à validateOnSubmit
+							isValid = await (phoneFieldRef.value as any).validateOnSubmit()
+						}
+						
+						formIsValid.value = isValid
+						
+						console.log(isValid ? 'Formulaire valide !' : 'Formulaire invalide !')
+					}
+				</script>
+				`,
+			},
+		],
+	},
+	args: {
+		modelValue: '',
+		required: true,
+		outlined: true,
+		outlinedIndicatif: true,
+		withCountryCode: true,
+		countryCodeRequired: true,
+		displayFormat: 'code',
+		customIndicatifs: [],
+		useCustomIndicatifsOnly: false,
+		isValidatedOnBlur: false,
+		bgColor: undefined,
+		readonly: false,
+		disabled: false,
+	},
+	render: (args) => {
+		return {
+			components: { PhoneField },
+			setup() {
+				const phoneFieldRef = ref(null)
+				const phoneNumber = ref('')
+				const formSubmitted = ref(false)
+				const formIsValid = ref(false)
+
+				const submitForm = async () => {
+					formSubmitted.value = true
+					// Validation du champ téléphone
+					let isValid = false
+					if (phoneFieldRef.value) {
+						// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Nécessaire pour accéder à validateOnSubmit
+						isValid = await (phoneFieldRef.value as any).validateOnSubmit()
+					}
+
+					formIsValid.value = isValid
+
+					console.log(isValid ? 'Formulaire valide !' : 'Formulaire invalide !')
+				}
+
+				return { phoneFieldRef, phoneNumber, formSubmitted, formIsValid, submitForm, args }
+			},
+			template: `
+				<div class="pa-4">
+					<form @submit.prevent="submitForm" class="d-flex flex-column">
+						<PhoneField
+							ref="phoneFieldRef"
+							v-model="phoneNumber"
+							:required="args.required"
+							:outlined="args.outlined"
+							:outlinedIndicatif="args.outlinedIndicatif"
+							:withCountryCode="args.withCountryCode"
+							:country-code-required="args.countryCodeRequired"
+							:isValidatedOnBlur="args.isValidatedOnBlur"
+							:readonly="args.readonly"
+							:disabled="args.disabled"
+							:bg-color="args.bgColor"
+							:display-format="args.displayFormat"
+							:custom-indicatifs="args.customIndicatifs"
+							:use-custom-indicatifs-only="args.useCustomIndicatifsOnly"
+							:display-asterisk="args.displayAsterisk"
+							:disable-error-handling="args.disableErrorHandling"
+						/>
+						<v-btn type="submit" color="primary" class="mt-4" style="width: 200px;">Soumettre le formulaire</v-btn>
+						<div v-if="formSubmitted" class="mt-4 pa-2" :class="{ 'bg-success': formIsValid, 'bg-error': !formIsValid }" style="width: fit-content;">
+							<p v-if="formIsValid" class="text-white">Formulaire valide !</p>
+							<p v-else class="text-white">Formulaire invalide !</p>
+						</div>
+					</form>
+					<div class="mt-8">
+						<h3>Comment utiliser la validation à la soumission</h3>
+						<p>1. Ajoutez une référence au composant PhoneField avec <code>ref="phoneFieldRef"</code></p>
+						<p>2. Désactivez la validation au blur si nécessaire avec <code>:isValidatedOnBlur="false"</code></p>
+						<p>3. Dans votre méthode de soumission, appelez <code>phoneFieldRef.value.validateOnSubmit()</code></p>
+						<p>4. Cette méthode retourne une Promise qui résout à <code>true</code> si le champ est valide, <code>false</code> sinon</p>
 					</div>
 				</div>
 			`,

--- a/src/components/PhoneField/tests/PhoneField.additional.spec.ts
+++ b/src/components/PhoneField/tests/PhoneField.additional.spec.ts
@@ -1,0 +1,266 @@
+import { mount } from '@vue/test-utils'
+import PhoneField from '../PhoneField.vue'
+import { describe, it, expect, beforeEach } from 'vitest'
+import { createVuetify } from 'vuetify'
+import * as components from 'vuetify/components'
+import * as directives from 'vuetify/directives'
+import { indicatifs } from '../indicatifs'
+
+const vuetify = createVuetify({
+	components,
+	directives,
+})
+
+// Tests supplémentaires pour le composant PhoneField
+describe('PhoneField - Additional Tests', () => {
+	// Tests pour les différents formats d'affichage
+	describe('Display formats', () => {
+		let wrapper
+
+		beforeEach(() => {
+			wrapper = mount(PhoneField, {
+				global: {
+					plugins: [vuetify],
+				},
+				props: {
+					withCountryCode: true,
+					dialCodeModel: { code: '+33', abbreviation: 'FR', country: 'France', phoneLength: 10, mask: '## ## ## ## ##' },
+				},
+			})
+		})
+
+		it('formats display text as code by default', async () => {
+			const select = wrapper.findComponent({ name: 'SySelect' })
+			// Vérifier que le format d'affichage est bien le code
+			const firstItem = select.props('items')[0]
+			expect(firstItem.displayText).toBe(firstItem.code)
+		})
+
+		it('formats display text as code-abbreviation', async () => {
+			await wrapper.setProps({ displayFormat: 'code-abbreviation' })
+			const select = wrapper.findComponent({ name: 'SySelect' })
+			const firstItem = select.props('items')[0]
+			expect(firstItem.displayText).toBe(`${firstItem.code} (${firstItem.abbreviation})`)
+		})
+
+		it('formats display text as code-country', async () => {
+			await wrapper.setProps({ displayFormat: 'code-country' })
+			const select = wrapper.findComponent({ name: 'SySelect' })
+			const firstItem = select.props('items')[0]
+			expect(firstItem.displayText).toBe(`${firstItem.code} ${firstItem.country}`)
+		})
+
+		it('formats display text as country', async () => {
+			await wrapper.setProps({ displayFormat: 'country' })
+			const select = wrapper.findComponent({ name: 'SySelect' })
+			const firstItem = select.props('items')[0]
+			expect(firstItem.displayText).toBe(firstItem.country)
+		})
+
+		it('formats display text as abbreviation', async () => {
+			await wrapper.setProps({ displayFormat: 'abbreviation' })
+			const select = wrapper.findComponent({ name: 'SySelect' })
+			const firstItem = select.props('items')[0]
+			expect(firstItem.displayText).toBe(firstItem.abbreviation)
+		})
+	})
+
+	// Tests pour l'initialisation avec un dialCode par défaut
+	describe('Default dialCode initialization', () => {
+		it('initializes with a default dialCode object', async () => {
+			const defaultDialCode = { code: '+44', abbreviation: 'UK', country: 'United Kingdom', phoneLength: 11, mask: '#### ### ####' }
+			const wrapper = mount(PhoneField, {
+				global: {
+					plugins: [vuetify],
+				},
+				props: {
+					withCountryCode: true,
+					dialCodeModel: defaultDialCode,
+				},
+			})
+
+			await wrapper.vm.$nextTick()
+
+			// Vérifier que le dialCode est correctement initialisé
+			expect(wrapper.vm.dialCode).toBeDefined()
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- This is a generic type
+			expect((wrapper.vm.dialCode as any).code).toBe('+44')
+			// Vérifier que le masque est appliqué (le format exact peut varier)
+			expect(wrapper.vm.phoneMask).toBeDefined()
+			// Vérifier que le counter est défini selon la phoneLength
+			expect(wrapper.vm.counter).toBeDefined()
+		})
+
+		it('initializes with a default dialCode string', async () => {
+			const wrapper = mount(PhoneField, {
+				global: {
+					plugins: [vuetify],
+				},
+				props: {
+					withCountryCode: true,
+					dialCodeModel: '+33',
+				},
+			})
+
+			await wrapper.vm.$nextTick()
+
+			// Vérifier que le dialCode est correctement initialisé
+			expect(wrapper.vm.dialCode).toBe('+33')
+		})
+	})
+
+	// Tests pour la désactivation de la gestion des erreurs
+	describe('Error handling', () => {
+		it('displays error messages by default when validation fails', async () => {
+			const wrapper = mount(PhoneField, {
+				global: {
+					plugins: [vuetify],
+				},
+				props: {
+					required: true,
+					modelValue: '',
+					isValidatedOnBlur: true,
+				},
+			})
+
+			// Déclencher la validation
+			await wrapper.vm.validateOnSubmit()
+
+			// Vérifier que les erreurs sont affichées
+			expect(wrapper.vm.hasError).toBe(true)
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any -- This is a generic type
+			expect((wrapper.vm as any).errors.length).toBeGreaterThan(0)
+
+			// Vérifier que les erreurs sont passées au composant SyTextField
+			const textField = wrapper.findComponent({ name: 'SyTextField' })
+			expect(textField.props('errorMessages')).toBeTruthy()
+		})
+
+		it('initializes with disableErrorHandling prop', async () => {
+			const wrapper = mount(PhoneField, {
+				global: {
+					plugins: [vuetify],
+				},
+				props: {
+					required: true,
+					modelValue: '',
+					isValidatedOnBlur: true,
+					disableErrorHandling: true,
+				},
+			})
+
+			// Vérifier que la propriété disableErrorHandling est bien prise en compte
+			// en vérifiant qu'elle est passée lors de l'initialisation du composable useValidation
+			expect(wrapper.vm.validation).toBeDefined()
+		})
+	})
+
+	// Tests pour la validation dans un contexte de formulaire
+	describe('Form validation', () => {
+		it('validates as part of a form submission', async () => {
+			const wrapper = mount(PhoneField, {
+				global: {
+					plugins: [vuetify],
+				},
+				props: {
+					required: true,
+					modelValue: '',
+				},
+			})
+
+			// Simuler une soumission de formulaire avec un champ vide
+			const isValid = await wrapper.vm.validateOnSubmit()
+			expect(isValid).toBe(false)
+
+			// Mettre à jour la valeur et valider à nouveau
+			await wrapper.setProps({ modelValue: '0123456789' })
+			const isValidAfterUpdate = await wrapper.vm.validateOnSubmit()
+			expect(isValidAfterUpdate).toBe(true)
+		})
+
+		it('validates country code as part of form submission', async () => {
+			const wrapper = mount(PhoneField, {
+				global: {
+					plugins: [vuetify],
+				},
+				props: {
+					required: true,
+					modelValue: '0123456789',
+					withCountryCode: true,
+					countryCodeRequired: true,
+				},
+			})
+
+			// Sans code pays, la validation échoue
+			const isValidWithoutCountry = await wrapper.vm.validateOnSubmit()
+			expect(isValidWithoutCountry).toBe(false)
+
+			// Ajouter un code pays et valider à nouveau
+			wrapper.vm.dialCode = { code: '+33', abbreviation: 'FR', country: 'France', phoneLength: 10, mask: '## ## ## ## ##' }
+			await wrapper.vm.$nextTick()
+
+			const isValidWithCountry = await wrapper.vm.validateOnSubmit()
+			expect(isValidWithCountry).toBe(true)
+		})
+	})
+
+	// Tests pour la gestion des indicatifs personnalisés
+	describe('Custom indicatifs', () => {
+		it('merges custom indicatifs with standard ones by default', () => {
+			const customIndicatifs = [{ code: '+999', abbreviation: 'XX', country: 'Test Country', phoneLength: 8, mask: '## ## ## ##' }]
+			const wrapper = mount(PhoneField, {
+				global: {
+					plugins: [vuetify],
+				},
+				props: {
+					customIndicatifs,
+					withCountryCode: true,
+				},
+			})
+
+			// Vérifier que les indicatifs personnalisés sont ajoutés aux indicatifs standards
+			expect(wrapper.vm.mergedDialCodes.length).toBe(indicatifs.length + customIndicatifs.length)
+			expect(wrapper.vm.mergedDialCodes).toContainEqual(customIndicatifs[0])
+		})
+
+		it('uses only custom indicatifs when useCustomIndicatifsOnly is true', () => {
+			const customIndicatifs = [{ code: '+999', abbreviation: 'XX', country: 'Test Country', phoneLength: 8, mask: '## ## ## ##' }]
+			const wrapper = mount(PhoneField, {
+				global: {
+					plugins: [vuetify],
+				},
+				props: {
+					customIndicatifs,
+					useCustomIndicatifsOnly: true,
+					withCountryCode: true,
+				},
+			})
+
+			// Vérifier que seuls les indicatifs personnalisés sont utilisés
+			expect(wrapper.vm.mergedDialCodes.length).toBe(customIndicatifs.length)
+			expect(wrapper.vm.mergedDialCodes).toEqual(customIndicatifs)
+		})
+
+		it('updates phone mask and counter based on selected custom indicatif', async () => {
+			const customIndicatifs = [{ code: '+999', abbreviation: 'XX', country: 'Test Country', phoneLength: 8, mask: '## ## ## ##' }]
+			const wrapper = mount(PhoneField, {
+				global: {
+					plugins: [vuetify],
+				},
+				props: {
+					customIndicatifs,
+					useCustomIndicatifsOnly: true,
+					withCountryCode: true,
+				},
+			})
+
+			// Sélectionner l'indicatif personnalisé
+			wrapper.vm.dialCode = customIndicatifs[0]
+			await wrapper.vm.$nextTick()
+
+			// Vérifier que le masque et le compteur sont mis à jour
+			expect(wrapper.vm.phoneMask).toBe('## ## ## ##')
+			expect(wrapper.vm.counter).toBe(8)
+		})
+	})
+})

--- a/src/components/PhoneField/tests/types.d.ts
+++ b/src/components/PhoneField/tests/types.d.ts
@@ -1,0 +1,19 @@
+import { ComponentPublicInstance } from 'vue'
+
+declare module '@vue/test-utils' {
+	interface VueWrapper {
+		vm: ComponentPublicInstance & {
+			dialCode: {
+				code: string
+				country: string
+				abbreviation: string
+				phoneLength: number
+				mask: string
+			} | null
+			errors: string[]
+			hasError: boolean
+			phoneMask: string
+			validateOnSubmit: () => Promise<boolean>
+		}
+	}
+}


### PR DESCRIPTION
## Description
 - ajout de stories pour les form validation des sySlect et syInputSelect + ajout de tests
 - ajout de la gestion d'erreur pour le SyInputSelect + ajout de tests
 - ajout du clearable sur le syInputSelect  (pour etre iso avec le SySelect) + ajout de tests
 - fix de la gestion d'erreur avec la props readonly ( TODO: PhoneField)
 - amelioration du PhoneField + ajout de tests
 - fix icon on error/warning/sucess on PhoneField
