### PR TITLE
SyTable / SyServerTable : pagination

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -73,6 +73,8 @@ const preview: Preview = {
 				document.documentElement.classList.add(`theme-${context.globals.theme}`)
 				localStorage.setItem('storybook-theme', context.globals.theme)
 			}
+			
+			
 			return story()
 		},
 	],

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -9,6 +9,29 @@ const vuetify = createVuetifyInstance()
 
 setup((app, { globals }) => {
 	app.use(vuetify)
+	
+	// Add global mixin to help with SySelect dropdown in docs mode
+	if (typeof window !== 'undefined') {
+		// Wait for DOM to be ready
+		window.addEventListener('DOMContentLoaded', () => {
+			// Add click handler to document to help with dropdown positioning
+			document.addEventListener('click', (event) => {
+				// Check if we're in docs mode
+				if (document.body.classList.contains('storybook-docs-mode')) {
+					// Find all dropdowns and make sure they're properly positioned
+					const lists = document.querySelectorAll('.v-list');
+					lists.forEach(list => {
+						if (list instanceof HTMLElement) {
+							list.style.position = 'absolute';
+							list.style.zIndex = '9999';
+							list.style.visibility = 'visible';
+						}
+					});
+				}
+			});
+		});
+	}
+	
 	app.config.idPrefix = (Math.random() + 1).toString(36).substring(7)
 
 	// Apply theme class to <html> (document.documentElement) instead of #root
@@ -74,6 +97,15 @@ const preview: Preview = {
 				localStorage.setItem('storybook-theme', context.globals.theme)
 			}
 			
+			// Check if we're in docs mode to apply special handling for dropdowns
+			const isInDocs = context.viewMode === 'docs';
+			
+			if (isInDocs) {
+				// Add a special class to help target docs mode in CSS
+				if (typeof document !== 'undefined') {
+					document.body.classList.add('storybook-docs-mode');
+				}
+			}
 			
 			return story()
 		},

--- a/.storybook/storybook.css
+++ b/.storybook/storybook.css
@@ -127,6 +127,43 @@ pre.prismjs {
 	transform: none !important;
 }
 
+/* Fix for SySelect dropdown in Storybook docs canvas */
+.docs-story .v-list,
+.storybook-docs-mode .v-list {
+	position: absolute !important;
+	z-index: 9999 !important;
+	background-color: white !important;
+	box-shadow: 0 2px 5px rgba(0, 0, 0, 0.12), 0 2px 10px rgba(0, 0, 0, 0.08) !important;
+	visibility: visible !important;
+	opacity: 1 !important;
+	pointer-events: auto !important;
+}
+
+/* Ensure the dropdown has proper positioning context */
+.docs-story .sy-select,
+.storybook-docs-mode .sy-select {
+	position: relative !important;
+	z-index: 100 !important;
+}
+
+/* Fix for dropdown positioning */
+.docs-story .v-list,
+.storybook-docs-mode .v-list {
+	top: auto !important;
+	left: auto !important;
+	margin-top: 0 !important;
+	width: auto !important;
+	min-width: 100px !important;
+}
+
+/* Make sure the menu content is visible */
+.storybook-docs-mode .v-menu__content {
+	position: absolute !important;
+	z-index: 9999 !important;
+	visibility: visible !important;
+	opacity: 1 !important;
+}
+
 /* Fix for Table doc */
 #story--démarrer-releases--list {
 	table {

--- a/src/components/Tables/SyServerTable/SyServerTable.mdx
+++ b/src/components/Tables/SyServerTable/SyServerTable.mdx
@@ -7,11 +7,11 @@ import * as SyServerTable from './SyServerTable.stories';
 
 Le composant `SyServerTable` est utilisé pour afficher des données tabulaires chargées depuis un serveur. Il s'appuie sur le composant `VDataTableServer` de Vuetify et offre des fonctionnalités supplémentaires comme le stockage local des options de tableau et des améliorations d'accessibilité.
 
-<Canvas of={SyServerTable.Default} />
+<Canvas story={{height: '550px'}} of={SyServerTable.Default} />
 
 ## API
 
-<Controls of={SyServerTable.Default} />
+<Controls story={{height: '550px'}} of={SyServerTable.Default} />
 
 ## Fonctionnalités
 
@@ -32,17 +32,17 @@ Pour gérer individuellement le stockage des options pour différents tableaux, 
 
 Le composant permet de trier les données par colonne en déléguant le tri au serveur.
 
-<Canvas of={SyServerTable.ServerSortBy} />
+<Canvas story={{height: '550px'}} of={SyServerTable.ServerSortBy} />
 
 ### Filtres des colonnes
 
 Le composant permet d'appliquer des filtres sur les colonnes. Vous pouvez définir des filtres personnalisés pour chaque colonne en utilisant la prop `show-filters`. Voir d'autres exemples de filtres dans les stories.
-<Canvas of={SyServerTable.ServerFilterByText} />
+<Canvas story={{height: '550px'}} of={SyServerTable.ServerFilterByText} />
 
 ### Resize des colonnes
 
 Le composant peut permettre de redimensionner les colonnes en utilisant la prop `resizable-columns`. Vous pouvez activer ou désactiver cette fonctionnalité selon vos besoins.
-<Canvas of={SyServerTable.ResizableColumns} />
+<Canvas story={{height: '550px'}} of={SyServerTable.ResizableColumns} />
 
 ### Accessibilité
 

--- a/src/components/Tables/SyServerTable/SyServerTable.stories.ts
+++ b/src/components/Tables/SyServerTable/SyServerTable.stories.ts
@@ -3248,6 +3248,7 @@ export const ManyServerTables: Story = {
 		],
 	},
 	args: {
+		'serverItemsLength': 15, // Add required serverItemsLength property
 		'headers': [
 			{ title: 'Nom', key: 'lastname' },
 			{ title: 'Prénom', key: 'firstname' },

--- a/src/components/Tables/SyServerTable/SyServerTable.stories.ts
+++ b/src/components/Tables/SyServerTable/SyServerTable.stories.ts
@@ -847,11 +847,11 @@ export const ServerFilterByText: Story = {
 			template: `
 				<div>
 					<SyServerTable
+						v-bind="args"
 						v-model:options="options"
 						:items="filteredUsers"
 						:server-items-length="totalFilteredUsers"
 						:loading="state === StateEnum.PENDING"
-						v-bind="args"
 						@update:options="fetchData"
 					/>
 				</div>
@@ -1145,11 +1145,11 @@ export const ServerFilterByNumber: Story = {
 			template: `
 				<div>
 					<SyServerTable
+						v-bind="args"
 						v-model:options="options"
 						:items="filteredUsers"
 						:server-items-length="totalFilteredUsers"
 						:loading="state === StateEnum.PENDING"
-						v-bind="args"
 						@update:options="fetchData"
 					/>
 				</div>
@@ -1465,11 +1465,11 @@ export const ServerFilterBySelect: Story = {
 			template: `
 				<div>
 					<SyServerTable
+						v-bind="args"
 						v-model:options="options"
 						:items="filteredUsers"
 						:server-items-length="totalFilteredUsers"
 						:loading="state === StateEnum.PENDING"
-						v-bind="args"
 						@update:options="fetchData"
 					/>
 				</div>
@@ -1801,11 +1801,11 @@ export const ServerFilterBySelectMultiple: Story = {
 			template: `
 				<div>
 					<SyServerTable
+						v-bind="args"
 						v-model:options="options"
 						:items="filteredUsers"
 						:server-items-length="totalFilteredUsers"
 						:loading="state === StateEnum.PENDING"
-						v-bind="args"
 						@update:options="fetchData"
 					/>
 				</div>
@@ -2093,11 +2093,11 @@ export const ServerFilterByExacteDate: Story = {
 			template: `
 				<div>
 					<SyServerTable
+						v-bind="args"
 						v-model:options="options"
 						:items="users"
 						:server-items-length="totalUsers"
 						:loading="state === StateEnum.PENDING"
-						v-bind="args"
 						@update:options="fetchData"
 					/>
 				</div>
@@ -2402,11 +2402,11 @@ export const ServerFilterByPeriod: Story = {
 			template: `
 				<div>
 					<SyServerTable
+						v-bind="args"
 						v-model:options="options"
 						:items="users"
 						:server-items-length="totalUsers"
 						:loading="state === StateEnum.PENDING"
-						v-bind="args"
 						@update:options="fetchData"
 					/>
 				</div>
@@ -2767,11 +2767,11 @@ export const CustomFilterSlot: Story = {
 			},
 			template: `
 				<SyServerTable
+					v-bind="args"
 					v-model:options="options"
 					:items="items"
 					:server-items-length="serverItemsLength"
 					:loading="loading"
-					v-bind="args"
 					@update:options="fetchData"
 				>
 					<template #filter.custom="{ header, value, updateFilter }">
@@ -3090,11 +3090,11 @@ export const CustomFilterInputs: Story = {
 			template: `
 				<div>
 					<SyServerTable
+						v-bind="args"
 						v-model:options="options"
 						:items="filteredUsers"
 						:server-items-length="totalFilteredUsers"
 						:loading="state === StateEnum.PENDING"
-						v-bind="args"
 						@update:options="fetchData"
 					/>
 				</div>
@@ -3372,21 +3372,21 @@ export const ManyServerTables: Story = {
 			template: `
 	  <div>
 		<SyServerTable
+		  v-bind="args"
 		  v-model:options="optionsTable1"
 		  :items="usersTable1"
 		  :server-items-length="totalUsersTable1"
 		  :loading="stateTable1 === StateEnum.PENDING"
-		  v-bind="args"
 		  suffix="table1"
 		  class="mb-10"
 		  @update:options="fetchDataTable1"
 		/>
 		<SyServerTable
+		  v-bind="args"
 		  v-model:options="optionsTable2"
 		  :items="usersTable2"
 		  :server-items-length="totalUsersTable2"
 		  :loading="stateTable2 === StateEnum.PENDING"
-		  v-bind="args"
 		  suffix="table2"
 		  @update:options="fetchDataTable2"
 		/>
@@ -3643,11 +3643,11 @@ export const DataAlignment: Story = {
 			},
 			template: `
 				<SyServerTable
+					v-bind="args"
 					v-model:options="options"
 					:items="users"
 					:server-items-length="totalUsers"
 					:loading="state === StateEnum.PENDING"
-					v-bind="args"
 					@update:options="[fetchData, args['onUpdate:options']]"
 				/>
 			`,
@@ -3877,11 +3877,11 @@ export const ResizableColumns: Story = {
 			template: `
 			<div>
 				<SyServerTable
+					v-bind="args"
 					v-model:options="options"
 					:items="users"
 					:server-items-length="totalUsers"
 					:loading="state === StateEnum.PENDING"
-					v-bind="args"
 					@update:options="fetchData"
 				/>
 			</div>

--- a/src/components/Tables/SyServerTable/SyServerTable.stories.ts
+++ b/src/components/Tables/SyServerTable/SyServerTable.stories.ts
@@ -2652,6 +2652,7 @@ export const CustomFilterSlot: Story = {
 		'caption': '',
 		'options': {
 			itemsPerPage: 4,
+			page: 1,
 			filters: [],
 		},
 		'showFilters': true,
@@ -2723,6 +2724,32 @@ export const CustomFilterSlot: Story = {
 					loading.value = false
 				}
 
+				function handleFilterChange(val) {
+					// Ensure options.value.filters is initialized
+					if (!options.value.filters) {
+						options.value.filters = []
+					}
+
+					// Create a new filters array with proper typing
+					const currentFilters = options.value.filters as import('../common/types').FilterOption[]
+					const newFilters = [...currentFilters].filter(f => f.key !== 'status')
+
+					// Add the new filter if a value is selected
+					if (val) {
+						newFilters.push({
+							key: 'status',
+							value: val,
+							type: 'select' as FilterType, // Use 'select' type for compatibility with filtering logic
+						})
+					}
+
+					// Update the options with the new filters
+					options.value = {
+						...options.value,
+						filters: newFilters,
+					}
+				}
+
 				// Initialize data
 				fetchData()
 
@@ -2734,6 +2761,7 @@ export const CustomFilterSlot: Story = {
 					statusOptions,
 					loading,
 					serverItemsLength,
+					handleFilterChange,
 					fetchData,
 				}
 			},
@@ -2760,8 +2788,10 @@ export const CustomFilterSlot: Story = {
 								color="primary"
 								bg-color="white"
 								@update:model-value="(val) => {
-								// Utiliser la fonction updateFilter fournie par le slot
-								updateFilter(val)
+									// Use updateFilter provided by the slot props
+									updateFilter(val);
+									// Also update our local state
+									handleFilterChange(val);
 								}"
 							/>
 						</div>

--- a/src/components/Tables/SyServerTable/SyServerTable.stories.ts
+++ b/src/components/Tables/SyServerTable/SyServerTable.stories.ts
@@ -255,6 +255,8 @@ export const Default: Story = {
 				const users = ref<User[]>([])
 				const state = ref(StateEnum.IDLE)
 
+				const options = ref(args.options)
+
 				const fetchData = async (): Promise<void> => {
 					// @ts-expect-error - fetchData is not defined
 					const { items, total } = await getDataFromApi(args.options)
@@ -312,12 +314,12 @@ export const Default: Story = {
 					]
 				}
 
-				return { args, users, state, fetchData, totalUsers, StateEnum }
+				return { args, users, state, fetchData, options, totalUsers, StateEnum }
 			},
 			template: `
 			<div>
 				<SyServerTable
-					v-model:options="args.options"
+					v-model:options="options"
 					:items="users"
 					:server-items-length="totalUsers"
 					:loading="state === StateEnum.PENDING"
@@ -471,6 +473,8 @@ export const ServerSortBy: Story = {
 				const users = ref<User[]>([])
 				const state = ref(StateEnum.IDLE)
 
+				const options = ref(args.options)
+
 				const fetchData = async (): Promise<void> => {
 					const { items, total } = await getDataFromApi(args.options as DataOptions)
 					users.value = items
@@ -522,12 +526,12 @@ export const ServerSortBy: Story = {
 					]
 				}
 
-				return { args, users, state, fetchData, totalUsers, StateEnum }
+				return { args, users, state, fetchData, options, totalUsers, StateEnum }
 			},
 			template: `
 	  <div>
 		<SyServerTable
-		  v-model:options="args.options"
+		  v-model:options="options"
 		  :items="users"
 		  :server-items-length="totalUsers"
 		  :loading="state === StateEnum.PENDING"
@@ -795,6 +799,7 @@ export const ServerFilterByText: Story = {
 					filteredUsers,
 					totalFilteredUsers,
 					state,
+					options,
 					fetchData,
 					StateEnum,
 				}
@@ -802,7 +807,7 @@ export const ServerFilterByText: Story = {
 			template: `
 				<div>
 					<SyServerTable
-						v-model:options="args.options"
+						v-model:options="options"
 						:items="filteredUsers"
 						:server-items-length="totalFilteredUsers"
 						:loading="state === StateEnum.PENDING"
@@ -1084,6 +1089,7 @@ export const ServerFilterByNumber: Story = {
 					args,
 					filteredUsers,
 					totalFilteredUsers,
+					options,
 					state,
 					fetchData,
 					StateEnum,
@@ -1092,7 +1098,7 @@ export const ServerFilterByNumber: Story = {
 			template: `
 				<div>
 					<SyServerTable
-						v-model:options="args.options"
+						v-model:options="options"
 						:items="filteredUsers"
 						:server-items-length="totalFilteredUsers"
 						:loading="state === StateEnum.PENDING"
@@ -1396,6 +1402,7 @@ export const ServerFilterBySelect: Story = {
 					args,
 					filteredUsers,
 					totalFilteredUsers,
+					options,
 					state,
 					fetchData,
 					StateEnum,
@@ -1404,7 +1411,7 @@ export const ServerFilterBySelect: Story = {
 			template: `
 				<div>
 					<SyServerTable
-						v-model:options="args.options"
+						v-model:options="options"
 						:items="filteredUsers"
 						:server-items-length="totalFilteredUsers"
 						:loading="state === StateEnum.PENDING"
@@ -1724,6 +1731,7 @@ export const ServerFilterBySelectMultiple: Story = {
 					args,
 					filteredUsers,
 					totalFilteredUsers,
+					options,
 					state,
 					fetchData,
 					StateEnum,
@@ -1732,7 +1740,7 @@ export const ServerFilterBySelectMultiple: Story = {
 			template: `
 				<div>
 					<SyServerTable
-						v-model:options="args.options"
+						v-model:options="options"
 						:items="filteredUsers"
 						:server-items-length="totalFilteredUsers"
 						:loading="state === StateEnum.PENDING"
@@ -2013,7 +2021,7 @@ export const ServerFilterByExacteDate: Story = {
 			template: `
 				<div>
 					<SyServerTable
-						v-model:options="args.options"
+						v-model:options="options"
 						:items="users"
 						:server-items-length="totalUsers"
 						:loading="state === StateEnum.PENDING"
@@ -2311,7 +2319,7 @@ export const ServerFilterByPeriod: Story = {
 			template: `
 				<div>
 					<SyServerTable
-						v-model:options="args.options"
+						v-model:options="options"
 						:items="users"
 						:server-items-length="totalUsers"
 						:loading="state === StateEnum.PENDING"
@@ -2679,7 +2687,7 @@ export const CustomFilterInputs: Story = {
 				code: `
 		<template>
 		  <SyServerTable
-			v-model:options="args.options"
+			v-model:options="options"
 			:items="filteredUsers"
 			:headers="headers"
 			:server-items-length="totalFilteredUsers"
@@ -2943,6 +2951,7 @@ export const CustomFilterInputs: Story = {
 					args,
 					filteredUsers,
 					totalFilteredUsers,
+					options,
 					state,
 					fetchData,
 					StateEnum,
@@ -2951,7 +2960,7 @@ export const CustomFilterInputs: Story = {
 			template: `
 				<div>
 					<SyServerTable
-						v-model:options="args.options"
+						v-model:options="options"
 						:items="filteredUsers"
 						:server-items-length="totalFilteredUsers"
 						:loading="state === StateEnum.PENDING"
@@ -3425,6 +3434,8 @@ export const DataAlignment: Story = {
 				const users = ref<User[]>([])
 				const state = ref(StateEnum.IDLE)
 
+				const options = ref(args.options)
+
 				const fetchData = async (): Promise<void> => {
 					// @ts-expect-error - fetchData is not defined
 					const { items, total } = await getDataFromApi(args.options)
@@ -3485,11 +3496,11 @@ export const DataAlignment: Story = {
 					]
 				}
 
-				return { args, users, state, fetchData, totalUsers, StateEnum }
+				return { args, users, state, fetchData, options, totalUsers, StateEnum }
 			},
 			template: `
 				<SyServerTable
-					v-model:options="args.options"
+					v-model:options="options"
 					:items="users"
 					:server-items-length="totalUsers"
 					:loading="state === StateEnum.PENDING"
@@ -3649,6 +3660,8 @@ export const ResizableColumns: Story = {
 				const users = ref<User[]>([])
 				const state = ref(StateEnum.IDLE)
 
+				const options = ref(args.options)
+
 				const fetchData = async (): Promise<void> => {
 					// @ts-expect-error - fetchData is not defined
 					const { items, total } = await getDataFromApi(args.options)
@@ -3706,12 +3719,12 @@ export const ResizableColumns: Story = {
 					]
 				}
 
-				return { args, users, state, fetchData, totalUsers, StateEnum }
+				return { args, users, state, fetchData, options, totalUsers, StateEnum }
 			},
 			template: `
 			<div>
 				<SyServerTable
-					v-model:options="args.options"
+					v-model:options="options"
 					:items="users"
 					:server-items-length="totalUsers"
 					:loading="state === StateEnum.PENDING"

--- a/src/components/Tables/SyServerTable/SyServerTable.stories.ts
+++ b/src/components/Tables/SyServerTable/SyServerTable.stories.ts
@@ -87,14 +87,6 @@ const meta = {
 			},
 			required: true,
 		},
-		itemsPerPage: {
-			description: 'Nombre d\'éléments par page',
-			control: { type: 'number' },
-			table: {
-				category: 'props',
-				type: { summary: 'number' },
-			},
-		},
 		caption: {
 			description: 'Texte de la légende du tableau',
 			control: { type: 'text' },
@@ -247,10 +239,6 @@ export const Default: Story = {
 		'onUpdate:options': fn(),
 	},
 	render: (args) => {
-		// Synchroniser itemsPerPage avec options.itemsPerPage
-		if (args.itemsPerPage !== undefined && args.options) {
-			args.options.itemsPerPage = args.itemsPerPage
-		}
 		return {
 			components: { SyServerTable },
 			setup() {
@@ -481,10 +469,6 @@ export const ServerSortBy: Story = {
 		'onUpdate:options': fn(),
 	},
 	render: (args) => {
-		// Synchroniser itemsPerPage avec options.itemsPerPage
-		if (args.itemsPerPage !== undefined && args.options) {
-			args.options.itemsPerPage = args.itemsPerPage
-		}
 		return {
 			components: { SyServerTable },
 			setup() {
@@ -762,10 +746,6 @@ export const ServerFilterByText: Story = {
 		'onUpdate:options': fn(),
 	},
 	render(args) {
-		// Synchroniser itemsPerPage avec options.itemsPerPage
-		if (args.itemsPerPage !== undefined && args.options) {
-			args.options.itemsPerPage = args.itemsPerPage
-		}
 		return {
 			components: { SyServerTable },
 			setup() {
@@ -1054,10 +1034,6 @@ export const ServerFilterByNumber: Story = {
 		'onUpdate:options': fn(),
 	},
 	render(args) {
-		// Synchroniser itemsPerPage avec options.itemsPerPage
-		if (args.itemsPerPage !== undefined && args.options) {
-			args.options.itemsPerPage = args.itemsPerPage
-		}
 		return {
 			components: { SyServerTable },
 			setup() {
@@ -1374,10 +1350,6 @@ export const ServerFilterBySelect: Story = {
 		'onUpdate:options': fn(),
 	},
 	render(args) {
-		// Synchroniser itemsPerPage avec options.itemsPerPage
-		if (args.itemsPerPage !== undefined && args.options) {
-			args.options.itemsPerPage = args.itemsPerPage
-		}
 		return {
 			components: { SyServerTable },
 			setup() {
@@ -1702,10 +1674,6 @@ export const ServerFilterBySelectMultiple: Story = {
 		'onUpdate:options': fn(),
 	},
 	render(args) {
-		// Synchroniser itemsPerPage avec options.itemsPerPage
-		if (args.itemsPerPage !== undefined && args.options) {
-			args.options.itemsPerPage = args.itemsPerPage
-		}
 		return {
 			components: { SyServerTable },
 			setup() {
@@ -1981,10 +1949,6 @@ export const ServerFilterByExacteDate: Story = {
 		'onUpdate:options': fn(),
 	},
 	render(args) {
-		// Synchroniser itemsPerPage avec options.itemsPerPage
-		if (args.itemsPerPage !== undefined && args.options) {
-			args.options.itemsPerPage = args.itemsPerPage
-		}
 		return {
 			components: { SyServerTable },
 			setup() {
@@ -2290,10 +2254,6 @@ export const ServerFilterByPeriod: Story = {
 		'onUpdate:options': fn(),
 	},
 	render(args) {
-		// Synchroniser itemsPerPage avec options.itemsPerPage
-		if (args.itemsPerPage !== undefined && args.options) {
-			args.options.itemsPerPage = args.itemsPerPage
-		}
 		return {
 			components: { SyServerTable },
 			setup() {
@@ -2662,10 +2622,6 @@ export const CustomFilterSlot: Story = {
 		'onUpdate:options': fn(),
 	},
 	render(args) {
-		// Synchroniser itemsPerPage avec options.itemsPerPage
-		if (args.itemsPerPage !== undefined && args.options) {
-			args.options.itemsPerPage = args.itemsPerPage
-		}
 		return {
 			components: { SyServerTable },
 			setup() {
@@ -3005,10 +2961,6 @@ export const CustomFilterInputs: Story = {
 		'onUpdate:options': fn(),
 	},
 	render(args) {
-		// Synchroniser itemsPerPage avec options.itemsPerPage
-		if (args.itemsPerPage !== undefined && args.options) {
-			args.options.itemsPerPage = args.itemsPerPage
-		}
 		return {
 			components: { SyServerTable },
 			setup() {
@@ -3261,10 +3213,6 @@ export const ManyServerTables: Story = {
 		'onUpdate:options': fn(),
 	},
 	render: (args) => {
-		// Synchroniser itemsPerPage avec options.itemsPerPage
-		if (args.itemsPerPage !== undefined && args.options) {
-			args.options.itemsPerPage = args.itemsPerPage
-		}
 		return {
 			components: { SyServerTable },
 			setup() {
@@ -3558,10 +3506,6 @@ export const DataAlignment: Story = {
 		'onUpdate:options': fn(),
 	},
 	render: (args) => {
-		// Synchroniser itemsPerPage avec options.itemsPerPage
-		if (args.itemsPerPage !== undefined && args.options) {
-			args.options.itemsPerPage = args.itemsPerPage
-		}
 		return {
 			components: { SyServerTable },
 			setup() {
@@ -3794,10 +3738,6 @@ export const ResizableColumns: Story = {
 		'onUpdate:options': fn(),
 	},
 	render: (args) => {
-		// Synchroniser itemsPerPage avec options.itemsPerPage
-		if (args.itemsPerPage !== undefined && args.options) {
-			args.options.itemsPerPage = args.itemsPerPage
-		}
 		return {
 			components: { SyServerTable },
 			setup() {

--- a/src/components/Tables/SyServerTable/SyServerTable.stories.ts
+++ b/src/components/Tables/SyServerTable/SyServerTable.stories.ts
@@ -90,6 +90,10 @@ const meta = {
 		itemsPerPage: {
 			description: 'Nombre d\'éléments par page',
 			control: { type: 'number' },
+			table: {
+				category: 'props',
+				type: { summary: 'number' },
+			},
 		},
 		caption: {
 			description: 'Texte de la légende du tableau',
@@ -239,6 +243,10 @@ export const Default: Story = {
 		striped: false,
 	},
 	render: (args) => {
+		// Synchroniser itemsPerPage avec options.itemsPerPage
+		if (args.itemsPerPage !== undefined && args.options) {
+			args.options.itemsPerPage = args.itemsPerPage
+		}
 		return {
 			components: { SyServerTable },
 			setup() {
@@ -455,6 +463,10 @@ export const ServerSortBy: Story = {
 		striped: false,
 	},
 	render: (args) => {
+		// Synchroniser itemsPerPage avec options.itemsPerPage
+		if (args.itemsPerPage !== undefined && args.options) {
+			args.options.itemsPerPage = args.itemsPerPage
+		}
 		return {
 			components: { SyServerTable },
 			setup() {
@@ -720,6 +732,10 @@ export const ServerFilterByText: Story = {
 		striped: false,
 	},
 	render(args) {
+		// Synchroniser itemsPerPage avec options.itemsPerPage
+		if (args.itemsPerPage !== undefined && args.options) {
+			args.options.itemsPerPage = args.itemsPerPage
+		}
 		return {
 			components: { SyServerTable },
 			setup() {
@@ -783,7 +799,6 @@ export const ServerFilterByText: Story = {
 
 				return {
 					args,
-					options,
 					filteredUsers,
 					totalFilteredUsers,
 					state,
@@ -794,7 +809,7 @@ export const ServerFilterByText: Story = {
 			template: `
 				<div>
 					<SyServerTable
-						v-model:options="options"
+						v-model:options="args.options"
 						:items="filteredUsers"
 						:headers="args.headers"
 						:caption="args.caption"
@@ -1006,6 +1021,10 @@ export const ServerFilterByNumber: Story = {
 		striped: false,
 	},
 	render(args) {
+		// Synchroniser itemsPerPage avec options.itemsPerPage
+		if (args.itemsPerPage !== undefined && args.options) {
+			args.options.itemsPerPage = args.itemsPerPage
+		}
 		return {
 			components: { SyServerTable },
 			setup() {
@@ -1075,7 +1094,6 @@ export const ServerFilterByNumber: Story = {
 
 				return {
 					args,
-					options,
 					filteredUsers,
 					totalFilteredUsers,
 					state,
@@ -1086,7 +1104,7 @@ export const ServerFilterByNumber: Story = {
 			template: `
 				<div>
 					<SyServerTable
-						v-model:options="options"
+						v-model:options="args.options"
 						:items="filteredUsers"
 						:headers="args.headers"
 						:caption="args.caption"
@@ -1320,6 +1338,10 @@ export const ServerFilterBySelect: Story = {
 		striped: false,
 	},
 	render(args) {
+		// Synchroniser itemsPerPage avec options.itemsPerPage
+		if (args.itemsPerPage !== undefined && args.options) {
+			args.options.itemsPerPage = args.itemsPerPage
+		}
 		return {
 			components: { SyServerTable },
 			setup() {
@@ -1389,7 +1411,6 @@ export const ServerFilterBySelect: Story = {
 
 				return {
 					args,
-					options,
 					filteredUsers,
 					totalFilteredUsers,
 					state,
@@ -1400,7 +1421,7 @@ export const ServerFilterBySelect: Story = {
 			template: `
 				<div>
 					<SyServerTable
-						v-model:options="options"
+						v-model:options="args.options"
 						:items="filteredUsers"
 						:headers="args.headers"
 						:caption="args.caption"
@@ -1642,6 +1663,10 @@ export const ServerFilterBySelectMultiple: Story = {
 		striped: false,
 	},
 	render(args) {
+		// Synchroniser itemsPerPage avec options.itemsPerPage
+		if (args.itemsPerPage !== undefined && args.options) {
+			args.options.itemsPerPage = args.itemsPerPage
+		}
 		return {
 			components: { SyServerTable },
 			setup() {
@@ -1719,7 +1744,6 @@ export const ServerFilterBySelectMultiple: Story = {
 
 				return {
 					args,
-					options,
 					filteredUsers,
 					totalFilteredUsers,
 					state,
@@ -1730,7 +1754,7 @@ export const ServerFilterBySelectMultiple: Story = {
 			template: `
 				<div>
 					<SyServerTable
-						v-model:options="options"
+						v-model:options="args.options"
 						:items="filteredUsers"
 						:headers="args.headers"
 						:caption="args.caption"
@@ -1910,6 +1934,10 @@ export const ServerFilterByExacteDate: Story = {
 		striped: false,
 	},
 	render(args) {
+		// Synchroniser itemsPerPage avec options.itemsPerPage
+		if (args.itemsPerPage !== undefined && args.options) {
+			args.options.itemsPerPage = args.itemsPerPage
+		}
 		return {
 			components: { SyServerTable },
 			setup() {
@@ -2012,7 +2040,7 @@ export const ServerFilterByExacteDate: Story = {
 			template: `
 				<div>
 					<SyServerTable
-						v-model:options="options"
+						v-model:options="args.options"
 						:items="users"
 						:headers="args.headers"
 						:caption="args.caption"
@@ -2209,6 +2237,10 @@ export const ServerFilterByPeriod: Story = {
 		striped: false,
 	},
 	render(args) {
+		// Synchroniser itemsPerPage avec options.itemsPerPage
+		if (args.itemsPerPage !== undefined && args.options) {
+			args.options.itemsPerPage = args.itemsPerPage
+		}
 		return {
 			components: { SyServerTable },
 			setup() {
@@ -2311,7 +2343,7 @@ export const ServerFilterByPeriod: Story = {
 			template: `
 				<div>
 					<SyServerTable
-						v-model:options="options"
+						v-model:options="args.options"
 						:items="users"
 						:headers="args.headers"
 						:caption="args.caption"
@@ -2575,6 +2607,10 @@ export const CustomFilterSlot: Story = {
 		striped: false,
 	},
 	render(args) {
+		// Synchroniser itemsPerPage avec options.itemsPerPage
+		if (args.itemsPerPage !== undefined && args.options) {
+			args.options.itemsPerPage = args.itemsPerPage
+		}
 		return {
 			components: { SyServerTable },
 			setup() {
@@ -2686,7 +2722,7 @@ export const CustomFilterInputs: Story = {
 				code: `
 		<template>
 		  <SyServerTable
-			v-model:options="options"
+			v-model:options="args.options"
 			:items="filteredUsers"
 			:headers="headers"
 			:server-items-length="totalFilteredUsers"
@@ -2880,6 +2916,10 @@ export const CustomFilterInputs: Story = {
 		striped: false,
 	},
 	render(args) {
+		// Synchroniser itemsPerPage avec options.itemsPerPage
+		if (args.itemsPerPage !== undefined && args.options) {
+			args.options.itemsPerPage = args.itemsPerPage
+		}
 		return {
 			components: { SyServerTable },
 			setup() {
@@ -2943,7 +2983,6 @@ export const CustomFilterInputs: Story = {
 
 				return {
 					args,
-					options,
 					filteredUsers,
 					totalFilteredUsers,
 					state,
@@ -2954,7 +2993,7 @@ export const CustomFilterInputs: Story = {
 			template: `
 				<div>
 					<SyServerTable
-						v-model:options="options"
+						v-model:options="args.options"
 						:items="filteredUsers"
 						:headers="args.headers"
 						:caption="args.caption"
@@ -3041,8 +3080,9 @@ export const ManyServerTables: Story = {
 			page: 1,
 		  })
 
-		  const fetchDataTable1 = async (): Promise<void> => {
-			const { items, total } = await getDataFromApi(optionsTable1.value)
+		  const fetchDataTable1 = async (options?: DataOptions): Promise<void> => {
+			const optionsToUse = options || optionsTable1.value
+			const { items, total } = await getDataFromApi(optionsToUse)
 			usersTable1.value = items
 			totalUsersTable1.value = total
 		  }
@@ -3057,8 +3097,9 @@ export const ManyServerTables: Story = {
 			page: 1,
 		  })
 
-		  const fetchDataTable2 = async (): Promise<void> => {
-			const { items, total } = await getDataFromApi(optionsTable2.value)
+		  const fetchDataTable2 = async (options?: DataOptions): Promise<void> => {
+			const optionsToUse = options || optionsTable2.value
+			const { items, total } = await getDataFromApi(optionsToUse)
 			usersTable2.value = items
 			totalUsersTable2.value = total
 		  }
@@ -3126,6 +3167,10 @@ export const ManyServerTables: Story = {
 		striped: false,
 	},
 	render: (args) => {
+		// Synchroniser itemsPerPage avec options.itemsPerPage
+		if (args.itemsPerPage !== undefined && args.options) {
+			args.options.itemsPerPage = args.itemsPerPage
+		}
 		return {
 			components: { SyServerTable },
 			setup() {
@@ -3140,8 +3185,9 @@ export const ManyServerTables: Story = {
 					page: 1,
 				})
 
-				const fetchDataTable1 = async (): Promise<void> => {
-					const { items, total } = await getDataFromApi(optionsTable1.value as DataOptions)
+				const fetchDataTable1 = async (options?: DataOptions): Promise<void> => {
+					const optionsToUse = options || optionsTable1.value as DataOptions
+					const { items, total } = await getDataFromApi(optionsToUse)
 					usersTable1.value = items
 					totalUsersTable1.value = total
 				}
@@ -3157,8 +3203,9 @@ export const ManyServerTables: Story = {
 					page: 1,
 				})
 
-				const fetchDataTable2 = async (): Promise<void> => {
-					const { items, total } = await getDataFromApi(optionsTable2.value as DataOptions)
+				const fetchDataTable2 = async (options?: DataOptions): Promise<void> => {
+					const optionsToUse = options || optionsTable2.value as DataOptions
+					const { items, total } = await getDataFromApi(optionsToUse)
 					usersTable2.value = items
 					totalUsersTable2.value = total
 				}
@@ -3208,6 +3255,10 @@ export const ManyServerTables: Story = {
 						{ firstname: 'Rosemarie', lastname: 'Quessy', email: 'rosemarie.quessy@example.com' },
 					]
 				}
+
+				// Chargement initial des données
+				fetchDataTable1()
+				fetchDataTable2()
 
 				return {
 					args,
@@ -3419,6 +3470,10 @@ export const DataAlignment: Story = {
 		'onUpdate:options': fn(),
 	},
 	render: (args) => {
+		// Synchroniser itemsPerPage avec options.itemsPerPage
+		if (args.itemsPerPage !== undefined && args.options) {
+			args.options.itemsPerPage = args.itemsPerPage
+		}
 		return {
 			components: { SyServerTable },
 			setup() {
@@ -3642,6 +3697,10 @@ export const ResizableColumns: Story = {
 		resizableColumns: true,
 	},
 	render: (args) => {
+		// Synchroniser itemsPerPage avec options.itemsPerPage
+		if (args.itemsPerPage !== undefined && args.options) {
+			args.options.itemsPerPage = args.itemsPerPage
+		}
 		return {
 			components: { SyServerTable },
 			setup() {

--- a/src/components/Tables/SyServerTable/SyServerTable.stories.ts
+++ b/src/components/Tables/SyServerTable/SyServerTable.stories.ts
@@ -492,7 +492,13 @@ export const ServerSortBy: Story = {
 				const users = ref<User[]>([])
 				const state = ref(StateEnum.IDLE)
 
-				const options = ref(args.options)
+				const options = ref({ ...args.options })
+
+				watch(options, (newVal) => {
+					if (args.options) {
+						Object.assign(args.options, JSON.parse(JSON.stringify(newVal)))
+					}
+				}, { deep: true })
 
 				const fetchData = async (): Promise<void> => {
 					const { items, total } = await getDataFromApi(options.value as DataOptions)
@@ -763,7 +769,14 @@ export const ServerFilterByText: Story = {
 		return {
 			components: { SyServerTable },
 			setup() {
-				const options = ref(args.options)
+				const options = ref({ ...args.options })
+
+				watch(options, (newVal) => {
+					if (args.options) {
+						Object.assign(args.options, JSON.parse(JSON.stringify(newVal)))
+					}
+				}, { deep: true })
+
 				const totalFilteredUsers = ref(0)
 				const filteredUsers = ref<Record<string, unknown>[]>([])
 				const state = ref(StateEnum.IDLE)
@@ -1048,7 +1061,14 @@ export const ServerFilterByNumber: Story = {
 		return {
 			components: { SyServerTable },
 			setup() {
-				const options = ref(args.options)
+				const options = ref({ ...args.options })
+
+				watch(options, (newVal) => {
+					if (args.options) {
+						Object.assign(args.options, JSON.parse(JSON.stringify(newVal)))
+					}
+				}, { deep: true })
+
 				const totalFilteredUsers = ref(0)
 				const filteredUsers = ref<Record<string, unknown>[]>([])
 				const state = ref(StateEnum.IDLE)
@@ -1361,7 +1381,14 @@ export const ServerFilterBySelect: Story = {
 		return {
 			components: { SyServerTable },
 			setup() {
-				const options = ref(args.options)
+				const options = ref({ ...args.options })
+
+				watch(options, (newVal) => {
+					if (args.options) {
+						Object.assign(args.options, JSON.parse(JSON.stringify(newVal)))
+					}
+				}, { deep: true })
+
 				const totalFilteredUsers = ref(0)
 				const filteredUsers = ref<Record<string, unknown>[]>([])
 				const state = ref(StateEnum.IDLE)
@@ -1682,7 +1709,14 @@ export const ServerFilterBySelectMultiple: Story = {
 		return {
 			components: { SyServerTable },
 			setup() {
-				const options = ref(args.options)
+				const options = ref({ ...args.options })
+
+				watch(options, (newVal) => {
+					if (args.options) {
+						Object.assign(args.options, JSON.parse(JSON.stringify(newVal)))
+					}
+				}, { deep: true })
+
 				const totalFilteredUsers = ref(0)
 				const filteredUsers = ref<Record<string, unknown>[]>([])
 				const state = ref(StateEnum.IDLE)
@@ -1935,6 +1969,11 @@ export const ServerFilterByExacteDate: Story = {
 				dateFormat: 'DD/MM/YYYY',
 			},
 		],
+		'options': {
+			itemsPerPage: 5,
+			page: 1,
+			filters: [],
+		},
 		'caption': '',
 		'suffix': 'server-filter-date',
 		'density': 'default',
@@ -1973,13 +2012,16 @@ export const ServerFilterByExacteDate: Story = {
 					},
 				]
 
+				const options = ref({ ...args.options })
+
+				watch(options, (newVal) => {
+					if (args.options) {
+						Object.assign(args.options, JSON.parse(JSON.stringify(newVal)))
+					}
+				}, { deep: true })
+
 				const totalUsers = ref(originalUsers.length)
 				const users = ref([...originalUsers])
-				const options = ref({
-					itemsPerPage: 5,
-					page: 1,
-					filters: [],
-				})
 				const state = ref(StateEnum.IDLE)
 
 				const fetchData = async () => {
@@ -2236,6 +2278,11 @@ export const ServerFilterByPeriod: Story = {
 				dateFormat: 'DD/MM/YYYY',
 			},
 		],
+		'options': {
+			itemsPerPage: 5,
+			page: 1,
+			filters: [],
+		},
 		'caption': '',
 		'suffix': 'server-filter-date',
 		'density': 'default',
@@ -2274,13 +2321,16 @@ export const ServerFilterByPeriod: Story = {
 					},
 				]
 
+				const options = ref({ ...args.options })
+
+				watch(options, (newVal) => {
+					if (args.options) {
+						Object.assign(args.options, JSON.parse(JSON.stringify(newVal)))
+					}
+				}, { deep: true })
+
 				const totalUsers = ref(originalUsers.length)
 				const users = ref([...originalUsers])
-				const options = ref({
-					itemsPerPage: 5,
-					page: 1,
-					filters: [],
-				})
 				const state = ref(StateEnum.IDLE)
 
 				const fetchData = async () => {
@@ -2619,7 +2669,14 @@ export const CustomFilterSlot: Story = {
 			components: { SyServerTable },
 			setup() {
 				// Create reactive references
-				const options = ref(args.options)
+				const options = ref({ ...args.options })
+
+				watch(options, (newVal) => {
+					if (args.options) {
+						Object.assign(args.options, JSON.parse(JSON.stringify(newVal)))
+					}
+				}, { deep: true })
+
 				const items = ref(args.items)
 				const customFilterValue = ref('')
 				const statusOptions = ['Actif', 'Inactif', 'En attente']
@@ -2925,7 +2982,14 @@ export const CustomFilterInputs: Story = {
 		return {
 			components: { SyServerTable },
 			setup() {
-				const options = ref(args.options)
+				const options = ref({ ...args.options })
+
+				watch(options, (newVal) => {
+					if (args.options) {
+						Object.assign(args.options, JSON.parse(JSON.stringify(newVal)))
+					}
+				}, { deep: true })
+
 				const totalFilteredUsers = ref(0)
 				const filteredUsers = ref<Record<string, unknown>[]>([])
 				const state = ref(StateEnum.IDLE)
@@ -3154,7 +3218,6 @@ export const ManyServerTables: Story = {
 		],
 	},
 	args: {
-		'serverItemsLength': 15,
 		'headers': [
 			{ title: 'Nom', key: 'lastname' },
 			{ title: 'Prénom', key: 'firstname' },
@@ -3475,7 +3538,13 @@ export const DataAlignment: Story = {
 				const users = ref<User[]>([])
 				const state = ref(StateEnum.IDLE)
 
-				const options = ref(args.options)
+				const options = ref({ ...args.options })
+
+				watch(options, (newVal) => {
+					if (args.options) {
+						Object.assign(args.options, JSON.parse(JSON.stringify(newVal)))
+					}
+				}, { deep: true })
 
 				const fetchData = async (): Promise<void> => {
 					// @ts-expect-error - fetchData is not defined
@@ -3705,7 +3774,13 @@ export const ResizableColumns: Story = {
 				const users = ref<User[]>([])
 				const state = ref(StateEnum.IDLE)
 
-				const options = ref(args.options)
+				const options = ref({ ...args.options })
+
+				watch(options, (newVal) => {
+					if (args.options) {
+						Object.assign(args.options, JSON.parse(JSON.stringify(newVal)))
+					}
+				}, { deep: true })
 
 				const fetchData = async (): Promise<void> => {
 					// @ts-expect-error - fetchData is not defined

--- a/src/components/Tables/SyServerTable/SyServerTable.stories.ts
+++ b/src/components/Tables/SyServerTable/SyServerTable.stories.ts
@@ -226,21 +226,22 @@ export const Default: Story = {
 		],
 	},
 	args: {
-		options: {
+		'options': {
 			itemsPerPage: 5,
 			sortBy: [{ key: 'lastname', order: 'asc' }],
 			page: 1,
 		},
-		headers: [
+		'headers': [
 			{ title: 'Nom', key: 'lastname' },
 			{ title: 'Prénom', key: 'firstname' },
 			{ title: 'Email', key: 'email' },
 		],
-		caption: '',
-		serverItemsLength: 15,
-		suffix: 'server-default',
-		density: 'default',
-		striped: false,
+		'caption': '',
+		'serverItemsLength': 15,
+		'suffix': 'server-default',
+		'density': 'default',
+		'striped': false,
+		'onUpdate:options': fn(),
 	},
 	render: (args) => {
 		// Synchroniser itemsPerPage avec options.itemsPerPage
@@ -318,14 +319,9 @@ export const Default: Story = {
 				<SyServerTable
 					v-model:options="args.options"
 					:items="users"
-					:headers="args.headers"
-					:caption="args.caption"
 					:server-items-length="totalUsers"
 					:loading="state === StateEnum.PENDING"
-					:suffix="args.suffix"
-					:density="args.density"
-					:striped="args.striped"
-					:resizable-columns="args.resizableColumns"
+					v-bind="args"
 					@update:options="fetchData"
 				/>
 			</div>
@@ -446,21 +442,22 @@ export const ServerSortBy: Story = {
 		],
 	},
 	args: {
-		options: {
+		'options': {
 			itemsPerPage: 5,
 			sortBy: [{ key: 'lastname', order: 'desc' }],
 			page: 1,
 		},
-		headers: [
+		'headers': [
 			{ title: 'Nom', key: 'lastname' },
 			{ title: 'Prénom', key: 'firstname' },
 			{ title: 'Email', key: 'email' },
 		],
-		caption: '',
-		serverItemsLength: 0,
-		suffix: 'server-sort',
-		density: 'default',
-		striped: false,
+		'caption': '',
+		'serverItemsLength': 0,
+		'suffix': 'server-sort',
+		'density': 'default',
+		'striped': false,
+		'onUpdate:options': fn(),
 	},
 	render: (args) => {
 		// Synchroniser itemsPerPage avec options.itemsPerPage
@@ -532,14 +529,9 @@ export const ServerSortBy: Story = {
 		<SyServerTable
 		  v-model:options="args.options"
 		  :items="users"
-		  :headers="args.headers"
-		  :caption="args.caption"
 		  :server-items-length="totalUsers"
 		  :loading="state === StateEnum.PENDING"
-		  :suffix="args.suffix"
-		  :density="args.density"
-		  :striped="args.striped"
-		  :resizable-columns="args.resizableColumns"
+		  v-bind="args"
 		  @update:options="fetchData"
 		/>
 	  </div>
@@ -699,8 +691,8 @@ export const ServerFilterByText: Story = {
 		],
 	},
 	args: {
-		serverItemsLength: 15,
-		headers: [
+		'serverItemsLength': 15,
+		'headers': [
 			{
 				title: 'Prénom',
 				key: 'firstname',
@@ -720,16 +712,17 @@ export const ServerFilterByText: Story = {
 				filterType: 'text',
 			},
 		],
-		caption: '',
-		options: {
+		'caption': '',
+		'options': {
 			itemsPerPage: 5,
 			page: 1,
 			filters: [],
 		},
-		showFilters: true,
-		suffix: 'server-filter-text',
-		density: 'default',
-		striped: false,
+		'showFilters': true,
+		'suffix': 'server-filter-text',
+		'density': 'default',
+		'striped': false,
+		'onUpdate:options': fn(),
 	},
 	render(args) {
 		// Synchroniser itemsPerPage avec options.itemsPerPage
@@ -811,15 +804,9 @@ export const ServerFilterByText: Story = {
 					<SyServerTable
 						v-model:options="args.options"
 						:items="filteredUsers"
-						:headers="args.headers"
-						:caption="args.caption"
 						:server-items-length="totalFilteredUsers"
 						:loading="state === StateEnum.PENDING"
-						:show-filters="args.showFilters"
-						:suffix="args.suffix"
-						:density="args.density"
-						:striped="args.striped"
-						:resizable-columns="args.resizableColumns"
+						v-bind="args"
 						@update:options="fetchData"
 					/>
 				</div>
@@ -988,7 +975,7 @@ export const ServerFilterByNumber: Story = {
 		],
 	},
 	args: {
-		headers: [
+		'headers': [
 			{
 				title: 'Nom',
 				key: 'name',
@@ -1008,17 +995,18 @@ export const ServerFilterByNumber: Story = {
 				filterType: 'number',
 			},
 		],
-		caption: '',
-		options: {
+		'caption': '',
+		'options': {
 			itemsPerPage: 5,
 			page: 1,
 			filters: [],
 		},
-		serverItemsLength: 15,
-		showFilters: true,
-		suffix: 'server-filter-number',
-		density: 'default',
-		striped: false,
+		'serverItemsLength': 15,
+		'showFilters': true,
+		'suffix': 'server-filter-number',
+		'density': 'default',
+		'striped': false,
+		'onUpdate:options': fn(),
 	},
 	render(args) {
 		// Synchroniser itemsPerPage avec options.itemsPerPage
@@ -1106,15 +1094,9 @@ export const ServerFilterByNumber: Story = {
 					<SyServerTable
 						v-model:options="args.options"
 						:items="filteredUsers"
-						:headers="args.headers"
-						:caption="args.caption"
 						:server-items-length="totalFilteredUsers"
 						:loading="state === StateEnum.PENDING"
-						:show-filters="args.showFilters"
-						:suffix="args.suffix"
-						:density="args.density"
-						:striped="args.striped"
-						:resizable-columns="args.resizableColumns"
+						v-bind="args"
 						@update:options="fetchData"
 					/>
 				</div>
@@ -1292,7 +1274,7 @@ export const ServerFilterBySelect: Story = {
 		],
 	},
 	args: {
-		headers: [
+		'headers': [
 			{
 				title: 'Nom',
 				key: 'name',
@@ -1325,17 +1307,18 @@ export const ServerFilterBySelect: Story = {
 				],
 			},
 		],
-		caption: '',
-		options: {
+		'caption': '',
+		'options': {
 			itemsPerPage: 5,
 			page: 1,
 			filters: [],
 		},
-		serverItemsLength: 15,
-		showFilters: true,
-		suffix: 'server-filter-select',
-		density: 'default',
-		striped: false,
+		'serverItemsLength': 15,
+		'showFilters': true,
+		'suffix': 'server-filter-select',
+		'density': 'default',
+		'striped': false,
+		'onUpdate:options': fn(),
 	},
 	render(args) {
 		// Synchroniser itemsPerPage avec options.itemsPerPage
@@ -1423,15 +1406,9 @@ export const ServerFilterBySelect: Story = {
 					<SyServerTable
 						v-model:options="args.options"
 						:items="filteredUsers"
-						:headers="args.headers"
-						:caption="args.caption"
 						:server-items-length="totalFilteredUsers"
 						:loading="state === StateEnum.PENDING"
-						:show-filters="args.showFilters"
-						:suffix="args.suffix"
-						:density="args.density"
-						:striped="args.striped"
-						:resizable-columns="args.resizableColumns"
+						v-bind="args"
 						@update:options="fetchData"
 					/>
 				</div>
@@ -1613,7 +1590,7 @@ export const ServerFilterBySelectMultiple: Story = {
 		],
 	},
 	args: {
-		headers: [
+		'headers': [
 			{
 				title: 'Nom',
 				key: 'name',
@@ -1650,17 +1627,18 @@ export const ServerFilterBySelectMultiple: Story = {
 				],
 			},
 		],
-		caption: '',
-		options: {
+		'caption': '',
+		'options': {
 			itemsPerPage: 5,
 			page: 1,
 			filters: [],
 		},
-		serverItemsLength: 15,
-		showFilters: true,
-		suffix: 'server-filter-select',
-		density: 'default',
-		striped: false,
+		'serverItemsLength': 15,
+		'showFilters': true,
+		'suffix': 'server-filter-select',
+		'density': 'default',
+		'striped': false,
+		'onUpdate:options': fn(),
 	},
 	render(args) {
 		// Synchroniser itemsPerPage avec options.itemsPerPage
@@ -1756,15 +1734,9 @@ export const ServerFilterBySelectMultiple: Story = {
 					<SyServerTable
 						v-model:options="args.options"
 						:items="filteredUsers"
-						:headers="args.headers"
-						:caption="args.caption"
 						:server-items-length="totalFilteredUsers"
 						:loading="state === StateEnum.PENDING"
-						:show-filters="args.showFilters"
-						:suffix="args.suffix"
-						:density="args.density"
-						:striped="args.striped"
-						:resizable-columns="args.resizableColumns"
+						v-bind="args"
 						@update:options="fetchData"
 					/>
 				</div>
@@ -1911,9 +1883,9 @@ export const ServerFilterByExacteDate: Story = {
 		],
 	},
 	args: {
-		serverItemsLength: 0,
-		showFilters: true,
-		headers: [
+		'serverItemsLength': 0,
+		'showFilters': true,
+		'headers': [
 			{
 				title: 'Nom',
 				key: 'name',
@@ -1928,10 +1900,11 @@ export const ServerFilterByExacteDate: Story = {
 				dateFormat: 'DD/MM/YYYY',
 			},
 		],
-		caption: '',
-		suffix: 'server-filter-date',
-		density: 'default',
-		striped: false,
+		'caption': '',
+		'suffix': 'server-filter-date',
+		'density': 'default',
+		'striped': false,
+		'onUpdate:options': fn(),
 	},
 	render(args) {
 		// Synchroniser itemsPerPage avec options.itemsPerPage
@@ -2042,15 +2015,9 @@ export const ServerFilterByExacteDate: Story = {
 					<SyServerTable
 						v-model:options="args.options"
 						:items="users"
-						:headers="args.headers"
-						:caption="args.caption"
 						:server-items-length="totalUsers"
 						:loading="state === StateEnum.PENDING"
-						:resizable-columns="args.resizableColumns"
-						:show-filters="true"
-						:suffix="args.suffix"
-						:density="args.density"
-						:striped="args.striped"
+						v-bind="args"
 						@update:options="fetchData"
 					/>
 				</div>
@@ -2214,9 +2181,9 @@ export const ServerFilterByPeriod: Story = {
 		],
 	},
 	args: {
-		serverItemsLength: 0,
-		showFilters: true,
-		headers: [
+		'serverItemsLength': 0,
+		'showFilters': true,
+		'headers': [
 			{
 				title: 'Nom',
 				key: 'name',
@@ -2231,10 +2198,11 @@ export const ServerFilterByPeriod: Story = {
 				dateFormat: 'DD/MM/YYYY',
 			},
 		],
-		caption: '',
-		suffix: 'server-filter-date',
-		density: 'default',
-		striped: false,
+		'caption': '',
+		'suffix': 'server-filter-date',
+		'density': 'default',
+		'striped': false,
+		'onUpdate:options': fn(),
 	},
 	render(args) {
 		// Synchroniser itemsPerPage avec options.itemsPerPage
@@ -2345,15 +2313,9 @@ export const ServerFilterByPeriod: Story = {
 					<SyServerTable
 						v-model:options="args.options"
 						:items="users"
-						:headers="args.headers"
-						:caption="args.caption"
 						:server-items-length="totalUsers"
 						:loading="state === StateEnum.PENDING"
-						:resizable-columns="args.resizableColumns"
-						:show-filters="true"
-						:suffix="args.suffix"
-						:density="args.density"
-						:striped="args.striped"
+						v-bind="args"
 						@update:options="fetchData"
 					/>
 				</div>
@@ -2543,8 +2505,8 @@ export const CustomFilterSlot: Story = {
 		],
 	},
 	args: {
-		serverItemsLength: 6,
-		headers: [
+		'serverItemsLength': 6,
+		'headers': [
 			{
 				title: 'Nom',
 				key: 'lastname',
@@ -2564,7 +2526,7 @@ export const CustomFilterSlot: Story = {
 				filterType: 'custom' as FilterType,
 			},
 		],
-		items: [
+		'items': [
 			{
 				firstname: 'Virginie',
 				lastname: 'Beauchesne',
@@ -2596,15 +2558,16 @@ export const CustomFilterSlot: Story = {
 				status: 'En attente',
 			},
 		],
-		caption: '',
-		options: {
+		'caption': '',
+		'options': {
 			itemsPerPage: 4,
 			filters: [],
 		},
-		showFilters: true,
-		suffix: 'server-custom-filter-slot',
-		density: 'default',
-		striped: false,
+		'showFilters': true,
+		'suffix': 'server-custom-filter-slot',
+		'density': 'default',
+		'striped': false,
+		'onUpdate:options': fn(),
 	},
 	render(args) {
 		// Synchroniser itemsPerPage avec options.itemsPerPage
@@ -2676,16 +2639,10 @@ export const CustomFilterSlot: Story = {
 			template: `
 				<SyServerTable
 					v-model:options="options"
-					:headers="args.headers"
 					:items="items"
-					:caption="args.caption"
 					:server-items-length="serverItemsLength"
 					:loading="loading"
-					:show-filters="args.showFilters"
-					:suffix="args.suffix"
-					:density="args.density"
-					:striped="args.striped"
-					:resizable-columns="args.resizableColumns"
+					v-bind="args"
 					@update:options="fetchData"
 				>
 					<template #filter.custom="{ header, value, updateFilter }">
@@ -2876,8 +2833,8 @@ export const CustomFilterInputs: Story = {
 		],
 	},
 	args: {
-		serverItemsLength: 15,
-		headers: [
+		'serverItemsLength': 15,
+		'headers': [
 			{
 				title: 'Prénom',
 				key: 'firstname',
@@ -2897,23 +2854,24 @@ export const CustomFilterInputs: Story = {
 				filterType: 'text',
 			},
 		],
-		caption: '',
-		options: {
+		'caption': '',
+		'options': {
 			itemsPerPage: 5,
 			page: 1,
 			filters: [],
 		},
-		filterInputConfig: {
+		'filterInputConfig': {
 			variant: 'outlined',
 			density: 'comfortable',
 			hideDetails: true,
 			clearable: false,
 			disableErrorHandling: true,
 		},
-		showFilters: true,
-		suffix: 'server-filter-text',
-		density: 'default',
-		striped: false,
+		'showFilters': true,
+		'suffix': 'server-filter-text',
+		'density': 'default',
+		'striped': false,
+		'onUpdate:options': fn(),
 	},
 	render(args) {
 		// Synchroniser itemsPerPage avec options.itemsPerPage
@@ -2995,16 +2953,9 @@ export const CustomFilterInputs: Story = {
 					<SyServerTable
 						v-model:options="args.options"
 						:items="filteredUsers"
-						:headers="args.headers"
-						:caption="args.caption"
 						:server-items-length="totalFilteredUsers"
 						:loading="state === StateEnum.PENDING"
-						:show-filters="args.showFilters"
-						:filter-input-config="args.filterInputConfig"
-						:suffix="args.suffix"
-						:density="args.density"
-						:striped="args.striped"
-						:resizable-columns="args.resizableColumns"
+						v-bind="args"
 						@update:options="fetchData"
 					/>
 				</div>
@@ -3155,16 +3106,17 @@ export const ManyServerTables: Story = {
 		],
 	},
 	args: {
-		serverItemsLength: 15,
-		headers: [
+		'serverItemsLength': 15,
+		'headers': [
 			{ title: 'Nom', key: 'lastname' },
 			{ title: 'Prénom', key: 'firstname' },
 			{ title: 'Email', key: 'email' },
 		],
-		caption: '',
-		suffix: 'multi',
-		density: 'default',
-		striped: false,
+		'caption': '',
+		'suffix': 'multi',
+		'density': 'default',
+		'striped': false,
+		'onUpdate:options': fn(),
 	},
 	render: (args) => {
 		// Synchroniser itemsPerPage avec options.itemsPerPage
@@ -3280,28 +3232,20 @@ export const ManyServerTables: Story = {
 		<SyServerTable
 		  v-model:options="optionsTable1"
 		  :items="usersTable1"
-		  :headers="args.headers"
-		  :caption="args.caption"
 		  :server-items-length="totalUsersTable1"
 		  :loading="stateTable1 === StateEnum.PENDING"
-		  :density="args.density"
-		  :striped="args.striped"
+		  v-bind="args"
 		  suffix="table1"
 		  class="mb-10"
-		  :resizable-columns="args.resizableColumns"
 		  @update:options="fetchDataTable1"
 		/>
 		<SyServerTable
 		  v-model:options="optionsTable2"
 		  :items="usersTable2"
-		  :headers="args.headers"
-		  :caption="args.caption"
 		  :server-items-length="totalUsersTable2"
 		  :loading="stateTable2 === StateEnum.PENDING"
-		  :density="args.density"
-		  :striped="args.striped"
+		  v-bind="args"
 		  suffix="table2"
-		  :resizable-columns="args.resizableColumns"
 		  @update:options="fetchDataTable2"
 		/>
 	  </div>
@@ -3547,13 +3491,9 @@ export const DataAlignment: Story = {
 				<SyServerTable
 					v-model:options="args.options"
 					:items="users"
-					:headers="args.headers"
-					:caption="args.caption"
 					:server-items-length="totalUsers"
 					:loading="state === StateEnum.PENDING"
-					:suffix="args.suffix"
-					:density="args.density"
-					:striped="args.striped"
+					v-bind="args"
 					@update:options="[fetchData, args['onUpdate:options']]"
 				/>
 			`,
@@ -3679,22 +3619,23 @@ export const ResizableColumns: Story = {
 		],
 	},
 	args: {
-		options: {
+		'options': {
 			itemsPerPage: 5,
 			sortBy: [{ key: 'lastname', order: 'asc' }],
 			page: 1,
 		},
-		headers: [
+		'headers': [
 			{ title: 'Nom', key: 'lastname' },
 			{ title: 'Prénom', key: 'firstname' },
 			{ title: 'Email', key: 'email' },
 		],
-		caption: '',
-		serverItemsLength: 15,
-		suffix: 'server-resizable-columns',
-		density: 'default',
-		striped: false,
-		resizableColumns: true,
+		'caption': '',
+		'serverItemsLength': 15,
+		'suffix': 'server-resizable-columns',
+		'density': 'default',
+		'striped': false,
+		'resizableColumns': true,
+		'onUpdate:options': fn(),
 	},
 	render: (args) => {
 		// Synchroniser itemsPerPage avec options.itemsPerPage
@@ -3772,14 +3713,9 @@ export const ResizableColumns: Story = {
 				<SyServerTable
 					v-model:options="args.options"
 					:items="users"
-					:headers="args.headers"
-					:caption="args.caption"
 					:server-items-length="totalUsers"
 					:loading="state === StateEnum.PENDING"
-					:suffix="args.suffix"
-					:density="args.density"
-					:striped="args.striped"
-					:resizable-columns="args.resizableColumns"
+					v-bind="args"
 					@update:options="fetchData"
 				/>
 			</div>

--- a/src/components/Tables/SyServerTable/SyServerTable.stories.ts
+++ b/src/components/Tables/SyServerTable/SyServerTable.stories.ts
@@ -1912,7 +1912,7 @@ export const ServerFilterByExacteDate: Story = {
 		],
 	},
 	args: {
-		'serverItemsLength': 0,
+		'serverItemsLength': 5,
 		'showFilters': true,
 		'headers': [
 			{
@@ -2213,7 +2213,7 @@ export const ServerFilterByPeriod: Story = {
 		],
 	},
 	args: {
-		'serverItemsLength': 0,
+		'serverItemsLength': 5,
 		'showFilters': true,
 		'headers': [
 			{
@@ -2404,7 +2404,7 @@ export const CustomFilterSlot: Story = {
 				name: 'Script',
 				code: `
 				<script setup lang="ts">
-					import { ref } from 'vue'
+					import { ref, watch } from 'vue'
 					import { SyServerTable } from '@cnamts/synapse'
 					import { StateEnum } from '@cnamts/synapse/src/components/Tables/common/constants/StateEnum'
 					import type { DataOptions, FilterOption } from '@cnamts/synapse/src/components/Tables/common/types'
@@ -2697,8 +2697,8 @@ export const CustomFilterSlot: Story = {
 								color="primary"
 								bg-color="white"
 								@update:model-value="(val) => {
-									// Utiliser la fonction updateFilter fournie par le slot
-									updateFilter(val)
+								// Utiliser la fonction updateFilter fournie par le slot
+								updateFilter(val)
 								}"
 							/>
 						</div>
@@ -3451,7 +3451,7 @@ export const DataAlignment: Story = {
 			},
 		],
 		'caption': '',
-		'serverItemsLength': 15,
+		'serverItemsLength': 3,
 		'suffix': 'server-resizable-columns',
 		'density': 'default',
 		'striped': false,

--- a/src/components/Tables/SyServerTable/SyServerTable.stories.ts
+++ b/src/components/Tables/SyServerTable/SyServerTable.stories.ts
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/vue3'
 import SyServerTable from './SyServerTable.vue'
 import { StateEnum } from '../common/constants/StateEnum'
 import type { DataOptions, FilterType } from '../common/types'
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 import type { VDataTable } from 'vuetify/components'
 import dayjs from 'dayjs'
 import { fn } from '@storybook/test'
@@ -258,7 +258,13 @@ export const Default: Story = {
 				const users = ref<User[]>([])
 				const state = ref(StateEnum.IDLE)
 
-				const options = ref(args.options)
+				const options = ref({ ...args.options })
+
+				watch(options, (newVal) => {
+					if (args.options) {
+						Object.assign(args.options, JSON.parse(JSON.stringify(newVal)))
+					}
+				}, { deep: true })
 
 				const fetchData = async (): Promise<void> => {
 					const { items, total } = await getDataFromApi(options.value as DataOptions)

--- a/src/components/Tables/SyServerTable/SyServerTable.stories.ts
+++ b/src/components/Tables/SyServerTable/SyServerTable.stories.ts
@@ -220,6 +220,9 @@ export const Default: Story = {
 							{ firstname: 'Alexandre', lastname: 'Lazure', email: 'alexandre.lazure@example.com' },
 						]
 					}
+                    
+                      // Initialize data
+		  			fetchData()
 				</script>
 				`,
 			},
@@ -258,8 +261,7 @@ export const Default: Story = {
 				const options = ref(args.options)
 
 				const fetchData = async (): Promise<void> => {
-					// @ts-expect-error - fetchData is not defined
-					const { items, total } = await getDataFromApi(args.options)
+					const { items, total } = await getDataFromApi(options.value as DataOptions)
 					users.value = items
 					totalUsers.value = total
 				}
@@ -313,6 +315,9 @@ export const Default: Story = {
 						{ firstname: 'Alexandre', lastname: 'Lazure', email: 'alexandre.lazure@example.com' },
 					]
 				}
+
+				// Initialize data
+				fetchData()
 
 				return { args, users, state, fetchData, options, totalUsers, StateEnum }
 			},
@@ -426,18 +431,26 @@ export const ServerSortBy: Story = {
 
 		  const getUsers = (): User[] => {
 			return [
-			  { firstname: 'Virginie', lastname: 'Beauchesne', email: 'virginie.beauchesne@example.com' },
-			  { firstname: 'Simone', lastname: 'Bellefeuille', email: 'simone.bellefeuille@example.com' },
-			  { firstname: 'Étienne', lastname: 'Salois', email: 'etienne.salois@example.com' },
-			  { firstname: 'Bernadette', lastname: 'Langelier', email: 'bernadette.langelier@example.com' },
-			  { firstname: 'Agate', lastname: 'Roy', email: 'agate.roy@example.com' },
-			  { firstname: 'Louis', lastname: 'Denis', email: 'louis.denis@example.com' },
-			  { firstname: 'Édith', lastname: 'Cartier', email: 'edith.cartier@example.com' },
-			  { firstname: 'Alphonse', lastname: 'Bouvier', email: 'alphonse.bouvier@example.com' },
-			  { firstname: 'Eustache', lastname: 'Dubois', email: 'eustache.dubois@example.com' },
-			  { firstname: 'Rosemarie', lastname: 'Quessy', email: 'rosemarie.quessy@example.com' },
-			]
+							{ firstname: 'Virginie', lastname: 'Beauchesne', email: 'virginie.beauchesne@example.com' },
+							{ firstname: 'Simone', lastname: 'Bellefeuille', email: 'simone.bellefeuille@example.com' },
+							{ firstname: 'Étienne', lastname: 'Salois', email: 'etienne.salois@example.com' },
+							{ firstname: 'Bernadette', lastname: 'Langelier', email: 'bernadette.langelier@example.com' },
+							{ firstname: 'Agate', lastname: 'Roy', email: 'agate.roy@example.com' },
+							{ firstname: 'Louis', lastname: 'Denis', email: 'louis.denis@example.com' },
+							{ firstname: 'Édith', lastname: 'Cartier', email: 'edith.cartier@example.com' },
+							{ firstname: 'Alphonse', lastname: 'Bouvier', email: 'alphonse.bouvier@example.com' },
+							{ firstname: 'Eustache', lastname: 'Dubois', email: 'eustache.dubois@example.com' },
+							{ firstname: 'Rosemarie', lastname: 'Quessy', email: 'rosemarie.quessy@example.com' },
+							{ firstname: 'Serge', lastname: 'Rivard', email: 'serge.rivard@example.com' },
+							{ firstname: 'Jacques', lastname: 'Demers', email: 'jacques.demers@example.com' },
+							{ firstname: 'Aimée', lastname: 'Josseaume', email: 'aimee.josseaume@example.com' },
+							{ firstname: 'Delphine', lastname: 'Robillard', email: 'delphine.robillard@example.com' },
+							{ firstname: 'Alexandre', lastname: 'Lazure', email: 'alexandre.lazure@example.com' },
+						]
 		  }
+          
+           // Initialize data
+		  	fetchData()
 		</script>
 		`,
 			},
@@ -455,7 +468,7 @@ export const ServerSortBy: Story = {
 			{ title: 'Email', key: 'email' },
 		],
 		'caption': '',
-		'serverItemsLength': 0,
+		'serverItemsLength': 15,
 		'suffix': 'server-sort',
 		'density': 'default',
 		'striped': false,
@@ -476,7 +489,7 @@ export const ServerSortBy: Story = {
 				const options = ref(args.options)
 
 				const fetchData = async (): Promise<void> => {
-					const { items, total } = await getDataFromApi(args.options as DataOptions)
+					const { items, total } = await getDataFromApi(options.value as DataOptions)
 					users.value = items
 					totalUsers.value = total
 				}
@@ -523,8 +536,16 @@ export const ServerSortBy: Story = {
 						{ firstname: 'Alphonse', lastname: 'Bouvier', email: 'alphonse.bouvier@example.com' },
 						{ firstname: 'Eustache', lastname: 'Dubois', email: 'eustache.dubois@example.com' },
 						{ firstname: 'Rosemarie', lastname: 'Quessy', email: 'rosemarie.quessy@example.com' },
+						{ firstname: 'Serge', lastname: 'Rivard', email: 'serge.rivard@example.com' },
+						{ firstname: 'Jacques', lastname: 'Demers', email: 'jacques.demers@example.com' },
+						{ firstname: 'Aimée', lastname: 'Josseaume', email: 'aimee.josseaume@example.com' },
+						{ firstname: 'Delphine', lastname: 'Robillard', email: 'delphine.robillard@example.com' },
+						{ firstname: 'Alexandre', lastname: 'Lazure', email: 'alexandre.lazure@example.com' },
 					]
 				}
+
+				// Initialize data
+				fetchData()
 
 				return { args, users, state, fetchData, options, totalUsers, StateEnum }
 			},
@@ -2008,6 +2029,9 @@ export const ServerFilterByExacteDate: Story = {
 					state.value = StateEnum.RESOLVED
 				}
 
+				// Initialize data
+				fetchData()
+
 				return {
 					args,
 					users,
@@ -2305,6 +2329,9 @@ export const ServerFilterByPeriod: Story = {
 
 					state.value = StateEnum.RESOLVED
 				}
+
+				// Initialize data
+				fetchData()
 
 				return {
 					args,
@@ -2632,6 +2659,9 @@ export const CustomFilterSlot: Story = {
 					items.value = filteredItems.slice(start, end)
 					loading.value = false
 				}
+
+				// Initialize data
+				fetchData()
 
 				return {
 					args,
@@ -3109,6 +3139,9 @@ export const ManyServerTables: Story = {
 			  { firstname: 'Rosemarie', lastname: 'Quessy', email: 'rosemarie.quessy@example.com' },
 			]
 		  }
+          
+          fetchDataTable1()
+          fetchDataTable2()
 		</script>
 		`,
 			},
@@ -3382,6 +3415,8 @@ export const DataAlignment: Story = {
 							},
 						]
 					}
+                    
+                    fetchData()
 				</script>
 				`,
 			},
@@ -3438,7 +3473,7 @@ export const DataAlignment: Story = {
 
 				const fetchData = async (): Promise<void> => {
 					// @ts-expect-error - fetchData is not defined
-					const { items, total } = await getDataFromApi(args.options)
+					const { items, total } = await getDataFromApi(options.value)
 					users.value = items
 					totalUsers.value = total
 				}
@@ -3495,6 +3530,8 @@ export const DataAlignment: Story = {
 						},
 					]
 				}
+
+				fetchData()
 
 				return { args, users, state, fetchData, options, totalUsers, StateEnum }
 			},
@@ -3624,6 +3661,8 @@ export const ResizableColumns: Story = {
 							{ firstname: 'Alexandre', lastname: 'Lazure', email: 'alexandre.lazure@example.com' },
 						]
 					}
+                    
+                    fetchData()
 				</script>
 				`,
 			},
@@ -3664,7 +3703,7 @@ export const ResizableColumns: Story = {
 
 				const fetchData = async (): Promise<void> => {
 					// @ts-expect-error - fetchData is not defined
-					const { items, total } = await getDataFromApi(args.options)
+					const { items, total } = await getDataFromApi(options.value)
 					users.value = items
 					totalUsers.value = total
 				}
@@ -3718,6 +3757,8 @@ export const ResizableColumns: Story = {
 						{ firstname: 'Alexandre', lastname: 'Lazure', email: 'alexandre.lazure@example.com' },
 					]
 				}
+
+				fetchData()
 
 				return { args, users, state, fetchData, options, totalUsers, StateEnum }
 			},

--- a/src/components/Tables/SyServerTable/SyServerTable.vue
+++ b/src/components/Tables/SyServerTable/SyServerTable.vue
@@ -3,6 +3,7 @@
 	import type { VDataTableServer } from 'vuetify/components'
 	import SyTableFilter from '../common/SyTableFilter.vue'
 	import TableHeader from '../common/TableHeader.vue'
+	import SyTablePagination from '../common/SyTablePagination.vue'
 	import { processItems } from '../common/formatters'
 	import { locales } from '../common/locales'
 	import { useTableUtils } from '../common/tableUtils'
@@ -42,6 +43,28 @@
 	// Récupère la fonction filterItems du composable
 	// Cela peut être utilisé pour la prévisualisation du filtrage côté client ou pour les tests
 	const { filterItems } = useTableFilter()
+	
+	// Pagination variables
+	const page = computed({
+		get: () => options.value.page || 1,
+		set: (newPage: number) => {
+			options.value = {
+				...options.value,
+				page: newPage,
+			}
+		},
+	})
+	
+	// Items per page with fallback to props or default
+	const itemsPerPageValue = computed(() => {
+		return options.value.itemsPerPage || props.itemsPerPage || 10
+	})
+	
+	// Calculate total number of pages
+	const pageCount = computed(() => {
+		if (!props.serverItemsLength) return 0
+		return Math.ceil(props.serverItemsLength / itemsPerPageValue.value)
+	})
 
 	defineExpose({ filterItems })
 
@@ -278,6 +301,16 @@
 						</th>
 					</tr>
 				</template>
+			</template>
+			<template #bottom>
+				<SyTablePagination
+					v-if="props.serverItemsLength > 0"
+					:page="page"
+					:page-count="pageCount"
+					:items-per-page="itemsPerPageValue"
+					:items-length="props.serverItemsLength"
+					@update:page="page = $event"
+				/>
 			</template>
 		</VDataTableServer>
 	</div>

--- a/src/components/Tables/SyServerTable/SyServerTable.vue
+++ b/src/components/Tables/SyServerTable/SyServerTable.vue
@@ -15,7 +15,6 @@
 	import { useTableItems } from '../common/useTableItems'
 
 	const props = withDefaults(defineProps<SyServerTableProps>(), {
-		itemsPerPage: undefined,
 		caption: '',
 		showFilters: false,
 		items: () => [],
@@ -70,7 +69,6 @@
 	const itemsLength = computed(() => props.serverItemsLength)
 	const { page, pageCount, itemsPerPageValue, updateItemsPerPage } = usePagination({
 		options,
-		itemsPerPageProp: props.itemsPerPage,
 		itemsLength,
 		table,
 		emit,
@@ -94,7 +92,6 @@
 		tableId: uniqueTableId.value,
 		prefix: 'server-table',
 		suffix: props.suffix,
-		itemsPerPage: props.itemsPerPage,
 		caption: props.caption,
 		serverItemsLength: props.serverItemsLength,
 		componentAttributes,

--- a/src/components/Tables/SyServerTable/tests/SyServerTable.spec.ts
+++ b/src/components/Tables/SyServerTable/tests/SyServerTable.spec.ts
@@ -168,9 +168,8 @@ describe('SyServerTable', () => {
 	it('passes itemsPerPage prop correctly', () => {
 		const wrapper = mount(SyServerTable, {
 			props: {
-				options: {} as DataOptions,
+				options: { itemsPerPage: 5 } as DataOptions,
 				serverItemsLength: 10,
-				itemsPerPage: 5,
 				suffix: 'test',
 			},
 			attrs: {

--- a/src/components/Tables/SyTable/SyTable.mdx
+++ b/src/components/Tables/SyTable/SyTable.mdx
@@ -7,7 +7,7 @@ import * as SyTable from './SyTable.stories';
 
 Le composant `SyTable` est utilisé pour afficher des données tabulaires côté client. Il s'appuie sur le composant `VDataTable` de Vuetify et offre des fonctionnalités supplémentaires comme le stockage local des options de tableau et des améliorations d'accessibilité.
 
-<Canvas of={SyTable.Default} />
+<Canvas story={{height: '550px'}} of={SyTable.Default} />
 
 ## API
 
@@ -25,17 +25,17 @@ Pour gérer individuellement le stockage des options pour différents tableaux, 
 
 Le composant permet de trier les données par colonne en cliquant sur l'en-tête de la colonne.
 
-<Canvas of={SyTable.SortBy} />
+<Canvas story={{height: '550px'}} of={SyTable.SortBy} />
 
 ### Filtres des colonnes
 
 Le composant permet d'appliquer des filtres sur les colonnes. Vous pouvez définir des filtres personnalisés pour chaque colonne en utilisant la prop `show-filters`. Voir d'autres exemples de filtres dans les stories.
-<Canvas of={SyTable.FilterByText} />
+<Canvas story={{height: '550px'}} of={SyTable.FilterByText} />
 
 ### Resize des colonnes
 
 Le composant peut permettre de redimensionner les colonnes en utilisant la prop `resizable-columns`. Vous pouvez activer ou désactiver cette fonctionnalité selon vos besoins.
-<Canvas of={SyTable.ResizableColumns} />
+<Canvas story={{height: '550px'}} of={SyTable.ResizableColumns} />
 
 ### Accessibilité
 

--- a/src/components/Tables/SyTable/SyTable.stories.ts
+++ b/src/components/Tables/SyTable/SyTable.stories.ts
@@ -70,14 +70,6 @@ const meta = {
 			},
 			required: true,
 		},
-		itemsPerPage: {
-			description: 'Nombre d\'éléments par page',
-			control: { type: 'number' },
-			table: {
-				category: 'props',
-				type: { summary: 'number' },
-			},
-		},
 		resizableColumns: {
 			description: 'Permet de redimensionner les colonnes du tableau',
 		},
@@ -232,10 +224,6 @@ export const Default: Story = {
 		'onUpdate:options': fn(),
 	},
 	render: (args) => {
-		// Synchroniser itemsPerPage avec options.itemsPerPage
-		if (args.itemsPerPage !== undefined && args.options) {
-			args.options.itemsPerPage = args.itemsPerPage
-		}
 		return {
 			components: { SyTable },
 			setup() {
@@ -400,10 +388,6 @@ export const SortBy: Story = {
 		'onUpdate:options': fn(),
 	},
 	render: (args) => {
-		// Synchroniser itemsPerPage avec options.itemsPerPage
-		if (args.itemsPerPage !== undefined && args.options) {
-			args.options.itemsPerPage = args.itemsPerPage
-		}
 		return {
 			components: { SyTable },
 			setup() {
@@ -571,10 +555,6 @@ export const FilterByText: Story = {
 		'onUpdate:options': fn(),
 	},
 	render: (args) => {
-		// Synchroniser itemsPerPage avec options.itemsPerPage
-		if (args.itemsPerPage !== undefined && args.options) {
-			args.options.itemsPerPage = args.itemsPerPage
-		}
 		return {
 			components: { SyTable },
 			setup() {
@@ -740,10 +720,6 @@ export const FilterByNumber: Story = {
 		'onUpdate:options': fn(),
 	},
 	render: (args) => {
-		// Synchroniser itemsPerPage avec options.itemsPerPage
-		if (args.itemsPerPage !== undefined && args.options) {
-			args.options.itemsPerPage = args.itemsPerPage
-		}
 		return {
 			components: { SyTable },
 			setup() {
@@ -935,10 +911,6 @@ export const FilterBySelect: Story = {
 		'onUpdate:options': fn(),
 	},
 	render: (args) => {
-		// Synchroniser itemsPerPage avec options.itemsPerPage
-		if (args.itemsPerPage !== undefined && args.options) {
-			args.options.itemsPerPage = args.itemsPerPage
-		}
 		return {
 			components: { SyTable },
 			setup() {
@@ -1138,10 +1110,6 @@ export const FilterBySelectMultiple: Story = {
 		'onUpdate:options': fn(),
 	},
 	render: (args) => {
-		// Synchroniser itemsPerPage avec options.itemsPerPage
-		if (args.itemsPerPage !== undefined && args.options) {
-			args.options.itemsPerPage = args.itemsPerPage
-		}
 		return {
 			components: { SyTable },
 			setup() {
@@ -1288,10 +1256,6 @@ export const FilterByExactDate: Story = {
 		'onUpdate:options': fn(),
 	},
 	render: (args) => {
-		// Synchroniser itemsPerPage avec options.itemsPerPage
-		if (args.itemsPerPage !== undefined && args.options) {
-			args.options.itemsPerPage = args.itemsPerPage
-		}
 		return {
 			components: { SyTable },
 			setup() {
@@ -1438,10 +1402,6 @@ export const FilterByPeriod: Story = {
 		'onUpdate:options': fn(),
 	},
 	render: (args) => {
-		// Synchroniser itemsPerPage avec options.itemsPerPage
-		if (args.itemsPerPage !== undefined && args.options) {
-			args.options.itemsPerPage = args.itemsPerPage
-		}
 		return {
 			components: { SyTable },
 			setup() {
@@ -1942,10 +1902,6 @@ export const CustomFilterInputs: Story = {
 		'onUpdate:options': fn(),
 	},
 	render: (args) => {
-		// Synchroniser itemsPerPage avec options.itemsPerPage
-		if (args.itemsPerPage !== undefined && args.options) {
-			args.options.itemsPerPage = args.itemsPerPage
-		}
 		return {
 			components: { SyTable },
 			setup() {
@@ -2114,10 +2070,6 @@ export const ManyTables: Story = {
 		'onUpdate:options': fn(),
 	},
 	render: (args) => {
-		// Synchroniser itemsPerPage avec options.itemsPerPage
-		if (args.itemsPerPage !== undefined && args.options) {
-			args.options.itemsPerPage = args.itemsPerPage
-		}
 		return {
 			components: { SyTable },
 			setup() {
@@ -2277,10 +2229,6 @@ export const DataAlignment: Story = {
 		'onUpdate:options': fn(),
 	},
 	render: (args) => {
-		// Synchroniser itemsPerPage avec options.itemsPerPage
-		if (args.itemsPerPage !== undefined && args.options) {
-			args.options.itemsPerPage = args.itemsPerPage
-		}
 		return {
 			components: { SyTable },
 			setup() {
@@ -2431,10 +2379,6 @@ export const ResizableColumns: Story = {
 		'onUpdate:options': fn(),
 	},
 	render: (args) => {
-		// Synchroniser itemsPerPage avec options.itemsPerPage
-		if (args.itemsPerPage !== undefined && args.options) {
-			args.options.itemsPerPage = args.itemsPerPage
-		}
 		return {
 			components: { SyTable },
 			setup() {

--- a/src/components/Tables/SyTable/SyTable.stories.ts
+++ b/src/components/Tables/SyTable/SyTable.stories.ts
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/vue3'
 import { fn } from '@storybook/test'
 import { ref } from 'vue'
 import SyTable from './SyTable.vue'
-import type { DataOptions } from '../common/types'
+import type { DataOptions, FilterType } from '../common/types'
 import type { VDataTable } from 'vuetify/components'
 import dayjs from 'dayjs'
 
@@ -1692,10 +1692,11 @@ export const CustomFilterSlot: Story = {
 			components: { SyTable },
 			setup() {
 				// Create a fresh copy of the options to avoid reactivity issues
-				const options = ref({
+				const options = ref<DataOptions>({
 					page: 1,
 					itemsPerPage: 4,
-					filters: [],
+					filters: [] as import('../common/types').FilterOption[],
+					sortBy: [],
 				})
 
 				// Create a reactive reference for the custom filter value
@@ -1704,15 +1705,21 @@ export const CustomFilterSlot: Story = {
 
 				// Function to update the filter when the select value changes
 				function handleFilterChange(val) {
-					// Create a new filters array
-					const newFilters = options.value.filters.filter(f => f.key !== 'status')
+					// Ensure options.value.filters is initialized
+					if (!options.value.filters) {
+						options.value.filters = []
+					}
+
+					// Create a new filters array with proper typing
+					const currentFilters = options.value.filters as import('../common/types').FilterOption[]
+					const newFilters = [...currentFilters].filter(f => f.key !== 'status')
 
 					// Add the new filter if a value is selected
 					if (val) {
 						newFilters.push({
 							key: 'status',
 							value: val,
-							type: 'select', // Use 'select' type for compatibility with filtering logic
+							type: 'select' as FilterType, // Use 'select' type for compatibility with filtering logic
 						})
 					}
 

--- a/src/components/Tables/SyTable/SyTable.stories.ts
+++ b/src/components/Tables/SyTable/SyTable.stories.ts
@@ -73,6 +73,10 @@ const meta = {
 		itemsPerPage: {
 			description: 'Nombre d\'éléments par page',
 			control: { type: 'number' },
+			table: {
+				category: 'props',
+				type: { summary: 'number' },
+			},
 		},
 		resizableColumns: {
 			description: 'Permet de redimensionner les colonnes du tableau',
@@ -226,7 +230,11 @@ export const Default: Story = {
 		density: 'default',
 		striped: false,
 	},
-	render(args) {
+	render: (args) => {
+		// Synchroniser itemsPerPage avec options.itemsPerPage
+		if (args.itemsPerPage !== undefined && args.options) {
+			args.options.itemsPerPage = args.itemsPerPage
+		}
 		return {
 			components: { SyTable },
 			setup() {
@@ -395,7 +403,11 @@ export const SortBy: Story = {
 		density: 'default',
 		striped: false,
 	},
-	render(args) {
+	render: (args) => {
+		// Synchroniser itemsPerPage avec options.itemsPerPage
+		if (args.itemsPerPage !== undefined && args.options) {
+			args.options.itemsPerPage = args.itemsPerPage
+		}
 		return {
 			components: { SyTable },
 			setup() {
@@ -567,7 +579,11 @@ export const FilterByText: Story = {
 		density: 'default',
 		striped: false,
 	},
-	render(args) {
+	render: (args) => {
+		// Synchroniser itemsPerPage avec options.itemsPerPage
+		if (args.itemsPerPage !== undefined && args.options) {
+			args.options.itemsPerPage = args.itemsPerPage
+		}
 		return {
 			components: { SyTable },
 			setup() {
@@ -583,7 +599,7 @@ export const FilterByText: Story = {
 			},
 			template: `
 				<SyTable
-					v-model:options="options"
+					v-model:options="args.options"
 					:headers="args.headers"
 					:items="items"
 					:caption="args.caption"
@@ -738,7 +754,11 @@ export const FilterByNumber: Story = {
 		density: 'default',
 		striped: false,
 	},
-	render(args) {
+	render: (args) => {
+		// Synchroniser itemsPerPage avec options.itemsPerPage
+		if (args.itemsPerPage !== undefined && args.options) {
+			args.options.itemsPerPage = args.itemsPerPage
+		}
 		return {
 			components: { SyTable },
 			setup() {
@@ -754,7 +774,7 @@ export const FilterByNumber: Story = {
 			},
 			template: `
 				<SyTable
-					v-model:options="options"
+					v-model:options="args.options"
 					:headers="args.headers"
 					:items="items"
 					:caption="args.caption"
@@ -935,7 +955,11 @@ export const FilterBySelect: Story = {
 		density: 'default',
 		striped: false,
 	},
-	render(args) {
+	render: (args) => {
+		// Synchroniser itemsPerPage avec options.itemsPerPage
+		if (args.itemsPerPage !== undefined && args.options) {
+			args.options.itemsPerPage = args.itemsPerPage
+		}
 		return {
 			components: { SyTable },
 			setup() {
@@ -951,7 +975,7 @@ export const FilterBySelect: Story = {
 			},
 			template: `
 				<SyTable
-					v-model:options="options"
+					v-model:options="args.options"
 					:headers="args.headers"
 					:items="items"
 					:caption="args.caption"
@@ -1140,7 +1164,11 @@ export const FilterBySelectMultiple: Story = {
 		density: 'default',
 		striped: false,
 	},
-	render(args) {
+	render: (args) => {
+		// Synchroniser itemsPerPage avec options.itemsPerPage
+		if (args.itemsPerPage !== undefined && args.options) {
+			args.options.itemsPerPage = args.itemsPerPage
+		}
 		return {
 			components: { SyTable },
 			setup() {
@@ -1156,7 +1184,7 @@ export const FilterBySelectMultiple: Story = {
 			},
 			template: `
 				<SyTable
-					v-model:options="options"
+					v-model:options="args.options"
 					:headers="args.headers"
 					:items="items"
 					:caption="args.caption"
@@ -1292,7 +1320,11 @@ export const FilterByExactDate: Story = {
 		density: 'default',
 		striped: false,
 	},
-	render(args) {
+	render: (args) => {
+		// Synchroniser itemsPerPage avec options.itemsPerPage
+		if (args.itemsPerPage !== undefined && args.options) {
+			args.options.itemsPerPage = args.itemsPerPage
+		}
 		return {
 			components: { SyTable },
 			setup() {
@@ -1308,7 +1340,7 @@ export const FilterByExactDate: Story = {
 			},
 			template: `
 				<SyTable
-					v-model:options="options"
+					v-model:options="args.options"
 					:headers="args.headers"
 					:items="items"
 					:caption="args.caption"
@@ -1444,7 +1476,11 @@ export const FilterByPeriod: Story = {
 		density: 'default',
 		striped: false,
 	},
-	render(args) {
+	render: (args) => {
+		// Synchroniser itemsPerPage avec options.itemsPerPage
+		if (args.itemsPerPage !== undefined && args.options) {
+			args.options.itemsPerPage = args.itemsPerPage
+		}
 		return {
 			components: { SyTable },
 			setup() {
@@ -1460,7 +1496,7 @@ export const FilterByPeriod: Story = {
 			},
 			template: `
 				<SyTable
-					v-model:options="options"
+					v-model:options="args.options"
 					:headers="args.headers"
 					:items="items"
 					:caption="args.caption"
@@ -1675,7 +1711,11 @@ export const CustomFilterSlot: Story = {
 		density: 'default',
 		striped: false,
 	},
-	render(args) {
+	render: (args) => {
+		// Synchroniser itemsPerPage avec options.itemsPerPage
+		if (args.itemsPerPage !== undefined && args.options) {
+			args.options.itemsPerPage = args.itemsPerPage
+		}
 		return {
 			components: { SyTable },
 			setup() {
@@ -1905,7 +1945,11 @@ export const CustomFilterInputs: Story = {
 		density: 'default',
 		striped: false,
 	},
-	render(args) {
+	render: (args) => {
+		// Synchroniser itemsPerPage avec options.itemsPerPage
+		if (args.itemsPerPage !== undefined && args.options) {
+			args.options.itemsPerPage = args.itemsPerPage
+		}
 		return {
 			components: { SyTable },
 			setup() {
@@ -1921,7 +1965,7 @@ export const CustomFilterInputs: Story = {
 			},
 			template: `
 				<SyTable
-					v-model:options="options"
+					v-model:options="args.options"
 					:headers="args.headers"
 					:items="items"
 					:caption="args.caption"
@@ -2079,7 +2123,11 @@ export const ManyTables: Story = {
 		density: 'default',
 		striped: false,
 	},
-	render(args) {
+	render: (args) => {
+		// Synchroniser itemsPerPage avec options.itemsPerPage
+		if (args.itemsPerPage !== undefined && args.options) {
+			args.options.itemsPerPage = args.itemsPerPage
+		}
 		return {
 			components: { SyTable },
 			setup() {
@@ -2248,7 +2296,11 @@ export const DataAlignment: Story = {
 		'suffix': 'alignment-table',
 		'onUpdate:options': fn(),
 	},
-	render(args) {
+	render: (args) => {
+		// Synchroniser itemsPerPage avec options.itemsPerPage
+		if (args.itemsPerPage !== undefined && args.options) {
+			args.options.itemsPerPage = args.itemsPerPage
+		}
 		return {
 			components: { SyTable },
 			setup() {
@@ -2400,7 +2452,11 @@ export const ResizableColumns: Story = {
 		},
 		suffix: 'resizable-columns',
 	},
-	render(args) {
+	render: (args) => {
+		// Synchroniser itemsPerPage avec options.itemsPerPage
+		if (args.itemsPerPage !== undefined && args.options) {
+			args.options.itemsPerPage = args.itemsPerPage
+		}
 		return {
 			components: { SyTable },
 			setup() {

--- a/src/components/Tables/SyTable/SyTable.stories.ts
+++ b/src/components/Tables/SyTable/SyTable.stories.ts
@@ -176,7 +176,7 @@ export const Default: Story = {
 		],
 	},
 	args: {
-		headers: [
+		'headers': [
 			{
 				title: 'Nom',
 				key: 'lastname',
@@ -190,7 +190,7 @@ export const Default: Story = {
 				value: 'email',
 			},
 		],
-		items: [
+		'items': [
 			{
 				firstname: 'Virginie',
 				lastname: 'Beauchesne',
@@ -222,13 +222,14 @@ export const Default: Story = {
 				email: 'agate.roy@exemple.com',
 			},
 		],
-		options: {
+		'options': {
 			itemsPerPage: 4,
 		},
-		caption: '',
-		suffix: 'default-table',
-		density: 'default',
-		striped: false,
+		'caption': '',
+		'suffix': 'default-table',
+		'density': 'default',
+		'striped': false,
+		'onUpdate:options': fn(),
 	},
 	render: (args) => {
 		// Synchroniser itemsPerPage avec options.itemsPerPage
@@ -243,13 +244,7 @@ export const Default: Story = {
 			template: `
 				<SyTable
 					v-model:options="args.options"
-					:headers="args.headers"
-					:items="args.items"
-					:caption="args.caption"
-					:suffix="args.suffix"
-					:density="args.density"
-					:striped="args.striped"
-					:resizable-columns="args.resizableColumns"
+					v-bind="args"
 				/>
 			`,
 		}
@@ -343,7 +338,7 @@ export const SortBy: Story = {
 		],
 	},
 	args: {
-		headers: [
+		'headers': [
 			{
 				title: 'Nom',
 				key: 'lastname',
@@ -357,7 +352,7 @@ export const SortBy: Story = {
 				value: 'email',
 			},
 		],
-		items: [
+		'items': [
 			{
 				firstname: 'Virginie',
 				lastname: 'Beauchesne',
@@ -389,8 +384,8 @@ export const SortBy: Story = {
 				email: 'agate.roy@exemple.com',
 			},
 		],
-		caption: '',
-		options: {
+		'caption': '',
+		'options': {
 			itemsPerPage: 4,
 			sortBy: [
 				{
@@ -399,9 +394,10 @@ export const SortBy: Story = {
 				},
 			],
 		},
-		suffix: 'sort-table',
-		density: 'default',
-		striped: false,
+		'suffix': 'sort-table',
+		'density': 'default',
+		'striped': false,
+		'onUpdate:options': fn(),
 	},
 	render: (args) => {
 		// Synchroniser itemsPerPage avec options.itemsPerPage
@@ -416,13 +412,7 @@ export const SortBy: Story = {
 			template: `
 				<SyTable
 					v-model:options="args.options"
-					:headers="args.headers"
-					:items="args.items"
-					:caption="args.caption"
-					:suffix="args.suffix"
-					:density="args.density"
-					:striped="args.striped"
-					:resizable-columns="args.resizableColumns"
+					v-bind="args"
 				/>
 			`,
 		}
@@ -517,7 +507,7 @@ export const FilterByText: Story = {
 		],
 	},
 	args: {
-		headers: [
+		'headers': [
 			{
 				title: 'Nom',
 				key: 'lastname',
@@ -537,7 +527,7 @@ export const FilterByText: Story = {
 				filterType: 'text',
 			},
 		],
-		items: [
+		'items': [
 			{
 				firstname: 'Virginie',
 				lastname: 'Beauchesne',
@@ -569,15 +559,16 @@ export const FilterByText: Story = {
 				email: 'agate.roy@exemple.com',
 			},
 		],
-		caption: '',
-		options: {
+		'caption': '',
+		'options': {
 			itemsPerPage: 4,
 			filters: [],
 		},
-		showFilters: true,
-		suffix: 'filter-text-table',
-		density: 'default',
-		striped: false,
+		'showFilters': true,
+		'suffix': 'filter-text-table',
+		'density': 'default',
+		'striped': false,
+		'onUpdate:options': fn(),
 	},
 	render: (args) => {
 		// Synchroniser itemsPerPage avec options.itemsPerPage
@@ -600,14 +591,7 @@ export const FilterByText: Story = {
 			template: `
 				<SyTable
 					v-model:options="args.options"
-					:headers="args.headers"
-					:items="items"
-					:caption="args.caption"
-					:show-filters="args.showFilters"
-					:suffix="args.suffix"
-					:density="args.density"
-					:striped="args.striped"
-					:resizable-columns="args.resizableColumns"
+					v-bind="args"
 				/>
 			`,
 		}
@@ -697,7 +681,7 @@ export const FilterByNumber: Story = {
 		],
 	},
 	args: {
-		headers: [
+		'headers': [
 			{
 				title: 'Nom',
 				key: 'name',
@@ -717,7 +701,7 @@ export const FilterByNumber: Story = {
 				filterType: 'number',
 			},
 		],
-		items: [
+		'items': [
 			{
 				name: 'Jean Dupont',
 				age: 32,
@@ -744,15 +728,16 @@ export const FilterByNumber: Story = {
 				salary: 58000,
 			},
 		],
-		caption: '',
-		options: {
+		'caption': '',
+		'options': {
 			itemsPerPage: 5,
 			filters: [],
 		},
-		showFilters: true,
-		suffix: 'filter-number-table',
-		density: 'default',
-		striped: false,
+		'showFilters': true,
+		'suffix': 'filter-number-table',
+		'density': 'default',
+		'striped': false,
+		'onUpdate:options': fn(),
 	},
 	render: (args) => {
 		// Synchroniser itemsPerPage avec options.itemsPerPage
@@ -775,14 +760,7 @@ export const FilterByNumber: Story = {
 			template: `
 				<SyTable
 					v-model:options="args.options"
-					:headers="args.headers"
-					:items="items"
-					:caption="args.caption"
-					:show-filters="args.showFilters"
-					:suffix="args.suffix"
-					:density="args.density"
-					:striped="args.striped"
-					:resizable-columns="args.resizableColumns"
+					v-bind="args"
 				/>
 			`,
 		}
@@ -885,7 +863,7 @@ export const FilterBySelect: Story = {
 		],
 	},
 	args: {
-		headers: [
+		'headers': [
 			{
 				title: 'Nom',
 				key: 'name',
@@ -918,7 +896,7 @@ export const FilterBySelect: Story = {
 				],
 			},
 		],
-		items: [
+		'items': [
 			{
 				name: 'Jean Dupont',
 				department: 'RH',
@@ -945,15 +923,16 @@ export const FilterBySelect: Story = {
 				status: 'Inactif',
 			},
 		],
-		caption: '',
-		options: {
+		'caption': '',
+		'options': {
 			itemsPerPage: 5,
 			filters: [],
 		},
-		showFilters: true,
-		suffix: 'filter-select-table',
-		density: 'default',
-		striped: false,
+		'showFilters': true,
+		'suffix': 'filter-select-table',
+		'density': 'default',
+		'striped': false,
+		'onUpdate:options': fn(),
 	},
 	render: (args) => {
 		// Synchroniser itemsPerPage avec options.itemsPerPage
@@ -976,14 +955,7 @@ export const FilterBySelect: Story = {
 			template: `
 				<SyTable
 					v-model:options="args.options"
-					:headers="args.headers"
-					:items="items"
-					:caption="args.caption"
-					:show-filters="args.showFilters"
-					:suffix="args.suffix"
-					:density="args.density"
-					:striped="args.striped"
-					:resizable-columns="args.resizableColumns"
+					v-bind="args"
 				/>
 			`,
 		}
@@ -1090,7 +1062,7 @@ export const FilterBySelectMultiple: Story = {
 		],
 	},
 	args: {
-		headers: [
+		'headers': [
 			{
 				title: 'Nom',
 				key: 'name',
@@ -1127,7 +1099,7 @@ export const FilterBySelectMultiple: Story = {
 				],
 			},
 		],
-		items: [
+		'items': [
 			{
 				name: 'Jean Dupont',
 				department: 'RH',
@@ -1154,15 +1126,16 @@ export const FilterBySelectMultiple: Story = {
 				status: 'Inactif',
 			},
 		],
-		caption: '',
-		options: {
+		'caption': '',
+		'options': {
 			itemsPerPage: 5,
 			filters: [],
 		},
-		showFilters: true,
-		suffix: 'filter-select-table',
-		density: 'default',
-		striped: false,
+		'showFilters': true,
+		'suffix': 'filter-select-table',
+		'density': 'default',
+		'striped': false,
+		'onUpdate:options': fn(),
 	},
 	render: (args) => {
 		// Synchroniser itemsPerPage avec options.itemsPerPage
@@ -1185,14 +1158,7 @@ export const FilterBySelectMultiple: Story = {
 			template: `
 				<SyTable
 					v-model:options="args.options"
-					:headers="args.headers"
-					:items="items"
-					:caption="args.caption"
-					:show-filters="args.showFilters"
-					:suffix="args.suffix"
-					:density="args.density"
-					:striped="args.striped"
-					:resizable-columns="args.resizableColumns"
+					v-bind="args"
 				/>
 			`,
 		}
@@ -1273,7 +1239,7 @@ export const FilterByExactDate: Story = {
 		],
 	},
 	args: {
-		headers: [
+		'headers': [
 			{
 				title: 'Nom',
 				key: 'name',
@@ -1288,7 +1254,7 @@ export const FilterByExactDate: Story = {
 				dateFormat: 'DD/MM/YYYY',
 			},
 		],
-		items: [
+		'items': [
 			{
 				name: 'Jean Dupont',
 				hireDate: dayjs('2025-05-15').format('DD/MM/YYYY'),
@@ -1310,15 +1276,16 @@ export const FilterByExactDate: Story = {
 				hireDate: dayjs('2025-07-30').format('DD/MM/YYYY'),
 			},
 		],
-		caption: '',
-		options: {
+		'caption': '',
+		'options': {
 			itemsPerPage: 5,
 			filters: [],
 		},
-		showFilters: true,
-		suffix: 'filter-date-table',
-		density: 'default',
-		striped: false,
+		'showFilters': true,
+		'suffix': 'filter-date-table',
+		'density': 'default',
+		'striped': false,
+		'onUpdate:options': fn(),
 	},
 	render: (args) => {
 		// Synchroniser itemsPerPage avec options.itemsPerPage
@@ -1341,14 +1308,7 @@ export const FilterByExactDate: Story = {
 			template: `
 				<SyTable
 					v-model:options="args.options"
-					:headers="args.headers"
-					:items="items"
-					:caption="args.caption"
-					:show-filters="args.showFilters"
-					:suffix="args.suffix"
-					:density="args.density"
-					:striped="args.striped"
-					:resizable-columns="args.resizableColumns"
+					v-bind="args"
 				/>
 			`,
 		}
@@ -1429,7 +1389,7 @@ export const FilterByPeriod: Story = {
 		],
 	},
 	args: {
-		headers: [
+		'headers': [
 			{
 				title: 'Nom',
 				key: 'name',
@@ -1444,7 +1404,7 @@ export const FilterByPeriod: Story = {
 				dateFormat: 'DD/MM/YYYY',
 			},
 		],
-		items: [
+		'items': [
 			{
 				name: 'Jean Dupont',
 				hireDate: dayjs('2025-05-15').format('DD/MM/YYYY'),
@@ -1466,15 +1426,16 @@ export const FilterByPeriod: Story = {
 				hireDate: dayjs('2025-07-30').format('DD/MM/YYYY'),
 			},
 		],
-		caption: '',
-		options: {
+		'caption': '',
+		'options': {
 			itemsPerPage: 5,
 			filters: [],
 		},
-		showFilters: true,
-		suffix: 'filter-date-table',
-		density: 'default',
-		striped: false,
+		'showFilters': true,
+		'suffix': 'filter-date-table',
+		'density': 'default',
+		'striped': false,
+		'onUpdate:options': fn(),
 	},
 	render: (args) => {
 		// Synchroniser itemsPerPage avec options.itemsPerPage
@@ -1497,14 +1458,7 @@ export const FilterByPeriod: Story = {
 			template: `
 				<SyTable
 					v-model:options="args.options"
-					:headers="args.headers"
-					:items="items"
-					:caption="args.caption"
-					:show-filters="args.showFilters"
-					:suffix="args.suffix"
-					:density="args.density"
-					:striped="args.striped"
-					:resizable-columns="args.resizableColumns"
+					v-bind="args"
 				/>
 			`,
 		}
@@ -1649,7 +1603,7 @@ export const CustomFilterSlot: Story = {
 		],
 	},
 	args: {
-		headers: [
+		'headers': [
 			{
 				title: 'Nom',
 				key: 'lastname',
@@ -1669,7 +1623,7 @@ export const CustomFilterSlot: Story = {
 				filterType: 'custom' as FilterType,
 			},
 		],
-		items: [
+		'items': [
 			{
 				firstname: 'Virginie',
 				lastname: 'Beauchesne',
@@ -1701,15 +1655,16 @@ export const CustomFilterSlot: Story = {
 				status: 'En attente',
 			},
 		],
-		caption: '',
-		options: {
+		'caption': '',
+		'options': {
 			itemsPerPage: 4,
 			filters: [],
 		},
-		showFilters: true,
-		suffix: 'custom-filter-slot-table',
-		density: 'default',
-		striped: false,
+		'showFilters': true,
+		'suffix': 'custom-filter-slot-table',
+		'density': 'default',
+		'striped': false,
+		'onUpdate:options': fn(),
 	},
 	render: (args) => {
 		// Synchroniser itemsPerPage avec options.itemsPerPage
@@ -1736,14 +1691,7 @@ export const CustomFilterSlot: Story = {
 			template: `
 				<SyTable
 					v-model:options="options"
-					:headers="args.headers"
-					:items="items"
-					:caption="args.caption"
-					:show-filters="args.showFilters"
-					:suffix="args.suffix"
-					:density="args.density"
-					:striped="args.striped"
-					:resizable-columns="args.resizableColumns"
+					v-bind="args"
 				>
 					<template #filter.custom="{ header, value, updateFilter }">
 						<div class="custom-filter-container">
@@ -1876,7 +1824,7 @@ export const CustomFilterInputs: Story = {
 		],
 	},
 	args: {
-		headers: [
+		'headers': [
 			{
 				title: 'Nom',
 				key: 'lastname',
@@ -1896,7 +1844,7 @@ export const CustomFilterInputs: Story = {
 				filterType: 'text',
 			},
 		],
-		items: [
+		'items': [
 			{
 				firstname: 'Virginie',
 				lastname: 'Beauchesne',
@@ -1928,22 +1876,23 @@ export const CustomFilterInputs: Story = {
 				email: 'agate.roy@exemple.com',
 			},
 		],
-		caption: '',
-		options: {
+		'caption': '',
+		'options': {
 			itemsPerPage: 4,
 			filters: [],
 		},
-		filterInputConfig: {
+		'filterInputConfig': {
 			variant: 'outlined',
 			density: 'comfortable',
 			hideDetails: true,
 			clearable: false,
 			disableErrorHandling: true,
 		},
-		showFilters: true,
-		suffix: 'filter-text-table',
-		density: 'default',
-		striped: false,
+		'showFilters': true,
+		'suffix': 'filter-text-table',
+		'density': 'default',
+		'striped': false,
+		'onUpdate:options': fn(),
 	},
 	render: (args) => {
 		// Synchroniser itemsPerPage avec options.itemsPerPage
@@ -1966,14 +1915,7 @@ export const CustomFilterInputs: Story = {
 			template: `
 				<SyTable
 					v-model:options="args.options"
-					:headers="args.headers"
-					:items="items"
-					:caption="args.caption"
-					:show-filters="args.showFilters"
-					:filter-input-config="args.filterInputConfig"
-					:resizable-columns="args.resizableColumns"
-					:suffix="args.suffix"
-					:density="args.density"
+					v-bind="args"
 				/>
 			`,
 		}
@@ -2072,7 +2014,7 @@ export const ManyTables: Story = {
 		],
 	},
 	args: {
-		headers: [
+		'headers': [
 			{
 				title: 'Nom',
 				key: 'lastname',
@@ -2086,7 +2028,7 @@ export const ManyTables: Story = {
 				value: 'email',
 			},
 		],
-		items: [
+		'items': [
 			{
 				firstname: 'Virginie',
 				lastname: 'Beauchesne',
@@ -2118,10 +2060,11 @@ export const ManyTables: Story = {
 				email: 'agate.roy@exemple.com',
 			},
 		],
-		caption: '',
-		suffix: 'multi-server',
-		density: 'default',
-		striped: false,
+		'caption': '',
+		'suffix': 'multi-server',
+		'density': 'default',
+		'striped': false,
+		'onUpdate:options': fn(),
 	},
 	render: (args) => {
 		// Synchroniser itemsPerPage avec options.itemsPerPage
@@ -2143,23 +2086,13 @@ export const ManyTables: Story = {
 				<div>
 					<SyTable
 						v-model:options="options1"
-						:resizable-columns="args.resizableColumns"
-						:headers="args.headers"
-						:items="args.items"
-						:caption="args.caption"
-						:density="args.density"
-						:striped="args.striped"
+						v-bind="args"
 						suffix="table1"
 						class="mb-10"
 					/>
 					<SyTable
 						v-model:options="options2"
-						:resizable-columns="args.resizableColumns"
-						:headers="args.headers"
-						:items="args.items"
-						:caption="args.caption"
-						:density="args.density"
-						:striped="args.striped"
+						v-bind="args"
 						suffix="table2"
 					/>
 				</div>
@@ -2309,10 +2242,7 @@ export const DataAlignment: Story = {
 			template: `
 				<SyTable
 					v-model:options="args.options"
-					:headers="args.headers"
-					:items="args.items"
-					:suffix="args.suffix"
-					@update:options="args['onUpdate:options']"
+					v-bind="args"
 				/>
 			`,
 		}
@@ -2400,8 +2330,8 @@ export const ResizableColumns: Story = {
 		],
 	},
 	args: {
-		resizableColumns: true,
-		headers: [
+		'resizableColumns': true,
+		'headers': [
 			{
 				title: 'Nom',
 				key: 'lastname',
@@ -2415,7 +2345,7 @@ export const ResizableColumns: Story = {
 				value: 'email',
 			},
 		],
-		items: [
+		'items': [
 			{
 				firstname: 'Virginie',
 				lastname: 'Beauchesne',
@@ -2447,10 +2377,11 @@ export const ResizableColumns: Story = {
 				email: 'agate.roy@exemple.com',
 			},
 		],
-		options: {
+		'options': {
 			itemsPerPage: 4,
 		},
-		suffix: 'resizable-columns',
+		'suffix': 'resizable-columns',
+		'onUpdate:options': fn(),
 	},
 	render: (args) => {
 		// Synchroniser itemsPerPage avec options.itemsPerPage
@@ -2465,10 +2396,7 @@ export const ResizableColumns: Story = {
 			template: `
 				<SyTable
 					v-model:options="args.options"
-					:headers="args.headers"
-					:items="args.items"
-					:resizableColumns="args.resizableColumns"
-					:suffix="args.suffix"
+					v-bind="args"
 				/>
 			`,
 		}

--- a/src/components/Tables/SyTable/SyTable.vue
+++ b/src/components/Tables/SyTable/SyTable.vue
@@ -3,6 +3,7 @@
 	import type { VDataTable } from 'vuetify/components'
 	import SyTableFilter from '../common/SyTableFilter.vue'
 	import TableHeader from '../common/TableHeader.vue'
+	import SyTablePagination from '../common/SyTablePagination.vue'
 	import { processItems } from '../common/formatters'
 	import { locales } from '../common/locales'
 	import { useTableUtils } from '../common/tableUtils'
@@ -37,6 +38,28 @@
 
 		// Applique les filtres aux éléments copiés
 		return filterItems(itemsCopy, filters.value)
+	})
+	
+	// Pagination variables
+	const page = computed({
+		get: () => options.value.page || 1,
+		set: (newPage: number) => {
+			options.value = {
+				...options.value,
+				page: newPage,
+			}
+		},
+	})
+	
+	// Items per page with fallback to props or default
+	const itemsPerPageValue = computed(() => {
+		return options.value.itemsPerPage || props.itemsPerPage || 10
+	})
+	
+	// Calculate total number of pages
+	const pageCount = computed(() => {
+		if (!filteredItems.value.length) return 0
+		return Math.ceil(filteredItems.value.length / itemsPerPageValue.value)
 	})
 
 	const filters = computed({
@@ -293,6 +316,16 @@
 						</td>
 					</tr>
 				</template>
+			</template>
+			<template #bottom>
+				<SyTablePagination
+					v-if="filteredItems.length > 0"
+					:page="page"
+					:page-count="pageCount"
+					:items-per-page="itemsPerPageValue"
+					:items-length="filteredItems.length"
+					@update:page="page = $event"
+				/>
 			</template>
 		</VDataTable>
 	</div>

--- a/src/components/Tables/SyTable/SyTable.vue
+++ b/src/components/Tables/SyTable/SyTable.vue
@@ -15,7 +15,6 @@
 	import { useTableItems } from '../common/useTableItems'
 
 	const props = withDefaults(defineProps<SyTableProps>(), {
-		itemsPerPage: undefined,
 		caption: '',
 		showFilters: false,
 		resizableColumns: false,
@@ -67,7 +66,6 @@
 	const itemsLength = computed(() => filteredItems.value.length)
 	const { page, pageCount, itemsPerPageValue, updateItemsPerPage } = usePagination({
 		options,
-		itemsPerPageProp: props.itemsPerPage,
 		itemsLength,
 		table,
 		emit,
@@ -89,7 +87,6 @@
 		tableId: uniqueTableId.value,
 		prefix: 'table',
 		suffix: props.suffix,
-		itemsPerPage: props.itemsPerPage,
 		caption: props.caption,
 		componentAttributes,
 		headersProp: toRef(props, 'headers'),

--- a/src/components/Tables/SyTable/SyTable.vue
+++ b/src/components/Tables/SyTable/SyTable.vue
@@ -7,8 +7,12 @@
 	import { processItems } from '../common/formatters'
 	import { locales } from '../common/locales'
 	import { useTableUtils } from '../common/tableUtils'
-	import type { DataOptions, FilterOption, SyTableProps, TableColumnHeader } from '../common/types'
+	import type { DataOptions, SyTableProps } from '../common/types'
 	import { useTableFilter } from '../common/useTableFilter'
+	import { usePagination } from '../common/usePagination'
+	import { useTableOptions } from '../common/useTableOptions'
+	import { useTableHeaders } from '../common/useTableHeaders'
+	import { useTableItems } from '../common/useTableItems'
 
 	const props = withDefaults(defineProps<SyTableProps>(), {
 		itemsPerPage: undefined,
@@ -32,78 +36,41 @@
 
 	const table = ref<VDataTable>()
 
+	// Get filter utilities
 	const { filterItems } = useTableFilter()
 
-	// Éléments filtrés en fonction des filtres
-	const filteredItems = computed(() => {
-		const itemsCopy = props.items.map((item) => {
-			return JSON.parse(JSON.stringify(item))
-		})
-
-		// Applique les filtres aux éléments copiés
-		return filterItems(itemsCopy, filters.value)
+	// Use the table options composable
+	const { filters } = useTableOptions({
+		options,
 	})
 
-	// Pagination variables
-	const page = computed({
-		get: () => options.value.page || 1,
-		set: (newPage: number) => {
-			options.value = {
-				...options.value,
-				page: newPage,
-			}
-		},
+	// Use the table headers composable
+	const headersProp = toRef(props, 'headers')
+	const { headers, getEnhancedHeader } = useTableHeaders({
+		headersProp,
+		filterInputConfig: props.filterInputConfig,
 	})
 
-	/**
-	 * Update items per page from pagination component
-	 */
-	function updateItemsPerPage(newItemsPerPage: number) {
-		// Create a completely new options object to force reactivity
-		const newOptions = {
-			...options.value,
-			itemsPerPage: newItemsPerPage,
-			page: 1, // Reset to first page when changing items per page
-		}
+	// Create a reactive reference for items
+	const itemsRef = computed(() => props.items)
 
-		// Update options with the new object
-		options.value = newOptions
-
-		// Force a refresh of the table
-		nextTick(() => {
-			if (table.value) {
-				// Force the table to refresh by triggering a re-render
-				table.value.$forceUpdate()
-
-				// Emit an event to notify parent components
-				emit('update:options', newOptions)
-			}
-		})
-	}
-
-	// Items per page with fallback to props or default
-	const itemsPerPageValue = computed(() => {
-		const value = options.value.itemsPerPage || props.itemsPerPage || 10
-		// If value is -1, it means "Tous" (all items)
-		return value
+	// Use the table items composable
+	const { filteredItems, createEmptyItemWithStructure } = useTableItems({
+		items: itemsRef,
+		headers,
+		filters,
+		options,
+		filterItems,
 	})
 
-	// Calculate total number of pages
-	const pageCount = computed(() => {
-		if (!filteredItems.value.length) return 0
-		// If itemsPerPageValue is -1 ("Tous"), return 1 page
-		if (itemsPerPageValue.value === -1) return 1
-		return Math.ceil(filteredItems.value.length / itemsPerPageValue.value)
-	})
-
-	const filters = computed({
-		get: () => options.value.filters || [],
-		set: (newFilters: FilterOption[]) => {
-			options.value = {
-				...options.value,
-				filters: newFilters,
-			}
-		},
+	// Use the pagination composable
+	const itemsLength = computed(() => filteredItems.value.length)
+	const { page, pageCount, itemsPerPageValue, updateItemsPerPage } = usePagination({
+		options,
+		itemsPerPageProp: props.itemsPerPage,
+		itemsLength,
+		table,
+		emit,
 	})
 
 	const componentAttributes = useAttrs()
@@ -169,47 +136,6 @@
 		{ deep: true },
 	)
 
-	// Fonction pour améliorer les en-têtes de colonnes avec les types de filtres appropriés
-	function getEnhancedHeader(column: TableColumnHeader): TableColumnHeader {
-		// Trouve l'en-tête correspondant dans les props si disponible
-		const matchingHeader = props.headers?.find(h => h.key === column.key || h.value === column.value)
-		// Crée un en-tête amélioré avec les types appropriés
-		return {
-			...column,
-			title: column.name || matchingHeader?.title,
-			// Utilise le filterType de la colonne si disponible, sinon utilise le filterType de l'en-tête correspondant
-			filterType: column.filterType || matchingHeader?.filterType,
-			// Utilise les filterOptions de la colonne si disponibles, sinon utilise les filterOptions de l'en-tête correspondant
-			filterOptions: column.filterOptions || matchingHeader?.filterOptions,
-		} as TableColumnHeader
-	}
-
-	// Fonction pour créer un élément vide qui maintient la structure des colonnes
-	function createEmptyItemWithStructure(): Record<string, unknown>[] {
-		// Si nous avons des éléments, utilise le premier élément comme modèle
-		if (props.items.length > 0) {
-			// Crée un objet vide avec les mêmes clés que le premier élément
-			const template = Object.keys(props.items[0]).reduce((obj, key) => {
-				obj[key] = ''
-				return obj
-			}, {} as Record<string, unknown>)
-			return [template]
-		}
-
-		// Si nous avons des en-têtes, les utilise pour créer une structure
-		if (props.headers && props.headers.length > 0) {
-			// Crée un objet vide avec les clés des en-têtes
-			const template = props.headers.reduce((obj, header) => {
-				const key = header.key || header.value || ''
-				if (key) obj[key] = ''
-				return obj
-			}, {} as Record<string, unknown>)
-			return [template]
-		}
-
-		// Repli vers un objet vide
-		return [{}]
-	}
 </script>
 
 <template>

--- a/src/components/Tables/SyTable/tests/SyTable.spec.ts
+++ b/src/components/Tables/SyTable/tests/SyTable.spec.ts
@@ -162,8 +162,7 @@ describe('SyTable', () => {
 	it('passes itemsPerPage prop correctly', () => {
 		const wrapper = mount(SyTable, {
 			props: {
-				options: {} as DataOptions,
-				itemsPerPage: 5,
+				options: { itemsPerPage: 5 } as DataOptions,
 				suffix: 'test',
 			},
 			attrs: {

--- a/src/components/Tables/common/SyTablePagination.vue
+++ b/src/components/Tables/common/SyTablePagination.vue
@@ -1,0 +1,176 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { DataOptions } from './types'
+
+const props = defineProps<{
+  /**
+   * Current page number
+   */
+  page: number
+  /**
+   * Total number of pages
+   */
+  pageCount: number
+  /**
+   * Number of items per page
+   */
+  itemsPerPage: number
+  /**
+   * Total number of items
+   */
+  itemsLength: number
+}>()
+
+const emit = defineEmits<{
+  /**
+   * Emitted when the page changes
+   */
+  (e: 'update:page', page: number): void
+}>()
+
+/**
+ * Compute the range of items being displayed
+ */
+const itemsRange = computed(() => {
+  const start = (props.page - 1) * props.itemsPerPage + 1
+  const end = Math.min(props.page * props.itemsPerPage, props.itemsLength)
+  return { start, end }
+})
+
+/**
+ * Compute the accessible title for the pagination group
+ */
+const paginationTitle = computed(() => {
+  return `Pagination – 1 à ${props.pageCount} pages`
+})
+
+/**
+ * Compute the visible page numbers to display
+ * Shows current page, previous and next 2 pages when available
+ */
+const visiblePageNumbers = computed(() => {
+  const pages = []
+  const currentPage = props.page
+  const totalPages = props.pageCount
+  
+  // Always show first page
+  pages.push(1)
+  
+  // Add ellipsis if needed
+  if (currentPage > 4) {
+    pages.push('ellipsis-start')
+  }
+  
+  // Show pages around current page
+  for (let i = Math.max(2, currentPage - 2); i <= Math.min(totalPages - 1, currentPage + 2); i++) {
+    pages.push(i)
+  }
+  
+  // Add ellipsis if needed
+  if (currentPage < totalPages - 3) {
+    pages.push('ellipsis-end')
+  }
+  
+  // Always show last page if more than 1 page
+  if (totalPages > 1) {
+    pages.push(totalPages)
+  }
+  
+  return pages
+})
+
+/**
+ * Navigate to previous page
+ */
+function previousPage() {
+  if (props.page > 1) {
+    emit('update:page', props.page - 1)
+  }
+}
+
+/**
+ * Navigate to next page
+ */
+function nextPage() {
+  if (props.page < props.pageCount) {
+    emit('update:page', props.page + 1)
+  }
+}
+
+/**
+ * Navigate to specific page
+ */
+function goToPage(page: number) {
+  if (page >= 1 && page <= props.pageCount) {
+    emit('update:page', page)
+  }
+}
+</script>
+
+<template>
+  <div 
+    v-if="pageCount > 1" 
+    class="sy-table-pagination"
+    role="group"
+    :aria-label="paginationTitle"
+  >
+    <div class="sy-table-pagination__info">
+      {{ itemsRange.start }}-{{ itemsRange.end }} sur {{ itemsLength }} éléments
+    </div>
+    
+    <div class="sy-table-pagination__controls">
+      <!-- Previous page button -->
+      <v-btn
+        variant="text"
+        icon="mdi-chevron-left"
+        :disabled="page <= 1"
+        @click="previousPage"
+        aria-label="Page précédente"
+      />
+      
+      <!-- Page numbers -->
+      <template v-for="(pageItem, index) in visiblePageNumbers" :key="index">
+        <v-btn
+          v-if="pageItem !== 'ellipsis-start' && pageItem !== 'ellipsis-end'"
+          size="small"
+          :variant="pageItem === page ? 'flat' : 'text'"
+          :color="pageItem === page ? 'primary' : undefined"
+          class="mx-1"
+          @click="goToPage(pageItem as number)"
+          :aria-current="pageItem === page ? 'page' : undefined"
+        >
+          {{ pageItem }}
+        </v-btn>
+        <span v-else class="mx-1">...</span>
+      </template>
+      
+      <!-- Next page button -->
+      <v-btn
+        variant="text"
+        icon="mdi-chevron-right"
+        :disabled="page >= pageCount"
+        @click="nextPage"
+        aria-label="Page suivante"
+      />
+    </div>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.sy-table-pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  
+  &__info {
+    font-size: 0.875rem;
+    color: rgba(0, 0, 0, 0.6);
+  }
+  
+  &__controls {
+    display: flex;
+    align-items: center;
+  }
+}
+</style>

--- a/src/components/Tables/common/SyTablePagination.vue
+++ b/src/components/Tables/common/SyTablePagination.vue
@@ -1,176 +1,373 @@
 <script setup lang="ts">
-import { computed } from 'vue'
-import type { DataOptions } from './types'
+	import { computed, ref, nextTick, watch } from 'vue'
+	import SySelect from '@/components/Customs/SySelect/SySelect.vue'
+	import { locales } from './locales'
 
-const props = defineProps<{
-  /**
-   * Current page number
-   */
-  page: number
-  /**
-   * Total number of pages
-   */
-  pageCount: number
-  /**
-   * Number of items per page
-   */
-  itemsPerPage: number
-  /**
-   * Total number of items
-   */
-  itemsLength: number
-}>()
+	// Generate unique ID for this pagination instance
+	const uniqueId = ref(`pagination-${Math.random().toString(36).substr(2, 9)}`)
 
-const emit = defineEmits<{
-  /**
-   * Emitted when the page changes
-   */
-  (e: 'update:page', page: number): void
-}>()
+	// Items per page options with the current value included
+	const itemsPerPageOptions = computed(() => {
+		// Standard options
+		const standardOptions = [10, 25, 50, 100]
 
-/**
- * Compute the range of items being displayed
- */
-const itemsRange = computed(() => {
-  const start = (props.page - 1) * props.itemsPerPage + 1
-  const end = Math.min(props.page * props.itemsPerPage, props.itemsLength)
-  return { start, end }
-})
+		// Add the current itemsPerPage if it's not already in the standard options
+		// and it's not -1 (which represents "Tous")
+		if (!standardOptions.includes(props.itemsPerPage) && props.itemsPerPage !== -1) {
+			standardOptions.push(props.itemsPerPage)
+			// Sort the options numerically
+			standardOptions.sort((a, b) => a - b)
+		}
 
-/**
- * Compute the accessible title for the pagination group
- */
-const paginationTitle = computed(() => {
-  return `Pagination – 1 à ${props.pageCount} pages`
-})
+		// Map to the format expected by SySelect
+		const options = standardOptions.map(value => ({
+			text: value.toString(),
+			value,
+		}))
 
-/**
- * Compute the visible page numbers to display
- * Shows current page, previous and next 2 pages when available
- */
-const visiblePageNumbers = computed(() => {
-  const pages = []
-  const currentPage = props.page
-  const totalPages = props.pageCount
-  
-  // Always show first page
-  pages.push(1)
-  
-  // Add ellipsis if needed
-  if (currentPage > 4) {
-    pages.push('ellipsis-start')
-  }
-  
-  // Show pages around current page
-  for (let i = Math.max(2, currentPage - 2); i <= Math.min(totalPages - 1, currentPage + 2); i++) {
-    pages.push(i)
-  }
-  
-  // Add ellipsis if needed
-  if (currentPage < totalPages - 3) {
-    pages.push('ellipsis-end')
-  }
-  
-  // Always show last page if more than 1 page
-  if (totalPages > 1) {
-    pages.push(totalPages)
-  }
-  
-  return pages
-})
+		// Add "Tous" option to display all elements
+		options.push({
+			text: locales.pagination.all,
+			value: -1,
+		})
 
-/**
- * Navigate to previous page
- */
-function previousPage() {
-  if (props.page > 1) {
-    emit('update:page', props.page - 1)
-  }
-}
+		return options
+	})
 
-/**
- * Navigate to next page
- */
-function nextPage() {
-  if (props.page < props.pageCount) {
-    emit('update:page', props.page + 1)
-  }
-}
+	const props = defineProps<{
+		/**
+		 * Current page number
+		 */
+		page: number
+		/**
+		 * Total number of pages
+		 */
+		pageCount: number
+		/**
+		 * Number of items per page
+		 */
+		itemsPerPage: number
+		/**
+		 * Total number of items
+		 */
+		itemsLength: number
+	}>()
 
-/**
- * Navigate to specific page
- */
-function goToPage(page: number) {
-  if (page >= 1 && page <= props.pageCount) {
-    emit('update:page', page)
-  }
-}
+	const emit = defineEmits<{
+		/**
+		 * Emitted when the page changes
+		 */
+		(e: 'update:page', page: number): void
+		/**
+		 * Emitted when the items per page changes
+		 */
+		(e: 'update:items-per-page', itemsPerPage: number): void
+	}>()
+
+	// Removed unused itemsRange computed property
+
+	// Removed unused paginationTitle computed property
+
+	/**
+	 * Compute the visible page numbers to display
+	 * Shows current page, previous and next 2 pages when available
+	 */
+	const visiblePageNumbers = computed(() => {
+		// Define array that can contain both numbers and strings
+		const pages: (number | string)[] = []
+		const currentPage = props.page
+		const totalPages = props.pageCount
+
+		// Always show first page
+		pages.push(1)
+
+		// Add ellipsis if needed
+		if (currentPage > 4) {
+			pages.push('ellipsis-start')
+		}
+
+		// Show pages around current page
+		for (let i = Math.max(2, currentPage - 2); i <= Math.min(totalPages - 1, currentPage + 2); i++) {
+			pages.push(i)
+		}
+
+		// Add ellipsis if needed
+		if (currentPage < totalPages - 3) {
+			pages.push('ellipsis-end')
+		}
+
+		// Always show last page if more than 1 page
+		if (totalPages > 1) {
+			pages.push(totalPages)
+		}
+
+		return pages
+	})
+
+	/**
+	 * Extract only the numeric middle pages from visiblePageNumbers
+	 */
+	const middlePages = computed(() => {
+		return visiblePageNumbers.value.filter(
+			page => typeof page === 'number' && page !== 1 && page !== props.pageCount,
+		) as number[]
+	})
+
+	/**
+	 * Navigate to previous page
+	 */
+	function previousPage() {
+		if (props.page > 1) {
+			emit('update:page', props.page - 1)
+		}
+	}
+
+	/**
+	 * Navigate to next page
+	 */
+	function nextPage() {
+		if (props.page < props.pageCount) {
+			emit('update:page', props.page + 1)
+		}
+	}
+
+	/**
+	 * Navigate to a specific page
+	 */
+	function goToPage(pageNumber: number) {
+		emit('update:page', pageNumber)
+	}
+
+	/**
+	 * Local items per page with two-way binding
+	 */
+	// Use a ref instead of a computed property for better compatibility with v-model
+	const localItemsPerPage = ref(props.itemsPerPage)
+
+	// Watch for changes from parent
+	watch(() => props.itemsPerPage, (newValue) => {
+		localItemsPerPage.value = newValue
+	})
+
+	// Watch for local changes and emit events
+	watch(localItemsPerPage, (newValue) => {
+		// First reset to page 1 when changing items per page
+		emit('update:page', 1)
+		// Then update the items per page
+		emit('update:items-per-page', newValue)
+
+		// Force a re-render of the component
+		nextTick(() => {
+			// This will trigger a re-render of the parent components
+			emit('update:items-per-page', newValue)
+		})
+	})
 </script>
 
 <template>
-  <div 
-    v-if="pageCount > 1" 
-    class="sy-table-pagination"
-    role="group"
-    :aria-label="paginationTitle"
-  >
-    <div class="sy-table-pagination__info">
-      {{ itemsRange.start }}-{{ itemsRange.end }} sur {{ itemsLength }} éléments
-    </div>
-    
-    <div class="sy-table-pagination__controls">
-      <!-- Previous page button -->
-      <v-btn
-        variant="text"
-        icon="mdi-chevron-left"
-        :disabled="page <= 1"
-        @click="previousPage"
-        aria-label="Page précédente"
-      />
-      
-      <!-- Page numbers -->
-      <template v-for="(pageItem, index) in visiblePageNumbers" :key="index">
-        <v-btn
-          v-if="pageItem !== 'ellipsis-start' && pageItem !== 'ellipsis-end'"
-          size="small"
-          :variant="pageItem === page ? 'flat' : 'text'"
-          :color="pageItem === page ? 'primary' : undefined"
-          class="mx-1"
-          @click="goToPage(pageItem as number)"
-          :aria-current="pageItem === page ? 'page' : undefined"
-        >
-          {{ pageItem }}
-        </v-btn>
-        <span v-else class="mx-1">...</span>
-      </template>
-      
-      <!-- Next page button -->
-      <v-btn
-        variant="text"
-        icon="mdi-chevron-right"
-        :disabled="page >= pageCount"
-        @click="nextPage"
-        aria-label="Page suivante"
-      />
-    </div>
-  </div>
+	<div
+		v-if="pageCount > 1"
+		class="sy-table-pagination"
+	>
+		<div class="info">
+			{{ locales.pagination.showingItems((page - 1) * itemsPerPage + 1, Math.min(page * itemsPerPage, itemsLength), itemsLength) }}
+		</div>
+
+		<nav
+			class="pagination"
+			:aria-labelledby="uniqueId"
+		>
+			<h2
+				:id="uniqueId"
+				class="d-sr-only"
+			>
+				{{ locales.pagination.paginationNavAriaLabel }}
+			</h2>
+			<ul class="list">
+				<!-- Previous link -->
+				<li>
+					<a
+						href="#"
+						:class="{ 'disabled': page <= 1 }"
+						@click.prevent="previousPage"
+					>{{ locales.pagination.previous }}</a>
+				</li>
+
+				<!-- First page -->
+				<li>
+					<a
+						href="#"
+						class="list-first"
+						:aria-current="page === 1 ? 'page' : undefined"
+						@click.prevent="goToPage(1)"
+					>{{ locales.pagination.pageText(1) }}</a>
+				</li>
+
+				<!-- Start ellipsis if needed -->
+				<li v-if="visiblePageNumbers.includes('ellipsis-start')">
+					<a class="ellipsis">&#8230;</a>
+				</li>
+
+				<!-- Middle pages (6, 7, 8, 9, 10) -->
+				<li
+					v-for="pageNum in middlePages"
+					:key="pageNum"
+				>
+					<a
+						href="#"
+						:aria-current="page === pageNum ? 'page' : undefined"
+						@click.prevent="goToPage(pageNum)"
+					>{{ locales.pagination.pageText(pageNum) }}</a>
+				</li>
+
+				<!-- End ellipsis if needed -->
+				<li v-if="visiblePageNumbers.includes('ellipsis-end')">
+					<a class="ellipsis">&#8230;</a>
+				</li>
+
+				<!-- Last page (if not already shown) -->
+				<li v-if="pageCount > 1">
+					<a
+						href="#"
+						class="list-last"
+						:aria-current="page === pageCount ? 'page' : undefined"
+						@click.prevent="goToPage(pageCount)"
+					>{{ locales.pagination.pageText(pageCount) }}</a>
+				</li>
+
+				<!-- Next link -->
+				<li>
+					<a
+						href="#"
+						:class="{ 'disabled': page >= pageCount }"
+						@click.prevent="nextPage"
+					>{{ locales.pagination.next }}</a>
+				</li>
+			</ul>
+		</nav>
+
+		<div class="rows-per-page">
+			<span class="rows-per-page-label">{{ locales.pagination.itemsPerPageText }}</span>
+			<SySelect
+				v-model="localItemsPerPage"
+				:items="itemsPerPageOptions"
+				hide-details
+				hide-messages
+				density="compact"
+				class="rows-per-page-select"
+				:aria-label="locales.pagination.itemsPerPageText"
+				:label="''"
+				style="width: 80px;"
+				:clearable="false"
+			/>
+		</div>
+	</div>
 </template>
 
 <style lang="scss" scoped>
+@use '@/assets/tokens';
+
 .sy-table-pagination {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 12px 16px;
-  
-  &__info {
-    font-size: 0.875rem;
-    color: rgba(0, 0, 0, 0.6);
-  }
-  
-  &__controls {
-    display: flex;
-    align-items: center;
-  }
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 12px 16px;
+	flex-wrap: wrap;
+	gap: 1rem;
+
+	.info {
+		font-size: 0.875rem;
+		color: rgb(0 0 0 / 60%);
+	}
+
+	.rows-per-page {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+
+		&-label {
+			font-size: 0.875rem;
+			color: rgb(0 0 0 / 60%);
+		}
+
+		&-select {
+			:deep(.v-field__field) {
+				min-height: 32px !important;
+			}
+
+			:deep(.v-field__input) {
+				min-height: 32px !important;
+				padding-top: 0 !important;
+				padding-bottom: 0 !important;
+			}
+
+			:deep(.v-field__append-inner) {
+				padding-top: 4px !important;
+			}
+		}
+	}
+
+	.pagination {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+		align-items: center;
+
+		.list {
+			display: flex;
+			flex-wrap: wrap;
+			gap: 0.5rem;
+			list-style: none;
+			padding: 0;
+			margin: 0;
+
+			li {
+				display: inline-block;
+			}
+
+			a {
+				display: inline-block;
+				padding: 0.5rem 0.75rem;
+				text-decoration: none;
+				color: tokens.$primary-base;
+				border: 1px solid tokens.$primary-base;
+				border-radius: 4px;
+				transition: all 0.2s ease;
+				font-size: 0.875rem;
+				line-height: 1;
+
+				&:hover,
+				&:focus {
+					background-color: rgba(tokens.$primary-base, 0.1);
+				}
+
+				&[aria-current='page'] {
+					background-color: tokens.$primary-base;
+					color: white;
+					font-weight: 500;
+				}
+
+				&.disabled {
+					color: rgb(0 0 0 / 40%);
+					border-color: rgb(0 0 0 / 20%);
+					pointer-events: none;
+				}
+
+				&.ellipsis {
+					border: none;
+					pointer-events: none;
+				}
+			}
+
+			// Style for Previous/Next links
+			li:first-child a,
+			li:last-child a {
+				background-color: transparent;
+				border: none;
+				padding-left: 0.25rem;
+				padding-right: 0.25rem;
+			}
+		}
+	}
 }
 </style>

--- a/src/components/Tables/common/SyTablePagination.vue
+++ b/src/components/Tables/common/SyTablePagination.vue
@@ -18,6 +18,15 @@
 			// Sort the options numerically
 			standardOptions.sort((a, b) => a - b)
 		}
+		
+		// Always include the total number of items as an option if it's reasonable
+		if (props.itemsLength > 0 && 
+		    props.itemsLength <= 500 && 
+		    !standardOptions.includes(props.itemsLength)) {
+			standardOptions.push(props.itemsLength)
+			// Sort the options numerically
+			standardOptions.sort((a, b) => a - b)
+		}
 
 		// Map to the format expected by SySelect
 		const options = standardOptions.map(value => ({
@@ -167,9 +176,9 @@
 <template>
 	<div class="sy-table-pagination">
 		<div class="info">
-			{{ itemsPerPage === -1 
+			{{ itemsPerPage === -1
 				? locales.pagination.showingItems(1, itemsLength, itemsLength)
-				: locales.pagination.showingItems((page - 1) * itemsPerPage + 1, Math.min(page * itemsPerPage, itemsLength), itemsLength) 
+				: locales.pagination.showingItems((page - 1) * itemsPerPage + 1, Math.min(page * itemsPerPage, itemsLength), itemsLength)
 			}}
 		</div>
 

--- a/src/components/Tables/common/SyTablePagination.vue
+++ b/src/components/Tables/common/SyTablePagination.vue
@@ -165,15 +165,16 @@
 </script>
 
 <template>
-	<div
-		v-if="pageCount > 1"
-		class="sy-table-pagination"
-	>
+	<div class="sy-table-pagination">
 		<div class="info">
-			{{ locales.pagination.showingItems((page - 1) * itemsPerPage + 1, Math.min(page * itemsPerPage, itemsLength), itemsLength) }}
+			{{ itemsPerPage === -1 
+				? locales.pagination.showingItems(1, itemsLength, itemsLength)
+				: locales.pagination.showingItems((page - 1) * itemsPerPage + 1, Math.min(page * itemsPerPage, itemsLength), itemsLength) 
+			}}
 		</div>
 
 		<nav
+			v-if="pageCount > 1"
 			class="pagination"
 			:aria-labelledby="uniqueId"
 		>

--- a/src/components/Tables/common/SyTablePagination.vue
+++ b/src/components/Tables/common/SyTablePagination.vue
@@ -6,24 +6,15 @@
 	// Generate unique ID for this pagination instance
 	const uniqueId = ref(`pagination-${Math.random().toString(36).substr(2, 9)}`)
 
-	// Items per page options with the current value included
+	// Items per page options - standard options and current value
 	const itemsPerPageOptions = computed(() => {
 		// Standard options
 		const standardOptions = [10, 25, 50, 100]
-
+		
 		// Add the current itemsPerPage if it's not already in the standard options
 		// and it's not -1 (which represents "Tous")
 		if (!standardOptions.includes(props.itemsPerPage) && props.itemsPerPage !== -1) {
 			standardOptions.push(props.itemsPerPage)
-			// Sort the options numerically
-			standardOptions.sort((a, b) => a - b)
-		}
-
-		// Always include the total number of items as an option if it's reasonable
-		if (props.itemsLength > 0
-			&& props.itemsLength <= 500
-			&& !standardOptions.includes(props.itemsLength)) {
-			standardOptions.push(props.itemsLength)
 			// Sort the options numerically
 			standardOptions.sort((a, b) => a - b)
 		}

--- a/src/components/Tables/common/SyTablePagination.vue
+++ b/src/components/Tables/common/SyTablePagination.vue
@@ -18,11 +18,11 @@
 			// Sort the options numerically
 			standardOptions.sort((a, b) => a - b)
 		}
-		
+
 		// Always include the total number of items as an option if it's reasonable
-		if (props.itemsLength > 0 && 
-		    props.itemsLength <= 500 && 
-		    !standardOptions.includes(props.itemsLength)) {
+		if (props.itemsLength > 0
+			&& props.itemsLength <= 500
+			&& !standardOptions.includes(props.itemsLength)) {
 			standardOptions.push(props.itemsLength)
 			// Sort the options numerically
 			standardOptions.sort((a, b) => a - b)

--- a/src/components/Tables/common/SyTablePagination.vue
+++ b/src/components/Tables/common/SyTablePagination.vue
@@ -10,7 +10,7 @@
 	const itemsPerPageOptions = computed(() => {
 		// Standard options
 		const standardOptions = [10, 25, 50, 100]
-		
+
 		// Add the current itemsPerPage if it's not already in the standard options
 		// and it's not -1 (which represents "Tous")
 		if (!standardOptions.includes(props.itemsPerPage) && props.itemsPerPage !== -1) {

--- a/src/components/Tables/common/SyTablePagination.vue
+++ b/src/components/Tables/common/SyTablePagination.vue
@@ -8,7 +8,6 @@
 
 	// Items per page options - standard options and current value
 	const itemsPerPageOptions = computed(() => {
-		// Standard options
 		const standardOptions = [10, 25, 50, 100]
 
 		// Add the current itemsPerPage if it's not already in the standard options
@@ -35,21 +34,9 @@
 	})
 
 	const props = defineProps<{
-		/**
-		 * Current page number
-		 */
 		page: number
-		/**
-		 * Total number of pages
-		 */
 		pageCount: number
-		/**
-		 * Number of items per page
-		 */
 		itemsPerPage: number
-		/**
-		 * Total number of items
-		 */
 		itemsLength: number
 	}>()
 
@@ -64,16 +51,11 @@
 		(e: 'update:items-per-page', itemsPerPage: number): void
 	}>()
 
-	// Removed unused itemsRange computed property
-
-	// Removed unused paginationTitle computed property
-
 	/**
-	 * Compute the visible page numbers to display
+	 * Visible page numbers to display
 	 * Shows current page, previous and next 2 pages when available
 	 */
 	const visiblePageNumbers = computed(() => {
-		// Define array that can contain both numbers and strings
 		const pages: (number | string)[] = []
 		const currentPage = props.page
 		const totalPages = props.pageCount
@@ -360,7 +342,6 @@
 				}
 			}
 
-			// Style for Previous/Next links
 			li:first-child a,
 			li:last-child a {
 				background-color: transparent;

--- a/src/components/Tables/common/locales.ts
+++ b/src/components/Tables/common/locales.ts
@@ -1,7 +1,21 @@
 export const locales = {
+	// Table locales
 	resetFilters: 'Réinitialiser les filtres',
 	noData: 'Aucune donnée disponible',
 	columnOrder: (columnTitle: string) => `Ordonner par ${columnTitle}`,
 	ResizableColumn: 'Redimensionner la colonne',
 	resizeColumn: (columnTitle: string) => `Redimensionner la colonne ${columnTitle}`,
+
+	// Pagination locales
+	pagination: {
+		itemsPerPageText: 'Lignes par page:',
+		previous: 'Précédent',
+		next: 'Suivant',
+		all: 'Tous',
+		showingItems: (start: number, end: number, total: number) => `${start}-${end} sur ${total} éléments`,
+		pageText: (page: number) => `${page}`,
+		pageAriaLabel: (page: number) => `Page ${page}`,
+		currentPageAriaLabel: (page: number) => `Page courante, Page ${page}`,
+		paginationNavAriaLabel: 'Navigation de pagination',
+	},
 }

--- a/src/components/Tables/common/tableFilterUtils.ts
+++ b/src/components/Tables/common/tableFilterUtils.ts
@@ -32,6 +32,10 @@ function applyFilter<T extends Record<string, unknown>>(item: T, filter: FilterO
 		case 'select': {
 			return filterBySelect(itemValue, filterValue)
 		}
+		case 'custom': {
+			// Traiter les filtres personnalisés comme des filtres de sélection
+			return filterBySelect(itemValue, filterValue)
+		}
 		case 'period':{
 			return filterByPeriod(itemValue, filterValue)
 		}

--- a/src/components/Tables/common/tableUtils.ts
+++ b/src/components/Tables/common/tableUtils.ts
@@ -10,7 +10,6 @@ export function useTableUtils({
 	tableId,
 	prefix,
 	suffix,
-	itemsPerPage,
 	serverItemsLength,
 	componentAttributes,
 	headersProp,
@@ -19,7 +18,6 @@ export function useTableUtils({
 	tableId: string
 	prefix: string
 	suffix?: string
-	itemsPerPage?: number
 	caption?: string
 	serverItemsLength?: number
 	componentAttributes: Record<string, unknown>
@@ -53,7 +51,7 @@ export function useTableUtils({
 	const optionsFacade = computed(() => {
 		return {
 			page: options.value.page || componentAttributes['page'],
-			itemsPerPage: options.value.itemsPerPage || itemsPerPage,
+			itemsPerPage: options.value.itemsPerPage || 10,
 			sortBy: options.value.sortBy,
 			groupBy: options.value.groupBy,
 			multiSort: options.value.multiSort,

--- a/src/components/Tables/common/tests/SyTablePagination.spec.ts
+++ b/src/components/Tables/common/tests/SyTablePagination.spec.ts
@@ -33,7 +33,6 @@ describe('SyTablePagination.vue', () => {
 			},
 		})
 		expect(wrapper.find('.pagination').exists()).toBe(true)
-		// Just check that the pagination container exists, as buttons might be rendered differently in test environment
 	})
 
 	it('does not display pagination navigation when there is only one page', () => {
@@ -48,9 +47,7 @@ describe('SyTablePagination.vue', () => {
 				plugins: [vuetify],
 			},
 		})
-		// The component itself should still be visible
 		expect(wrapper.find('.sy-table-pagination').exists()).toBe(true)
-		// But the pagination navigation should not be visible
 		expect(wrapper.find('.pagination').exists()).toBe(false)
 	})
 
@@ -68,7 +65,6 @@ describe('SyTablePagination.vue', () => {
 		})
 		expect(wrapper.find('.sy-table-pagination').exists()).toBe(true)
 		expect(wrapper.find('.info').exists()).toBe(true)
-		// The SySelect component should be present
 		expect(wrapper.findComponent({ name: 'SySelect' }).exists()).toBe(true)
 	})
 
@@ -85,12 +81,9 @@ describe('SyTablePagination.vue', () => {
 			},
 		})
 
-		// Access the component instance to check computed properties
-		// Use a type assertion with 'unknown' first to avoid TypeScript errors
 		const vm = wrapper.vm as unknown as { itemsPerPageOptions: Array<{ text: string, value: number }> }
 		expect(vm.itemsPerPageOptions).toBeDefined()
 
-		// Check if the options include the total items count
 		const options = vm.itemsPerPageOptions
 		const hasItemsLength = options.some(option => option.value === 42)
 		expect(hasItemsLength).toBe(true)
@@ -109,7 +102,6 @@ describe('SyTablePagination.vue', () => {
 			},
 		})
 
-		// The info text should show "1-42 sur 42 éléments"
 		const infoText = wrapper.find('.info').text()
 		expect(infoText).toContain('1-42')
 	})
@@ -127,10 +119,8 @@ describe('SyTablePagination.vue', () => {
 			},
 		})
 
-		// Call the nextPage method directly
 		await (wrapper.vm as unknown as { nextPage: () => Promise<void> }).nextPage()
 
-		// Check if the update:page event was emitted with value 2
 		expect(wrapper.emitted('update:page')).toBeTruthy()
 		expect(wrapper.emitted('update:page')![0]).toEqual([2])
 	})
@@ -148,10 +138,8 @@ describe('SyTablePagination.vue', () => {
 			},
 		})
 
-		// Check that the items per page selector exists
 		expect(wrapper.find('.rows-per-page-label').exists()).toBe(true)
 
-		// Check that the label text is correct
 		const labelText = wrapper.find('.rows-per-page-label').text()
 		expect(labelText).toContain('Lignes par page')
 	})

--- a/src/components/Tables/common/tests/SyTablePagination.spec.ts
+++ b/src/components/Tables/common/tests/SyTablePagination.spec.ts
@@ -89,7 +89,7 @@ describe('SyTablePagination.vue', () => {
 		// Should have standard options (10, 25, 50, 100) plus the 'All' option (-1)
 		expect(options1.length).toBe(5)
 		expect(options1.map(o => o.value).sort((a, b) => a - b)).toEqual([-1, 10, 25, 50, 100])
-		
+
 		// Test with custom value
 		const wrapper2 = mount(SyTablePagination, {
 			props: {
@@ -105,11 +105,11 @@ describe('SyTablePagination.vue', () => {
 
 		const vm2 = wrapper2.vm as unknown as { itemsPerPageOptions: Array<{ text: string, value: number }> }
 		const options2 = vm2.itemsPerPageOptions
-		
+
 		// Should include the custom value (42)
 		const hasCustomValue = options2.some(option => option.value === 42)
 		expect(hasCustomValue).toBe(true)
-		
+
 		// Should have standard options + custom value + 'All' option
 		expect(options2.length).toBe(6)
 		expect(options2.map(o => o.value).sort((a, b) => a - b)).toEqual([-1, 10, 25, 42, 50, 100])

--- a/src/components/Tables/common/tests/SyTablePagination.spec.ts
+++ b/src/components/Tables/common/tests/SyTablePagination.spec.ts
@@ -68,11 +68,12 @@ describe('SyTablePagination.vue', () => {
 		expect(wrapper.findComponent({ name: 'SySelect' }).exists()).toBe(true)
 	})
 
-	it('includes total items count in items per page options', async () => {
-		const wrapper = mount(SyTablePagination, {
+	it('includes standard options and current itemsPerPage value', async () => {
+		// Test with standard value
+		const wrapper1 = mount(SyTablePagination, {
 			props: {
 				page: 1,
-				itemsPerPage: 10,
+				itemsPerPage: 10, // Standard value
 				itemsLength: 42,
 				pageCount: 5,
 			},
@@ -81,12 +82,37 @@ describe('SyTablePagination.vue', () => {
 			},
 		})
 
-		const vm = wrapper.vm as unknown as { itemsPerPageOptions: Array<{ text: string, value: number }> }
-		expect(vm.itemsPerPageOptions).toBeDefined()
+		const vm1 = wrapper1.vm as unknown as { itemsPerPageOptions: Array<{ text: string, value: number }> }
+		expect(vm1.itemsPerPageOptions).toBeDefined()
 
-		const options = vm.itemsPerPageOptions
-		const hasItemsLength = options.some(option => option.value === 42)
-		expect(hasItemsLength).toBe(true)
+		const options1 = vm1.itemsPerPageOptions
+		// Should have standard options (10, 25, 50, 100) plus the 'All' option (-1)
+		expect(options1.length).toBe(5)
+		expect(options1.map(o => o.value).sort((a, b) => a - b)).toEqual([-1, 10, 25, 50, 100])
+		
+		// Test with custom value
+		const wrapper2 = mount(SyTablePagination, {
+			props: {
+				page: 1,
+				itemsPerPage: 42, // Custom value
+				itemsLength: 100,
+				pageCount: 5,
+			},
+			global: {
+				plugins: [vuetify],
+			},
+		})
+
+		const vm2 = wrapper2.vm as unknown as { itemsPerPageOptions: Array<{ text: string, value: number }> }
+		const options2 = vm2.itemsPerPageOptions
+		
+		// Should include the custom value (42)
+		const hasCustomValue = options2.some(option => option.value === 42)
+		expect(hasCustomValue).toBe(true)
+		
+		// Should have standard options + custom value + 'All' option
+		expect(options2.length).toBe(6)
+		expect(options2.map(o => o.value).sort((a, b) => a - b)).toEqual([-1, 10, 25, 42, 50, 100])
 	})
 
 	it('shows correct range when "All" is selected', async () => {

--- a/src/components/Tables/common/tests/SyTablePagination.spec.ts
+++ b/src/components/Tables/common/tests/SyTablePagination.spec.ts
@@ -1,0 +1,158 @@
+import { mount } from '@vue/test-utils'
+import { expect, describe, it } from 'vitest'
+import SyTablePagination from '../SyTablePagination.vue'
+import { vuetify } from '@tests/unit/setup'
+
+describe('SyTablePagination.vue', () => {
+	it('renders the component with default props', () => {
+		const wrapper = mount(SyTablePagination, {
+			props: {
+				page: 1,
+				itemsPerPage: 10,
+				itemsLength: 100,
+				pageCount: 10,
+			},
+			global: {
+				plugins: [vuetify],
+			},
+		})
+		expect(wrapper.exists()).toBe(true)
+		expect(wrapper.find('.sy-table-pagination').exists()).toBe(true)
+	})
+
+	it('displays pagination when there are multiple pages', () => {
+		const wrapper = mount(SyTablePagination, {
+			props: {
+				page: 1,
+				itemsPerPage: 10,
+				itemsLength: 100,
+				pageCount: 10,
+			},
+			global: {
+				plugins: [vuetify],
+			},
+		})
+		expect(wrapper.find('.pagination').exists()).toBe(true)
+		// Just check that the pagination container exists, as buttons might be rendered differently in test environment
+	})
+
+	it('does not display pagination navigation when there is only one page', () => {
+		const wrapper = mount(SyTablePagination, {
+			props: {
+				page: 1,
+				itemsPerPage: 10,
+				itemsLength: 5,
+				pageCount: 1,
+			},
+			global: {
+				plugins: [vuetify],
+			},
+		})
+		// The component itself should still be visible
+		expect(wrapper.find('.sy-table-pagination').exists()).toBe(true)
+		// But the pagination navigation should not be visible
+		expect(wrapper.find('.pagination').exists()).toBe(false)
+	})
+
+	it('always shows items per page selector even with only one page', () => {
+		const wrapper = mount(SyTablePagination, {
+			props: {
+				page: 1,
+				itemsPerPage: 10,
+				itemsLength: 5,
+				pageCount: 1,
+			},
+			global: {
+				plugins: [vuetify],
+			},
+		})
+		expect(wrapper.find('.sy-table-pagination').exists()).toBe(true)
+		expect(wrapper.find('.info').exists()).toBe(true)
+		// The SySelect component should be present
+		expect(wrapper.findComponent({ name: 'SySelect' }).exists()).toBe(true)
+	})
+
+	it('includes total items count in items per page options', async () => {
+		const wrapper = mount(SyTablePagination, {
+			props: {
+				page: 1,
+				itemsPerPage: 10,
+				itemsLength: 42,
+				pageCount: 5,
+			},
+			global: {
+				plugins: [vuetify],
+			},
+		})
+
+		// Access the component instance to check computed properties
+		// Use a type assertion with 'unknown' first to avoid TypeScript errors
+		const vm = wrapper.vm as unknown as { itemsPerPageOptions: Array<{ text: string; value: number }> }
+		expect(vm.itemsPerPageOptions).toBeDefined()
+
+		// Check if the options include the total items count
+		const options = vm.itemsPerPageOptions
+		const hasItemsLength = options.some((option) => option.value === 42)
+		expect(hasItemsLength).toBe(true)
+	})
+
+	it('shows correct range when "All" is selected', async () => {
+		const wrapper = mount(SyTablePagination, {
+			props: {
+				page: 1,
+				itemsPerPage: -1, // "All" option
+				itemsLength: 42,
+				pageCount: 1,
+			},
+			global: {
+				plugins: [vuetify],
+			},
+		})
+
+		// The info text should show "1-42 sur 42 éléments"
+		const infoText = wrapper.find('.info').text()
+		expect(infoText).toContain('1-42')
+	})
+
+	it('emits update:page event when nextPage method is called', async () => {
+		const wrapper = mount(SyTablePagination, {
+			props: {
+				page: 1,
+				itemsPerPage: 10,
+				itemsLength: 100,
+				pageCount: 10,
+			},
+			global: {
+				plugins: [vuetify],
+			},
+		})
+
+		// Call the nextPage method directly
+		await (wrapper.vm as unknown as { nextPage: () => Promise<void> }).nextPage()
+
+		// Check if the update:page event was emitted with value 2
+		expect(wrapper.emitted('update:page')).toBeTruthy()
+		expect(wrapper.emitted('update:page')![0]).toEqual([2])
+	})
+
+	it('has the correct structure for items per page selection', () => {
+		const wrapper = mount(SyTablePagination, {
+			props: {
+				page: 1,
+				itemsPerPage: 10,
+				itemsLength: 100,
+				pageCount: 10,
+			},
+			global: {
+				plugins: [vuetify],
+			},
+		})
+
+		// Check that the items per page selector exists
+		expect(wrapper.find('.rows-per-page-label').exists()).toBe(true)
+
+		// Check that the label text is correct
+		const labelText = wrapper.find('.rows-per-page-label').text()
+		expect(labelText).toContain('Lignes par page')
+	})
+})

--- a/src/components/Tables/common/tests/SyTablePagination.spec.ts
+++ b/src/components/Tables/common/tests/SyTablePagination.spec.ts
@@ -87,12 +87,12 @@ describe('SyTablePagination.vue', () => {
 
 		// Access the component instance to check computed properties
 		// Use a type assertion with 'unknown' first to avoid TypeScript errors
-		const vm = wrapper.vm as unknown as { itemsPerPageOptions: Array<{ text: string; value: number }> }
+		const vm = wrapper.vm as unknown as { itemsPerPageOptions: Array<{ text: string, value: number }> }
 		expect(vm.itemsPerPageOptions).toBeDefined()
 
 		// Check if the options include the total items count
 		const options = vm.itemsPerPageOptions
-		const hasItemsLength = options.some((option) => option.value === 42)
+		const hasItemsLength = options.some(option => option.value === 42)
 		expect(hasItemsLength).toBe(true)
 	})
 

--- a/src/components/Tables/common/tests/tableUtils.spec.ts
+++ b/src/components/Tables/common/tests/tableUtils.spec.ts
@@ -117,7 +117,6 @@ describe('tableUtils', () => {
 		const { optionsFacade } = useTableUtils({
 			tableId: 'test-table',
 			prefix: 'table',
-			itemsPerPage: 10,
 			caption: 'Test Table',
 			componentAttributes,
 			options,
@@ -125,7 +124,6 @@ describe('tableUtils', () => {
 
 		expect(optionsFacade.value).toEqual({
 			page: 2,
-			itemsPerPage: 10,
 			sortBy: [{ key: 'name', order: 'asc' }],
 			groupBy: undefined,
 			multiSort: undefined,

--- a/src/components/Tables/common/tests/tableUtils.spec.ts
+++ b/src/components/Tables/common/tests/tableUtils.spec.ts
@@ -207,7 +207,9 @@ describe('tableUtils', () => {
 	it('should setup local storage correctly', () => {
 		mockLocalStorageUtility.getItem.mockReturnValue({
 			page: 2,
-			itemsPerPage: 20,
+			options: {
+				itemsPerPage: 20,
+			},
 		})
 
 		const options = ref<Partial<DataOptions>>({})
@@ -227,7 +229,9 @@ describe('tableUtils', () => {
 		expect(mockLocalStorageUtility.getItem).toHaveBeenCalledWith('table-test')
 		expect(localOptions.value).toEqual({
 			page: 2,
-			itemsPerPage: 20,
+			options: {
+				itemsPerPage: 20,
+			},
 		})
 
 		// Test watchOptions

--- a/src/components/Tables/common/tests/tableUtils.spec.ts
+++ b/src/components/Tables/common/tests/tableUtils.spec.ts
@@ -125,6 +125,7 @@ describe('tableUtils', () => {
 		expect(optionsFacade.value).toEqual({
 			page: 2,
 			sortBy: [{ key: 'name', order: 'asc' }],
+			itemsPerPage: 10,
 			groupBy: undefined,
 			multiSort: undefined,
 			mustSort: undefined,

--- a/src/components/Tables/common/types.ts
+++ b/src/components/Tables/common/types.ts
@@ -63,7 +63,6 @@ export type TableColumnHeader = {
 export interface SyTableProps {
 	items?: Record<string, unknown>[]
 	suffix: string
-	itemsPerPage?: number
 	caption?: string
 	showFilters?: boolean
 	headers?: DataTableHeaders[]
@@ -77,7 +76,6 @@ export interface SyServerTableProps {
 	serverItemsLength: number
 	items?: Record<string, unknown>[]
 	suffix: string
-	itemsPerPage?: number
 	caption?: string
 	showFilters?: boolean
 	headers?: DataTableHeaders[]

--- a/src/components/Tables/common/usePagination.ts
+++ b/src/components/Tables/common/usePagination.ts
@@ -1,0 +1,86 @@
+import { computed, nextTick, type Ref } from 'vue'
+import type { DataOptions } from './types'
+
+/**
+ * Composable for managing table pagination
+ *
+ * @param options - Reactive reference to table options
+ * @param itemsPerPageProp - Default items per page from props
+ * @param itemsLength - Total number of items (for client-side) or serverItemsLength (for server-side)
+ * @param table - Reference to the table component
+ * @param emit - Emit function for update:options event
+ * @returns Pagination utilities and computed properties
+ */
+export function usePagination({
+	options,
+	itemsPerPageProp,
+	itemsLength,
+	table,
+	emit,
+}: {
+	options: Ref<Partial<DataOptions>>
+	itemsPerPageProp?: number
+	itemsLength: Ref<number>
+	table: Ref<unknown>
+	emit: (event: 'update:options', options: Partial<DataOptions>) => void
+}) {
+	// Current page with getter/setter
+	const page = computed({
+		get: () => options.value.page || 1,
+		set: (newPage: number) => {
+			options.value = {
+				...options.value,
+				page: newPage,
+			}
+		},
+	})
+
+	// Items per page with fallback to props or default
+	const itemsPerPageValue = computed(() => {
+		const value = options.value.itemsPerPage || itemsPerPageProp || 10
+		// If value is -1, it means "Tous" (all items)
+		return value
+	})
+
+	// Calculate total number of pages
+	const pageCount = computed(() => {
+		if (!itemsLength.value) return 0
+		// If itemsPerPageValue is -1 ("Tous"), return 1 page
+		if (itemsPerPageValue.value === -1) return 1
+		return Math.ceil(itemsLength.value / itemsPerPageValue.value)
+	})
+
+	/**
+   * Update items per page from pagination component
+   */
+	function updateItemsPerPage(newItemsPerPage: number) {
+		// Create a completely new options object to force reactivity
+		const newOptions = {
+			...options.value,
+			itemsPerPage: newItemsPerPage,
+			page: 1, // Reset to first page when changing items per page
+		}
+
+		// Update options with the new object
+		options.value = newOptions
+
+		// Force a refresh of the table
+		nextTick(() => {
+			// Try to force update if the table has that method
+			const tableValue = table.value as { $forceUpdate?: () => void }
+			if (tableValue && typeof tableValue.$forceUpdate === 'function') {
+				tableValue.$forceUpdate()
+			}
+
+			// Emit an event to notify parent components
+			emit('update:options', newOptions)
+		})
+	}
+
+	return {
+		page,
+		pageCount,
+		itemsPerPageValue,
+		updateItemsPerPage,
+	}
+}

--- a/src/components/Tables/common/usePagination.ts
+++ b/src/components/Tables/common/usePagination.ts
@@ -5,7 +5,6 @@ import type { DataOptions } from './types'
  * Composable for managing table pagination
  *
  * @param options - Reactive reference to table options
- * @param itemsPerPageProp - Default items per page from props
  * @param itemsLength - Total number of items (for client-side) or serverItemsLength (for server-side)
  * @param table - Reference to the table component
  * @param emit - Emit function for update:options event
@@ -13,13 +12,11 @@ import type { DataOptions } from './types'
  */
 export function usePagination({
 	options,
-	itemsPerPageProp,
 	itemsLength,
 	table,
 	emit,
 }: {
 	options: Ref<Partial<DataOptions>>
-	itemsPerPageProp?: number
 	itemsLength: Ref<number>
 	table: Ref<unknown>
 	emit: (event: 'update:options', options: Partial<DataOptions>) => void
@@ -35,9 +32,9 @@ export function usePagination({
 		},
 	})
 
-	// Items per page with fallback to props or default
+	// Items per page with fallback to default
 	const itemsPerPageValue = computed(() => {
-		const value = options.value.itemsPerPage || itemsPerPageProp || 10
+		const value = options.value.itemsPerPage || 10
 		// If value is -1, it means "Tous" (all items)
 		return value
 	})

--- a/src/components/Tables/common/useTableHeaders.ts
+++ b/src/components/Tables/common/useTableHeaders.ts
@@ -1,0 +1,69 @@
+import { computed, type Ref } from 'vue'
+import type { DataTableHeaders, TableColumnHeader } from './types'
+
+/**
+ * Composable for processing and enhancing table headers
+ *
+ * @param headersProp - Reference to headers from props
+ * @param filterInputConfig - Configuration for filter inputs
+ * @returns Header utilities and computed properties
+ */
+export function useTableHeaders({
+	headersProp,
+	filterInputConfig = {},
+}: {
+	headersProp: Ref<DataTableHeaders[] | undefined>
+	filterInputConfig?: Record<string, unknown>
+}) {
+	// Process headers to ensure they have title property
+	const headers = computed(() => {
+		if (!Array.isArray(headersProp?.value)) {
+			return undefined
+		}
+		return headersProp.value.map(header => ({
+			...header,
+			title: header.title ?? header.text,
+		}))
+	})
+
+	// Get filterable headers
+	const filterableHeaders = computed(() => {
+		if (!headers.value) return []
+		return headers.value.filter(header => header.filterable)
+	})
+
+	/**
+   * Enhance header with filter type and configuration
+   */
+	function getEnhancedHeader(column: TableColumnHeader): TableColumnHeader {
+		// If column is not filterable, return as is
+		if (!column.filterable) return column
+
+		// Default filter type is 'text' if not specified
+		const filterType = column.filterType || 'text'
+
+		// Get column-specific filter config or empty object
+		const columnFilterConfig = column.key && filterInputConfig[column.key as string] ? filterInputConfig[column.key as string] : {}
+
+		// Return enhanced header with filter properties
+		return {
+			...(column as object),
+			filterType,
+			filterConfig: columnFilterConfig as Record<string, unknown>,
+		} as TableColumnHeader
+	}
+
+	/**
+   * Get header by key
+   */
+	function getHeaderByKey(key: string): TableColumnHeader | undefined {
+		return headers.value?.find(header => header.key === key)
+	}
+
+	return {
+		headers,
+		filterableHeaders,
+		getEnhancedHeader,
+		getHeaderByKey,
+	}
+}

--- a/src/components/Tables/common/useTableItems.ts
+++ b/src/components/Tables/common/useTableItems.ts
@@ -1,0 +1,87 @@
+import { computed, type Ref } from 'vue'
+import { processItems } from './formatters'
+import type { DataOptions, FilterOption, TableColumnHeader } from './types'
+
+/**
+ * Composable for handling table items processing
+ *
+ * @param items - Reference to table items
+ * @param headers - Reference to table headers
+ * @param filters - Reference to active filters
+ * @param options - Reference to table options
+ * @param filterItems - Function to filter items (from useTableFilter)
+ * @returns Item utilities and computed properties
+ */
+export function useTableItems({
+	items,
+	headers,
+	filters,
+	options,
+	filterItems,
+}: {
+	items: Ref<Record<string, unknown>[]>
+	headers: Ref<TableColumnHeader[] | undefined>
+	filters: Ref<FilterOption[]>
+	options: Ref<Partial<DataOptions>>
+	filterItems: <T extends Record<string, unknown>>(items: T[], filters: FilterOption[]) => T[]
+}) {
+	// Process items with formatters based on headers
+	const processedItems = computed(() => {
+		if (!headers.value) return items.value
+		// Just return the items as is since we can't process them with headers
+		return processItems(items.value)
+	})
+
+	// Filter items based on active filters
+	const filteredItems = computed(() => {
+		// Create a deep copy of items to avoid modifying originals
+		const itemsCopy = processedItems.value.map((item) => {
+			return JSON.parse(JSON.stringify(item))
+		})
+
+		// Apply filters to copied items
+		return filterItems(itemsCopy, filters.value)
+	})
+
+	// Apply pagination to filtered items
+	const paginatedItems = computed(() => {
+		if (!filteredItems.value.length) return []
+
+		const page = options.value.page || 1
+		const itemsPerPage = options.value.itemsPerPage || 10
+
+		// If itemsPerPage is -1 ("Tous"), return all items
+		if (itemsPerPage === -1) return filteredItems.value
+
+		const start = (page - 1) * itemsPerPage
+		const end = start + itemsPerPage
+
+		return filteredItems.value.slice(start, end)
+	})
+
+	/**
+   * Create an empty item that maintains the structure of columns
+   * Useful for displaying empty state with correct column structure
+   */
+	function createEmptyItemWithStructure(): Record<string, unknown>[] {
+		if (!headers.value || !headers.value.length) return []
+
+		const emptyItem: Record<string, unknown> = {}
+
+		// Create an empty object with all header keys
+		headers.value.forEach((header) => {
+			if (header.key) {
+				emptyItem[header.key] = ''
+			}
+		})
+
+		return [emptyItem]
+	}
+
+	return {
+		processedItems,
+		filteredItems,
+		paginatedItems,
+		createEmptyItemWithStructure,
+	}
+}

--- a/src/components/Tables/common/useTableOptions.ts
+++ b/src/components/Tables/common/useTableOptions.ts
@@ -19,6 +19,7 @@ export function useTableOptions({
 			options.value = {
 				...options.value,
 				filters: newFilters,
+				page: 1, // reset
 			}
 		},
 	})

--- a/src/components/Tables/common/useTableOptions.ts
+++ b/src/components/Tables/common/useTableOptions.ts
@@ -1,0 +1,92 @@
+import { computed, type Ref } from 'vue'
+import type { DataOptions, FilterOption } from './types'
+
+/**
+ * Composable for managing table options and filters
+ *
+ * @param options - Reactive reference to table options
+ * @returns Table options utilities and computed properties
+ */
+export function useTableOptions({
+	options,
+}: {
+	options: Ref<Partial<DataOptions>>
+}) {
+	// Computed for filters with getter/setter
+	const filters = computed({
+		get: () => options.value.filters || [],
+		set: (newFilters: FilterOption[]) => {
+			options.value = {
+				...options.value,
+				filters: newFilters,
+			}
+		},
+	})
+
+	// Computed for sorting options
+	const sortBy = computed({
+		get: () => options.value.sortBy || [],
+		set: (newSortBy) => {
+			options.value = {
+				...options.value,
+				sortBy: newSortBy,
+			}
+		},
+	})
+
+	/**
+   * Update options with new values
+   */
+	function updateOptions(newOptions: Partial<DataOptions>) {
+		options.value = {
+			...options.value,
+			...newOptions,
+		}
+	}
+
+	/**
+   * Reset filters to empty array
+   */
+	function resetFilters() {
+		options.value = {
+			...options.value,
+			filters: [],
+			page: 1, // Reset to first page when clearing filters
+		}
+	}
+
+	/**
+   * Update a specific filter or add it if it doesn't exist
+   */
+	function updateFilter(filter: FilterOption) {
+		const currentFilters = [...filters.value]
+		const existingFilterIndex = currentFilters.findIndex(f => f.key === filter.key)
+
+		if (existingFilterIndex >= 0) {
+			// Update existing filter
+			currentFilters[existingFilterIndex] = filter
+		}
+		else {
+			// Add new filter
+			currentFilters.push(filter)
+		}
+
+		filters.value = currentFilters
+	}
+
+	/**
+   * Remove a filter by key
+   */
+	function removeFilter(key: string) {
+		filters.value = filters.value.filter(f => f.key !== key)
+	}
+
+	return {
+		filters,
+		sortBy,
+		updateOptions,
+		resetFilters,
+		updateFilter,
+		removeFilter,
+	}
+}


### PR DESCRIPTION
Basé sur https://design-system.w3.org/components/pagination.html

Si besoin d’une pagination celle-ci comporte deux éléments :
-	La navigation sera assurée par un composant avec le role="group" ayant un titre accessible : « Pagination – 1 à {n} pages » qui contrôlera le tableau. Il comporte une liste restreinte de n° de page et des boutons permettant d’accéder à l’exhaustivité des n° de pages
-	Une liste de nombre de lignes attendus par page contrôle le composant de navigation en déterminant le nombre de page maximales de la navigation
- La navigation est masquée s’il n’y a qu’une page à afficher.
En cas de filtrage du tableau, le calcul du nombre de page est rafraichi avec le composant de navigation. 