### PR TITLE
fix handleBlur in dateTextInput

### DIFF
--- a/src/components/DatePicker/DateTextInput/DateTextInput.vue
+++ b/src/components/DatePicker/DateTextInput/DateTextInput.vue
@@ -725,11 +725,21 @@
 		hasInteracted.value = true
 
 		// Vérifier si la valeur est vide
-		if (!inputValue.value) {
-			emit('update:model-value', null)
-			validateRules('')
-			emit('blur')
-			return
+		if (inputValue.value) {
+			const validation = validateDateFormat(inputValue.value)
+			if (validation.isValid) {
+				// Si le format est valide, la date est également valide grâce à notre correction dans useDateFormatValidation
+				const formattedDate = props.dateFormatReturn
+					? dayjs(inputValue.value, props.format).format(props.dateFormatReturn)
+					: inputValue.value
+				emit('update:model-value', formattedDate)
+			}
+			else {
+				// Si le format n'est pas valide ou si la date est invalide, ajouter le message d'erreur
+				clearValidation()
+				errors.value.push(validation.message)
+				emit('update:model-value', props.modelValue)
+			}
 		}
 
 		// Appliquer l'auto-clamping au moment du blur si activé

--- a/src/components/DatePicker/DateTextInput/DateTextInput.vue
+++ b/src/components/DatePicker/DateTextInput/DateTextInput.vue
@@ -917,6 +917,7 @@
 		if (errors.value.length === 0) {
 			validateRules(inputValue.value || '')
 		}
+		emit('blur')
 	}
 
 	const isValidating = ref(false)


### PR DESCRIPTION
Fix du pb de gestion d'etat a la perte de focus sur le dp


Pour tester: 
- aller sur la page: https://deploy-preview-749--synapse-dev.netlify.app/?path=/story/composants-formulaires-datepicker-dateinput--default
- Saisir 33/12/2024
- sortir du focus , le champs doit tjs etre en erreur
