### PR TITLE
DialogBox Props autofocusValidateBtn

### DIFF
--- a/src/components/DialogBox/DialogBox.stories.ts
+++ b/src/components/DialogBox/DialogBox.stories.ts
@@ -101,6 +101,18 @@ const meta: Meta<typeof DialogBox> = {
 				},
 			},
 		},
+		'autofocusValidateBtn': {
+			control: 'boolean',
+			description: 'Focus automatique sur le bouton de validation à l\'ouverture',
+			table: {
+				type: {
+					summary: 'boolean',
+				},
+				defaultValue: {
+					summary: 'false',
+				},
+			},
+		},
 		'vuetifyOptions': {
 			control: 'object',
 			description: 'Personnalisation des composants Vuetify internes',

--- a/src/components/DialogBox/DialogBox.vue
+++ b/src/components/DialogBox/DialogBox.vue
@@ -185,6 +185,7 @@
 							v-bind="options.confirmBtn"
 							ref="confirmBtn"
 							class="sy-dialog-box-confirm-btn"
+							:class="props.autofocusValidateBtn ? 'sy-dialog-box-confirm-btn--autofocus' : ''"
 							data-test-id="confirm-btn"
 							@click="$emit('confirm')"
 						>
@@ -217,7 +218,8 @@ h2 {
 
 .sy-dialog-box-close-btn:focus-visible,
 .sy-dialog-box-cancel-btn:focus-visible,
-.sy-dialog-box-confirm-btn:focus-visible {
+.sy-dialog-box-confirm-btn:focus-visible,
+.sy-dialog-box-confirm-btn--autofocus:focus {
 	:deep(.v-btn__overlay) {
 		display: none;
 	}
@@ -226,12 +228,6 @@ h2 {
 		opacity: 1;
 		border: transparent;
 		outline: 2px solid rgb(var(--v-theme-primary));
-		outline-offset: 2px;
-	}
-}
-
-.sy-dialog-box-confirm-btn:focus-visible {
-	&::after {
 		outline-offset: 2px;
 	}
 }

--- a/src/components/DialogBox/DialogBox.vue
+++ b/src/components/DialogBox/DialogBox.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 	import useCustomizableOptions, { type CustomizableOptions } from '@/composables/useCustomizableOptions'
 	import { mdiClose } from '@mdi/js'
-	import { ref, useId, watch } from 'vue'
-	import type { VDialog } from 'vuetify/components'
+	import { ref, useId, watch, nextTick } from 'vue'
+	import type { VBtn, VDialog } from 'vuetify/components'
 	import { config } from './config'
 	import { locales } from './locales'
 	import { useDisplay } from 'vuetify/lib/framework.mjs'
@@ -15,6 +15,7 @@
 		confirmBtnText?: string
 		hideActions?: boolean
 		persistent?: boolean
+		autofocusValidateBtn?: boolean
 	} & CustomizableOptions>(), {
 		title: undefined,
 		width: '800px',
@@ -22,6 +23,7 @@
 		confirmBtnText: locales.confirmBtn,
 		hideActions: false,
 		persistent: false,
+		autofocusValidateBtn: false,
 	})
 
 	defineEmits(['cancel', 'confirm', 'update:modelValue'])
@@ -35,16 +37,22 @@
 		default: false,
 	})
 
+	const confirmBtn = ref<VBtn | null>(null)
 	// Restor the focus to the last active element when the dialog is closed
 	let activeElement: HTMLElement | null = null
 	watch(dialog, (newValue) => {
 		if (newValue) {
 			activeElement = document.activeElement as HTMLElement
+			if (props.autofocusValidateBtn) {
+				nextTick(() => {
+					confirmBtn.value?.$el.focus()
+				})
+			}
 		}
 		else if (activeElement) {
 			activeElement.focus()
 		}
-	})
+	}, { immediate: true })
 
 	const id = `dialog-${useId()}`
 	const dialogContent = ref<VDialog | undefined>(undefined)
@@ -177,6 +185,7 @@
 							class="sy-dialog-box-confirm-btn"
 							v-bind="options.confirmBtn"
 							data-test-id="confirm-btn"
+							ref="confirmBtn"
 							@click="$emit('confirm')"
 						>
 							{{ props.confirmBtnText }}

--- a/src/components/DialogBox/DialogBox.vue
+++ b/src/components/DialogBox/DialogBox.vue
@@ -182,10 +182,10 @@
 						</VBtn>
 
 						<VBtn
-							class="sy-dialog-box-confirm-btn"
 							v-bind="options.confirmBtn"
-							data-test-id="confirm-btn"
 							ref="confirmBtn"
+							class="sy-dialog-box-confirm-btn"
+							data-test-id="confirm-btn"
 							@click="$emit('confirm')"
 						>
 							{{ props.confirmBtnText }}

--- a/src/components/DialogBox/tests/DialogBox.spec.ts
+++ b/src/components/DialogBox/tests/DialogBox.spec.ts
@@ -348,4 +348,26 @@ describe('DialogBox', () => {
 			expect(result).toEqual([])
 		})
 	})
+
+	it('focus the confirm button on open if autofocusValidateBtn is true', async () => {
+		const wrapper = mount(DialogBox, {
+			props: {
+				...defaultProps,
+				autofocusValidateBtn: true,
+			},
+			global: {
+				plugins: [vuetify],
+			},
+			attachTo: document.body,
+		})
+
+		const modal = wrapper.getComponent(VCard)
+
+		const confirmBtn = modal.find('[data-test-id="confirm-btn"]')
+
+		await wrapper.vm.$nextTick()
+
+		expect(confirmBtn.element).toEqual(document.activeElement)
+		wrapper.unmount()
+	})
 })


### PR DESCRIPTION
## Description

Ajout d'une props pour mettre le focus automatiquement sur le boutton de validation


## Type de changement

<!-- Supprimez les options non pertinentes. -->

- Nouvelle fonctionnalité


## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Le composant est conforme aux maquettes (tokens)
- [x] Le composant est fonctionnel
- [x] Le composant est responsive (mobile, tablet et desktop)
- [x] Le composant répond aux critères d'accessibilité (test Tanaguru + A11y linter)
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai mis en place une stories pour ma fonctionnalité / fix /...
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
