### PR TITLE
SySelect focus on clear

### DIFF
--- a/src/components/Customs/Selects/SyBtnSelect/SyBtnSelect.stories.ts
+++ b/src/components/Customs/Selects/SyBtnSelect/SyBtnSelect.stories.ts
@@ -48,7 +48,7 @@ export const Default: Story = {
 				name: 'Script',
 				code: `
 <script setup lang="ts">
-import SyBtnSelect from './SyBtnSelect.vue'
+import { SyBtnSelect } from '@cnamts/synapse'
 
 const primaryInfo = 'Mes options'
 const items = [
@@ -105,7 +105,7 @@ export const MobileView: Story = {
 				name: 'Script',
 				code: `
 <script setup lang="ts">
-import SyBtnSelect from './SyBtnSelect.vue'
+import { SyBtnSelect } from '@cnamts/synapse'
 
 const primaryInfo = 'Mes options'
 const items = ['Option 1', 'Option 2']
@@ -156,7 +156,7 @@ export const WithSlotPrependIcon: Story = {
 				name: 'Script',
 				code: `
 <script setup lang="ts">
-import SyBtnSelect from './SyBtnSelect.vue'
+import { SyBtnSelect } from '@cnamts/synapse'
 import { mdiAccount } from '@mdi/js'
 
 const primaryInfo = 'Jane Doe'
@@ -214,7 +214,7 @@ export const WithSlotAppendIcon: Story = {
 				name: 'Script',
 				code: `
 <script setup lang="ts">
-import SyBtnSelect from './SyBtnSelect.vue'
+import { SyBtnSelect } from '@cnamts/synapse'
 import { mdiAccount } from '@mdi/js'
 
 const primaryInfo = 'Jane Doe'
@@ -270,7 +270,7 @@ export const WithIconOnly: Story = {
 				name: 'Script',
 				code: `
 <script setup lang="ts">
-import SyBtnSelect from './SyBtnSelect.vue'
+import { SyBtnSelect } from '@cnamts/synapse'
 import { mdiAccount } from '@mdi/js'
 
 const primaryInfo = 'Jane Doe'
@@ -328,7 +328,7 @@ export const WithLogoutItemSlot: Story = {
 				name: 'Script',
 				code: `
 <script setup lang="ts">
-import SyBtnSelect from './SyBtnSelect.vue'
+import { SyBtnSelect } from '@cnamts/synapse'
 
 const primaryInfo = 'Mes options'
 const items = ['Option 1', 'Option 2']
@@ -385,7 +385,7 @@ export const WithCustomKeys: Story = {
 				name: 'Script',
 				code: `
 <script setup lang="ts">
-import SyBtnSelect from './SyBtnSelect.vue'
+import { SyBtnSelect } from '@cnamts/synapse'
 import { mdiAccount } from '@mdi/js'
 
 const primaryInfo = 'Information principale'
@@ -454,7 +454,7 @@ export const WithMultipleSlots: Story = {
 				name: 'Script',
 				code: `
 <script setup lang="ts">
-import SyBtnSelect from './SyBtnSelect.vue'
+import { SyBtnSelect } from '@cnamts/synapse'
 import { mdiAccount } from '@mdi/js'
 
 const primaryInfo = 'Information principale'
@@ -517,7 +517,7 @@ export const WithCustomStyles: Story = {
 				name: 'Script',
 				code: `
 <script setup lang="ts">
-import SyBtnSelect from './SyBtnSelect.vue'
+import { SyBtnSelect } from '@cnamts/synapse'
 import { mdiAccount } from '@mdi/js'
 
 const primaryInfo = 'Jane Doe'
@@ -577,7 +577,7 @@ export const WithStyledOptions: Story = {
 				name: 'Script',
 				code: `
 <script setup lang="ts">
-import SyBtnSelect from './SyBtnSelect.vue'
+import { SyBtnSelect } from '@cnamts/synapse'
 import { mdiAccount } from '@mdi/js'
 
 const primaryInfo = 'Information principale'

--- a/src/components/Customs/Selects/SySelect/SySelect.stories.ts
+++ b/src/components/Customs/Selects/SySelect/SySelect.stories.ts
@@ -91,7 +91,7 @@ export const Default: Story = {
 				name: 'Script',
 				code: `
 				<script setup lang="ts">
-					import SySelect from '@cnamts/SySelect'
+					import { SySelect } from '@cnamts/synapse'
 					
 					const items =  [
 						{ text: 'Adrien', value: 'Adrien' },
@@ -162,7 +162,7 @@ export const HelpText: Story = {
 				name: 'Script',
 				code: `
 				<script setup lang="ts">
-					import SySelect from '@cnamts/SySelect'
+					import { SySelect } from '@cnamts/synapse'
 					
 					const items =  [
 						{ text: 'Adrien', value: 'Adrien' },
@@ -237,7 +237,7 @@ export const Required: Story = {
 				name: 'Script',
 				code: `
 				<script setup lang="ts">
-					import SySelect from '@cnamts/SySelect'
+					import { SySelect } from '@cnamts/synapse'
 					
 					const items =  [
 						{ text: 'Option 1', value: '1' },
@@ -526,7 +526,7 @@ export const withCustomError: Story = {
 				name: 'Script',
 				code: `
 				<script setup lang="ts">
-					import SySelect from '@cnamts/SySelect'
+					import { SySelect } from '@cnamts/synapse'
 					import { ref } from 'vue'
 					
 					const items =  [
@@ -598,7 +598,7 @@ export const withCustomKey: Story = {
 				name: 'Script',
 				code: `
 					<script setup lang="ts">
-						import SySelect from '@cnamts/SySelect'
+						import { SySelect } from '@cnamts/synapse'
 						
 						const items =  [
 							{ customKey: 'Choix 1', value: '1' },

--- a/src/components/Customs/Selects/SySelect/SySelect.vue
+++ b/src/components/Customs/Selects/SySelect/SySelect.vue
@@ -880,7 +880,7 @@
 				v-if="props.clearable && selectedItemText"
 				type="button"
 				class="sy-select__clear-button"
-				:style="{ right: hasError ? '38px' : '32px' }"
+				:style="{ right: hasError ? '62px' : '42px' }"
 				:aria-label="locales.clear"
 				@keydown.enter.prevent="$event => selectItem(null, $event)"
 				@keydown.space.prevent="$event => selectItem(null, $event)"
@@ -1065,7 +1065,11 @@
 	justify-content: center;
 	top: 50%;
 	transform: translateY(-50%);
-	right: 10px;
+	right: 20px;
+
+	.v-icon {
+		position: static;
+	}
 }
 
 .v-chip {

--- a/src/components/Customs/Selects/SySelect/SySelect.vue
+++ b/src/components/Customs/Selects/SySelect/SySelect.vue
@@ -7,7 +7,7 @@
 	import { ref, watch, onMounted, onUnmounted, computed, nextTick, type PropType } from 'vue'
 	import { useSySelectKeyboard } from './composables/useSySelectKeyboard'
 	import { vRgaaSvgFix } from '../../../../directives/rgaaSvgFix'
-	import type { VTextField } from 'vuetify/components'
+	import type { VList, VTextField } from 'vuetify/components'
 	import { VChip } from 'vuetify/components'
 	import SyCheckbox from '@/components/Customs/SyCheckbox/SyCheckbox.vue'
 	import SyIcon from '@/components/Customs/SyIcon/SyIcon.vue'
@@ -135,6 +135,7 @@
 
 	const labelWidth = ref(0)
 	const labelRef = ref<HTMLElement | null>(null)
+	const list = ref<VList | null>(null)
 
 	const toggleMenu = (skipInitialFocus = false) => {
 		if (props.readonly) return
@@ -160,7 +161,7 @@
 	const closeList = (event?: Event) => {
 		// Check if the click is inside the dropdown list
 		const target = event?.target as HTMLElement
-		const listElement = document.querySelector('.v-list')
+		const listElement = list.value?.$el
 
 		// In multiple selection mode, don't close the dropdown when clicking on list items
 		if (props.multiple && listElement && listElement.contains(target)) {
@@ -222,7 +223,7 @@
 				// S'assurer que le focus DOM revient à l'input et restaurer le focus visuel
 				nextTick(() => {
 					// Focus DOM sur l'input
-					const inputElement = document.querySelector('.v-field__input')
+					const inputElement = input.value!.$el.querySelector('input')
 					if (inputElement) {
 						(inputElement as HTMLInputElement).focus()
 					}
@@ -905,6 +906,7 @@
 	<VList
 		v-if="isOpen"
 		:id="uniqueMenuId"
+		ref="list"
 		class="v-list"
 		role="listbox"
 		:aria-multiselectable="props.multiple ? 'true' : undefined"

--- a/src/components/Customs/Selects/SySelect/SySelect.vue
+++ b/src/components/Customs/Selects/SySelect/SySelect.vue
@@ -175,8 +175,8 @@
 	const uniqueMenuId = ref(props.menuId === 'sy-select-menu' ? `sy-select-menu-${Math.random().toString(36).substring(7)}` : props.menuId)
 	const listStyles = ref<Record<string, string>>({})
 	const updateListPosition = () => {
-		if (input.value?.$el) {
-			const rect = input.value.$el.getBoundingClientRect()
+		if (textInput.value?.$el) {
+			const rect = textInput.value.$el.getBoundingClientRect()
 			listStyles.value = {
 				position: 'fixed',
 				top: props.density === 'compact' ? `${rect.bottom + 22}px` : `${rect.bottom}px`,
@@ -223,7 +223,7 @@
 				// S'assurer que le focus DOM revient à l'input et restaurer le focus visuel
 				nextTick(() => {
 					// Focus DOM sur l'input
-					const inputElement = input.value!.$el.querySelector('input')
+					const inputElement = textInput.value!.$el.querySelector('input')
 					if (inputElement) {
 						(inputElement as HTMLInputElement).focus()
 					}
@@ -388,7 +388,7 @@
 		return (props.required || props.errorMessages.length > 0) && !selectedItem.value
 	})
 
-	const input = ref<InstanceType<typeof VTextField> | null>(null)
+	const textInput = ref<InstanceType<typeof VTextField> | null>(null)
 
 	// Détecte s'il y a des messages d'erreur, de succès ou d'avertissement
 	const hasMessages = computed(() => {
@@ -573,9 +573,9 @@
 
 	// Function to set up proper ARIA attributes
 	const setupAriaAttributes = () => {
-		if (input.value && input.value.$el) {
+		if (textInput.value && textInput.value.$el) {
 			// Find the input element
-			const inputElement = input.value.$el?.querySelector?.('input')
+			const inputElement = textInput.value.$el?.querySelector?.('input')
 			if (inputElement) {
 				// Remove problematic attributes that shouldn't be on input
 				inputElement.removeAttribute('aria-describedby')
@@ -607,7 +607,7 @@
 			}
 
 			// Clean up parent element - remove any conflicting attributes
-			const parentElement = input.value.$el
+			const parentElement = textInput.value.$el
 			if (parentElement) {
 				// Remove any role or ARIA attributes from parent that should be on input
 				parentElement.removeAttribute('role')
@@ -642,7 +642,7 @@
 			setupAriaAttributes()
 
 			// Set up MutationObserver to monitor attribute changes
-			if (input.value && input.value.$el) {
+			if (textInput.value && textInput.value.$el) {
 				mutationObserver = new MutationObserver((mutations) => {
 					let needsCleanup = false
 					mutations.forEach((mutation) => {
@@ -662,7 +662,7 @@
 							}
 
 							// Check if aria-hidden was added to parent
-							if (target === input.value?.$el && attributeName === 'aria-hidden') {
+							if (target === textInput.value?.$el && attributeName === 'aria-hidden') {
 								needsCleanup = true
 							}
 
@@ -683,7 +683,7 @@
 				})
 
 				// Observe both the parent element and its children
-				mutationObserver.observe(input.value.$el, {
+				mutationObserver.observe(textInput.value.$el, {
 					attributes: true,
 					subtree: true,
 					attributeFilter: ['role', 'aria-hidden', 'aria-expanded', 'aria-controls', 'aria-haspopup', 'aria-live'],
@@ -695,8 +695,8 @@
 	// Watchers to update ARIA attributes dynamically on input element
 	watch(isOpen, (newValue) => {
 		nextTick(() => {
-			if (input.value && input.value.$el) {
-				const inputElement = input.value.$el?.querySelector?.('input')
+			if (textInput.value && textInput.value.$el) {
+				const inputElement = textInput.value.$el?.querySelector?.('input')
 				if (inputElement) {
 					inputElement.setAttribute('aria-expanded', newValue ? 'true' : 'false')
 					if (newValue && activeDescendantId.value) {
@@ -712,8 +712,8 @@
 
 	watch(activeDescendantId, (newValue) => {
 		nextTick(() => {
-			if (input.value && input.value.$el && isOpen.value) {
-				const inputElement = input.value.$el?.querySelector?.('input')
+			if (textInput.value && textInput.value.$el && isOpen.value) {
+				const inputElement = textInput.value.$el?.querySelector?.('input')
 				if (inputElement) {
 					if (newValue) {
 						inputElement.setAttribute('aria-activedescendant', newValue)
@@ -728,8 +728,8 @@
 
 	watch(hasError, (newValue) => {
 		nextTick(() => {
-			if (input.value && input.value.$el) {
-				const inputElement = input.value.$el?.querySelector?.('input')
+			if (textInput.value && textInput.value.$el) {
+				const inputElement = textInput.value.$el?.querySelector?.('input')
 				if (inputElement) {
 					if (newValue) {
 						inputElement.setAttribute('aria-invalid', 'true')
@@ -746,8 +746,8 @@
 	// This prevents Vuetify from overriding our combobox attributes
 	watch(selectedItem, () => {
 		nextTick(() => {
-			if (input.value && input.value.$el) {
-				const inputElement = input.value.$el?.querySelector?.('input')
+			if (textInput.value && textInput.value.$el) {
+				const inputElement = textInput.value.$el?.querySelector?.('input')
 				if (inputElement) {
 					// Ensure combobox role is maintained on input
 					inputElement.setAttribute('role', 'combobox')
@@ -775,7 +775,7 @@
 				}
 
 				// Clean up parent element
-				const parentElement = input.value.$el
+				const parentElement = textInput.value.$el
 				if (parentElement) {
 					parentElement.removeAttribute('role')
 					parentElement.removeAttribute('aria-hidden')
@@ -808,7 +808,7 @@
 <template>
 	<VTextField
 		:id="inputId"
-		ref="input"
+		ref="textInput"
 		v-model="selectedItemText"
 		v-click-outside="closeList"
 		v-rgaa-svg-fix="true"
@@ -912,7 +912,7 @@
 		:aria-multiselectable="props.multiple ? 'true' : undefined"
 		:aria-label="$attrs['aria-label'] || labelWithAsterisk"
 		:style="{
-			minWidth: `${input?.$el.offsetWidth}px`,
+			minWidth: `${textInput?.$el.offsetWidth}px`,
 			...listStyles
 		}"
 		bg-color="white"


### PR DESCRIPTION
## Description

Le focus doit bien s'appliquer au composant lors du clear

## Stories

```
<script setup lang="ts">
	import SySelect from '@/components/Customs/Selects/SySelect/SySelect.vue'
	import DatePicker from '@/components/DatePicker/CalendarMode/DatePicker.vue'
	import { ref } from 'vue'

	const items = [
		{ text: 'Adrien', value: 'Adrien' },
		{ text: 'Axel', value: 'Axel' },
		{ text: 'Baptiste', value: 'Baptiste' },
		{ text: 'Clement', value: 'Clement' },
		{ text: 'Corentin', value: 'Corentin' },
		{ text: 'Damien', value: 'Damien' },
		{ text: 'David', value: 'David' },
		{ text: 'Eloi', value: 'Eloi' },
		{ text: 'Louis', value: 'Louis' },
		{ text: 'Valentin', value: 'Valentin' },
	]

	const date = ref<string>('')
	const value = ref<string | null>()
</script>

<template>
	<DatePicker
		v-model="date"
		placeholder="Sélectionner une date"
		use-combined-mode
		format="DD/MM/YYYY"
	/>
	<SySelect
		v-model="value"
		:items="items"
		:clearable="true"
	/>
</template>

```

## Type de changement

<!-- Supprimez les options non pertinentes. -->

- Nouvelle fonctionnalité
- Correction de bug
- Changement cassant
- Refactoring
- Maintenance
- Documentation
- Ce changement nécessite une mise à jour de la documentation

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Le composant est conforme aux maquettes (tokens)
- [x] Le composant est fonctionnel
- [x] Le composant est responsive (mobile, tablet et desktop)
- [x] Le composant répond aux critères d'accessibilité (test Tanaguru + A11y linter)
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai mis en place une stories pour ma fonctionnalité / fix /...
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
