### PR TITLE
Fix/not after date fix

### DIFF
--- a/src/components/DatePicker/docExamples/DatePickerValidationExamples.vue
+++ b/src/components/DatePicker/docExamples/DatePickerValidationExamples.vue
@@ -244,7 +244,7 @@
 						type: 'notBeforeDate',
 						options: {
 							message: 'La date ne peut pas être antérieure au 01/01/2025',
-							successMessage: 'Date valide (après le 01/01/2025)',
+							successMessage: 'Date valide (après ou le 01/01/2025)',
 							date: '01/01/2025'
 						}
 					}]"
@@ -286,7 +286,7 @@
 						type: 'notAfterDate',
 						options: {
 							message: 'La date ne peut pas être postérieure au 31/12/2025',
-							successMessage: 'Date valide (avant le 31/12/2025)',
+							successMessage: 'Date valide (avant ou le 31/12/2025)',
 							date: '31/12/2025'
 						}
 					}]"

--- a/src/composables/rules/useFieldValidation.ts
+++ b/src/composables/rules/useFieldValidation.ts
@@ -227,6 +227,10 @@ export function useFieldValidation() {
 						return { error: 'Date de référence invalide' }
 					}
 
+					// Normaliser les dates en réinitialisant les heures/minutes/secondes
+					dateValue.setHours(0, 0, 0, 0)
+					referenceDate.setHours(0, 0, 0, 0)
+
 					return createValidationResult(
 						dateValue >= referenceDate,
 						options.message || options.warningMessage || `${identifier} ne peut pas être avant le ${options.date}.`,
@@ -252,6 +256,10 @@ export function useFieldValidation() {
 					if (!referenceDate) {
 						return { error: 'Date de référence invalide' }
 					}
+
+					// Normaliser les dates en réinitialisant les heures/minutes/secondes
+					dateValue.setHours(0, 0, 0, 0)
+					referenceDate.setHours(0, 0, 0, 0)
 
 					return createValidationResult(
 						dateValue <= referenceDate,


### PR DESCRIPTION
Fix: La règle notAfterDate ne gère pas les dates égales alors que notBeforeDate le fait. 
testable ici https://deploy-preview-1239--synapse-dev.netlify.app/?path=/story/composants-formulaires-datepicker-validation--validation-examples