### PR TITLE
Ajout event "open-close" sur les blocs dépliants amelipro qui n'en av…

### DIFF
--- a/src/components/Amelipro/AmeliproAccordion/AmeliproAccordion.stories.ts
+++ b/src/components/Amelipro/AmeliproAccordion/AmeliproAccordion.stories.ts
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/vue3'
 import AmeliproAccordion from './AmeliproAccordion.vue'
+import { fn } from '@storybook/test'
 
 const meta = {
 	argTypes: {
@@ -26,10 +27,11 @@ type Story = StoryObj<typeof AmeliproAccordion>
 
 export const Default: Story = {
 	args: {
-		accordionTitle: 'Mon titre',
-		default: '[Slot: default]',
-		headerRight: '[Slot: headerRight]',
-		uniqueId: 'amelipro-accordion-unique-id',
+		'accordionTitle': 'Mon titre',
+		'default': '[Slot: default]',
+		'headerRight': '[Slot: headerRight]',
+		'uniqueId': 'amelipro-accordion-unique-id',
+		'onOpen-close': fn(),
 	},
 	parameters: {
 		sourceCode: [
@@ -69,6 +71,7 @@ export const Default: Story = {
 <AmeliproAccordion
 	class="w-100"
 	v-bind="args"
+	@open-close="args['onOpen-close']"
 >
 	<template #default>
 		{{ args.default }}

--- a/src/components/Amelipro/AmeliproAccordion/AmeliproAccordion.vue
+++ b/src/components/Amelipro/AmeliproAccordion/AmeliproAccordion.vue
@@ -45,10 +45,12 @@
 		},
 	})
 
+	const emit = defineEmits(['open-close'])
 	const opened = ref(props.isOpen)
 
 	const openClose = (): void => {
 		opened.value = !opened.value
+		emit('open-close', props.uniqueId, opened.value)
 	}
 
 	// Rendre publique la méthode openClose permet à un bouton ou à un composant externe de fermer/ouvrir l'accordéon

--- a/src/components/Amelipro/AmeliproAccordionList/AmeliproAccordionList.stories.ts
+++ b/src/components/Amelipro/AmeliproAccordionList/AmeliproAccordionList.stories.ts
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/vue3'
 import AmeliproAccordionList from './AmeliproAccordionList.vue'
 import type { IDataListItem } from '../types'
 import { computed, ref } from 'vue'
+import { fn } from '@storybook/test'
 
 const meta = {
 	argTypes: {
@@ -158,8 +159,9 @@ export const Default: Story = {
 	name: 'Par défaut',
 	args: {
 		items,
-		title: 'Exemple de liste de résultats',
-		uniqueId: 'amelipro-accordion-list-unique-id',
+		'title': 'Exemple de liste de résultats',
+		'uniqueId': 'amelipro-accordion-list-unique-id',
+		'onOpen-close': fn(),
 	},
 	parameters: {
 		sourceCode: [
@@ -289,6 +291,7 @@ export const Default: Story = {
 		template: `
 	<AmeliproAccordionList
 		v-bind="args"
+		@open-close="args['onOpen-close']"
 	>
 		<template #headingContent="item">
 			<p class="mb-0">

--- a/src/components/Amelipro/AmeliproAccordionList/AmeliproAccordionList.vue
+++ b/src/components/Amelipro/AmeliproAccordionList/AmeliproAccordionList.vue
@@ -130,8 +130,10 @@
 		}
 	})
 
+	const emit = defineEmits(['click', 'change:sort-select', 'change:pagination-select', 'open-close'])
 	const openClose = (id: number): void => {
 		openId.value = openId.value === String(id) ? null : String(id)
+		emit('open-close', id, openId.value)
 	}
 
 	const hideSelectLabel = (): void => {
@@ -141,7 +143,6 @@
 		}
 	}
 
-	const emit = defineEmits(['click', 'change:sort-select', 'change:pagination-select'])
 	const emitClickEvent = (newCurrentPage: number): void => {
 		emit('click')
 		if (newCurrentPage !== null && newCurrentPage !== undefined) {

--- a/src/components/Amelipro/AmeliproAccordionResult/AmeliproAccordionResult.stories.ts
+++ b/src/components/Amelipro/AmeliproAccordionResult/AmeliproAccordionResult.stories.ts
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/vue3'
 import AmeliproAccordionResult from './AmeliproAccordionResult.vue'
+import { fn } from '@storybook/test'
 
 const meta = {
 	argTypes: {
@@ -21,9 +22,10 @@ type Story = StoryObj<typeof AmeliproAccordionResult>
 
 export const Default: Story = {
 	args: {
-		accordionContent: '[Slot: accordionContent]',
-		headingContent: '[Slot: headingContent]',
-		uniqueId: 'amelipro-accordion-result-unique-id',
+		'accordionContent': '[Slot: accordionContent]',
+		'headingContent': '[Slot: headingContent]',
+		'uniqueId': 'amelipro-accordion-result-unique-id',
+		'onOpen-close': fn(),
 	},
 	parameters: {
 		sourceCode: [
@@ -55,6 +57,7 @@ export const Default: Story = {
 <AmeliproAccordionResult
 	class="w-100"
 	v-bind="args"
+	@open-close="args['onOpen-close']"
 >
 	<template #headingContent>
 		[Slot: headingContent]

--- a/src/components/Amelipro/AmeliproAccordionResult/AmeliproAccordionResult.vue
+++ b/src/components/Amelipro/AmeliproAccordionResult/AmeliproAccordionResult.vue
@@ -29,10 +29,12 @@
 		},
 	})
 
+	const emit = defineEmits(['open-close'])
 	const opened = ref(props.isOpen)
 
 	const openClose = (): void => {
 		opened.value = !opened.value
+		emit('open-close', props.uniqueId, opened.value)
 	}
 
 	// Rendre publique la méthode openClose permet à un bouton ou à un composant externe de fermer/ouvrir l'accordéon

--- a/src/components/Amelipro/AmeliproAccordionResultList/AmeliproAccordionResultList.stories.ts
+++ b/src/components/Amelipro/AmeliproAccordionResultList/AmeliproAccordionResultList.stories.ts
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/vue3'
 import AmeliproAccordionResultList from './AmeliproAccordionResultList.vue'
 import type { IDataListItem } from '../types'
 import { computed, ref } from 'vue'
+import { fn } from '@storybook/test'
 
 const meta = {
 	argTypes: {
@@ -143,8 +144,9 @@ const items: IDataListItem[] = [
 export const Default: Story = {
 	args: {
 		items,
-		title: 'Exemple de liste de résultats',
-		uniqueId: 'amelipro-accordion-result-list-unique-id',
+		'title': 'Exemple de liste de résultats',
+		'uniqueId': 'amelipro-accordion-result-list-unique-id',
+		'onOpen-close': fn(),
 	},
 	parameters: {
 		sourceCode: [
@@ -261,6 +263,7 @@ export const Default: Story = {
 		template: `
 	<AmeliproAccordionResultList
 		v-bind="args"
+		@open-close="args['onOpen-close']"
 	>
 		<template #headingContent="item">
 			<p class="mb-0">

--- a/src/components/Amelipro/AmeliproAccordionResultList/AmeliproAccordionResultList.vue
+++ b/src/components/Amelipro/AmeliproAccordionResultList/AmeliproAccordionResultList.vue
@@ -122,8 +122,10 @@
 		}
 	})
 
+	const emit = defineEmits(['click', 'change:sort-select', 'change:pagination-select', 'open-close'])
 	const openClose = (id: number): void => {
 		openId.value = openId.value === String(id) ? null : String(id)
+		emit('open-close', id, openId.value)
 	}
 
 	const hideSelectLabel = (): void => {
@@ -133,7 +135,6 @@
 		}
 	}
 
-	const emit = defineEmits(['click', 'change:sort-select', 'change:pagination-select', 'open-close'])
 	const emitClickEvent = (newCurrentPage: number): void => {
 		emit('click')
 		if (newCurrentPage !== null && newCurrentPage !== undefined) {


### PR DESCRIPTION
…aient pas

## Description

 **AmeliproAccordion**, **AmeliproAccordionResult**, **AmeliproAccordionList** et **AmeliproAccordionResultList** : Ajout d'un événement `open-close`

## Stories

#1296 

## Type de changement

- Nouvelle fonctionnalité
- Documentation
- Ce changement nécessite une mise à jour de la documentation

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Le composant est conforme aux maquettes (tokens)
- [x] Le composant est fonctionnel
- [x] Le composant est responsive (mobile, tablet et desktop)
- [ ] Le composant répond aux critères d'accessibilité (test Tanaguru + A11y linter)
- [x] J'ai effectué une review de mon propre code
- [ ] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai mis en place une stories pour ma fonctionnalité / fix /...
- [x] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications
