### PR TITLE
RatingPicker ajout des evenements claviers manquant

### DIFF
--- a/src/components/RatingPicker/EmotionPicker/EmotionPicker.vue
+++ b/src/components/RatingPicker/EmotionPicker/EmotionPicker.vue
@@ -156,6 +156,8 @@
 				@keyup.space="emitInputEvent(index); setFocus(index - 1)"
 				@keyup.right="focusNextElement(index - 1)"
 				@keyup.left="focusPrevElement(index - 1)"
+				@keyup.up="focusPrevElement(index - 1)"
+				@keyup.down="focusNextElement(index - 1)"
 			>
 				<SyIcon
 					:icon="getIcon(index - 1)"

--- a/src/components/RatingPicker/NumberPicker/NumberPicker.vue
+++ b/src/components/RatingPicker/NumberPicker/NumberPicker.vue
@@ -131,6 +131,8 @@
 						@keyup.space="emitInputEvent(index); setFocus(index - 1)"
 						@keyup.right="focusNextElement(index - 1)"
 						@keyup.left="focusPrevElement(index - 1)"
+						@keyup.up="focusPrevElement(index - 1)"
+						@keyup.down="focusNextElement(index - 1)"
 					>
 						{{ index }}
 					</div>

--- a/src/components/RatingPicker/StarsPicker/StarsPicker.vue
+++ b/src/components/RatingPicker/StarsPicker/StarsPicker.vue
@@ -104,6 +104,8 @@
 				@keyup.space="emitInputEvent(index); setFocus(index - 1)"
 				@keyup.right="focusNextElement(index - 1)"
 				@keyup.left="focusPrevElement(index - 1)"
+				@keyup.up="focusPrevElement(index - 1)"
+				@keyup.down="focusNextElement(index - 1)"
 			>
 				<span class="d-sr-only">{{ locales.etoiles(index) }}</span>
 				<SyIcon


### PR DESCRIPTION
la navigation dans les items du rating picker peut se faire avec les flèche gauche et droite, cette PR ajoute les flèches haut et bas afin d'être plus proche du patterne [W3C](https://www.w3.org/WAI/ARIA/apg/patterns/radio/examples/radio/)