### PR TITLE
SyTabs : add tab-prepend and tab-append slots

### DIFF
--- a/src/components/Customs/SyTabs/SyTabs.stories.ts
+++ b/src/components/Customs/SyTabs/SyTabs.stories.ts
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/vue3'
 
 import SyTabs from './SyTabs.vue'
 import { ref } from 'vue'
+import { mdiHome } from '@mdi/js'
 
 // Plus d'informations sur la configuration de Storybook pour Vue:
 // https://storybook.js.org/docs/vue/writing-stories/introduction
@@ -165,7 +166,173 @@ const items = [
 }
 
 /**
- * Exemple avec slots personnalisés pour le contenu des onglets.
+ * Exemple avec slot tabs prepend
+ */
+export const WithTabsPrependSlot: Story = {
+	render: args => ({
+		components: { SyTabs },
+		setup() {
+			return { args }
+		},
+		template: `
+      <SyTabs :items="args.items">
+        <template #tabs-prepend>
+            <div class="p-4 bg-info-light rounded">
+              <p class="mr-4">Tabs prepend content</p>
+            </div>
+        </template>
+      </SyTabs>
+    `,
+	}),
+	parameters: {
+		sourceCode: [
+			{
+				name: 'Template',
+				code: ` 
+              <SyTabs :items="args.items">
+        <template #tabs-prepend>
+            <div class="p-4 bg-info-light rounded">
+                <p class="mr-4">Tabs prepend content</p>
+            </div>
+        </template>
+      </SyTabs>
+      `,
+			},
+		],
+	},
+}
+
+/**
+ * Exemple avec slot tabs append
+ */
+export const WithTabsAppendSlot: Story = {
+	render: args => ({
+		components: { SyTabs },
+		setup() {
+			return { args }
+		},
+		template: `
+      <SyTabs :items="args.items">
+        <template #tabs-append>
+            <div class="p-4 bg-info-light rounded">
+              <p class="mr-4">Tabs append content</p>
+            </div>
+        </template>
+      </SyTabs>
+    `,
+	}),
+	parameters: {
+		sourceCode: [
+			{
+				name: 'Template',
+				code: ` 
+              <SyTabs :items="args.items">
+        <template #tabs-append>
+            <div class="p-4 bg-info-light rounded">
+                <p class="mr-4">Tabs append content</p>
+            </div>
+        </template>
+      </SyTabs>
+      `,
+			},
+		],
+	},
+}
+
+/**
+ * Exemple avec slot tab prepend
+ */
+export const WithTabPrependSlot: Story = {
+	render: args => ({
+		components: { SyTabs },
+		setup() {
+			return { args, mdiHome }
+		},
+		template: `
+      <SyTabs :items="args.items">
+        <template #tab-prepend="{ item, index, isActive }">
+          <VIcon
+              v-if="index === 0"
+              class="mr-2"
+              :color="isActive ? 'primary' : 'grey'"
+              :icon="mdiHome"
+          />
+        </template>
+
+      </SyTabs>
+    `,
+	}),
+	parameters: {
+		sourceCode: [
+			{
+				name: 'Template',
+				code: ` 
+              <SyTabs :items="args.items">
+        <template #tab-prepend="{ item, index, isActive }">
+          <VIcon
+              v-if="index === 0"
+              class="mr-2"
+              :color="isActive ? 'primary' : 'grey'"
+              :icon="mdiHome"
+          />
+        </template>
+      </SyTabs>
+      `,
+				script: `
+<script setup>
+import { mdiHome } from '@mdi/js'
+</script>
+                `,
+			},
+		],
+	},
+}
+
+/**
+ * Exemple avec slot tab append
+ */
+export const WithTabAppendSlot: Story = {
+	render: args => ({
+		components: { SyTabs },
+		setup() {
+			return { args, mdiHome }
+		},
+		template: `
+      <SyTabs :items="args.items">
+        <template #tab-append="{ item, index, isActive }">
+          <VIcon
+              v-if="index === 0"
+              class="ml-2"
+              :color="isActive ? 'primary' : 'grey'"
+              :icon="mdiHome"
+          />
+        </template>
+      </SyTabs>
+    `,
+	}),
+	parameters: {
+		sourceCode: [
+			{
+				name: 'Template',
+				code: ` 
+              <SyTabs :items="args.items">
+        <template #tab-append="{ item, index, isActive }">
+        <VIcon
+              v-if="index === 0"
+              class="ml-2"
+              :color="isActive ? 'primary' : 'grey'"
+              :icon="mdiHome"
+          />
+      </template>
+      </SyTabs>
+      `,
+			},
+		],
+	},
+}
+
+/**
+ * Exemple avec slot pannel
  */
 export const WithCustomContent: Story = {
 	render: args => ({
@@ -183,7 +350,7 @@ export const WithCustomContent: Story = {
         </template>
         <template #panel-1>
           <div class="p-4 bg-success-light rounded">
-            <h3 class="text-h6 font-weight-bold">Contenu personnalisé pour l'onglet 2</h3>
+            <h3 class="text-h6 font-weight-bold text-secondary">Contenu personnalisé pour l'onglet 2</h3>
             <p>Ce panneau utilise un style différent.</p>
           </div>
         </template>
@@ -204,19 +371,12 @@ export const WithCustomContent: Story = {
         </template>
         <template #panel-1>
           <div class="p-4 bg-success-light rounded">
-            <h3 class="text-h6 font-weight-bold">Contenu personnalisé pour l'onglet 2</h3>
+            <h3 class="text-h6 font-weight-bold text-secondary">Contenu personnalisé pour l'onglet 2</h3>
             <p>Ce panneau utilise un style différent.</p>
           </div>
         </template>
       </SyTabs>
       `,
-			},
-			{
-				name: 'Script',
-				code: `
-
-        `,
-
 			},
 		],
 	},

--- a/src/components/Customs/SyTabs/SyTabs.stories.ts
+++ b/src/components/Customs/SyTabs/SyTabs.stories.ts
@@ -258,7 +258,6 @@ export const WithTabPrependSlot: Story = {
               :icon="mdiHome"
           />
         </template>
-
       </SyTabs>
     `,
 	}),
@@ -326,6 +325,11 @@ export const WithTabAppendSlot: Story = {
       </template>
       </SyTabs>
       `,
+				script: `
+        <script setup>
+        import { mdiHome } from '@mdi/js'
+        </script>
+                `,
 			},
 		],
 	},

--- a/src/components/Customs/SyTabs/SyTabs.vue
+++ b/src/components/Customs/SyTabs/SyTabs.vue
@@ -49,8 +49,8 @@
 		'tabs-prepend': () => unknown
 		'tabs-append': () => unknown
 		'default': () => unknown
-		'tab-prepend': (props: { item: TabItem; index: number; isActive: boolean }) => unknown
-		'tab-append': (props: { item: TabItem; index: number; isActive: boolean }) => unknown
+		'tab-prepend': (props: { item: TabItem, index: number, isActive: boolean }) => unknown
+		'tab-append': (props: { item: TabItem, index: number, isActive: boolean }) => unknown
 	}>()
 
 	const options = useCustomizableOptions(config, { vuetifyOptions: props.vuetifyOptions })

--- a/src/components/Customs/SyTabs/SyTabs.vue
+++ b/src/components/Customs/SyTabs/SyTabs.vue
@@ -49,6 +49,8 @@
 		'tabs-prepend': () => unknown
 		'tabs-append': () => unknown
 		'default': () => unknown
+		'tab-prepend': (props: { item: TabItem; index: number; isActive: boolean }) => unknown
+		'tab-append': (props: { item: TabItem; index: number; isActive: boolean }) => unknown
 	}>()
 
 	const options = useCustomizableOptions(config, { vuetifyOptions: props.vuetifyOptions })
@@ -355,7 +357,19 @@
 									}
 								}"
 							>
+								<slot
+									name="tab-prepend"
+									:item="item"
+									:index="index"
+									:is-active="activeItemIndex === index"
+								/>
 								{{ item.label.toUpperCase() }}
+								<slot
+									name="tab-append"
+									:item="item"
+									:index="index"
+									:is-active="activeItemIndex === index"
+								/>
 							</RouterLink>
 							<!-- Use regular anchor for external links -->
 							<a
@@ -387,7 +401,19 @@
 									}
 								}"
 							>
+								<slot
+									name="tab-prepend"
+									:item="item"
+									:index="index"
+									:is-active="activeItemIndex === index"
+								/>
 								{{ item.label.toUpperCase() }}
+								<slot
+									name="tab-append"
+									:item="item"
+									:index="index"
+									:is-active="activeItemIndex === index"
+								/>
 							</a>
 							<!-- Fallback button for items without navigation -->
 							<!-- Version désactivée du RouterLink -->
@@ -406,7 +432,19 @@
 								tabindex="-1"
 								disabled
 							>
+								<slot
+									name="tab-prepend"
+									:item="item"
+									:index="index"
+									:is-active="activeItemIndex === index"
+								/>
 								{{ item.label.toUpperCase() }}
+								<slot
+									name="tab-append"
+									:item="item"
+									:index="index"
+									:is-active="activeItemIndex === index"
+								/>
 							</button>
 							<!-- Version désactivée du lien -->
 							<button
@@ -424,7 +462,18 @@
 								tabindex="-1"
 								disabled
 							>
+								<slot
+									name="tab-prepend"
+									:item="item"
+									:index="index"
+									:is-active="activeItemIndex === index"
+								/>
 								{{ item.label.toUpperCase() }}
+								<slot
+									name="tab-append"
+									:item="item"
+									:index="index"
+								/>
 							</button>
 							<!-- Fallback button pour les onglets standards -->
 							<button
@@ -449,7 +498,19 @@
 									}
 								}"
 							>
+								<slot
+									name="tab-prepend"
+									:item="item"
+									:index="index"
+									:is-active="activeItemIndex === index"
+								/>
 								{{ item.label.toUpperCase() }}
+								<slot
+									name="tab-append"
+									:item="item"
+									:index="index"
+									:is-active="activeItemIndex === index"
+								/>
 							</button>
 						</li>
 					</ul>

--- a/src/components/Customs/SyTabs/SyTabs.vue
+++ b/src/components/Customs/SyTabs/SyTabs.vue
@@ -473,7 +473,7 @@
 									name="tab-append"
 									:item="item"
 									:index="index"
-                  :is-active="activeItemIndex === index"
+									:is-active="activeItemIndex === index"
 								/>
 							</button>
 							<!-- Fallback button pour les onglets standards -->

--- a/src/components/Customs/SyTabs/SyTabs.vue
+++ b/src/components/Customs/SyTabs/SyTabs.vue
@@ -473,6 +473,7 @@
 									name="tab-append"
 									:item="item"
 									:index="index"
+                  :is-active="activeItemIndex === index"
 								/>
 							</button>
 							<!-- Fallback button pour les onglets standards -->

--- a/src/components/Customs/SyTabs/tests/SyTabs.spec.ts
+++ b/src/components/Customs/SyTabs/tests/SyTabs.spec.ts
@@ -438,4 +438,102 @@ describe('SyTabs', () => {
 			expect(tabItems.length).toBe(testItems.length)
 		})
 	})
+
+	// Tests des slots
+	describe('Slots', () => {
+		it('doit afficher le contenu du slot tabs-prepend', () => {
+			const wrapper = createWrapper({
+				slots: {
+					'tabs-prepend': '<div data-test="tabs-prepend">prepend</div>',
+				},
+			})
+
+			const prepend = wrapper.find('[data-test="tabs-prepend"]')
+			expect(prepend.exists()).toBe(true)
+			expect(prepend.text()).toBe('prepend')
+		})
+
+		it('doit afficher le contenu du slot tabs-append', () => {
+			const wrapper = createWrapper({
+				slots: {
+					'tabs-append': '<div data-test="tabs-append">append</div>',
+				},
+			})
+
+			const append = wrapper.find('[data-test="tabs-append"]')
+			expect(append.exists()).toBe(true)
+			expect(append.text()).toBe('append')
+		})
+
+		it('doit passer correctement item, index et isActive au slot tab-prepend', async () => {
+			const wrapper = createWrapper({
+				slots: {
+					'tab-prepend': `
+						<template #default="{ item, index, isActive }">
+							<span
+								data-test="tab-prepend-slot"
+								:data-index="index"
+								:data-value="item.value"
+								:data-active="isActive"
+							/>
+						</template>
+					`,
+				},
+			})
+
+			// Vérifier l'état initial : premier onglet actif
+			let markers = wrapper.findAll('[data-test="tab-prepend-slot"]')
+			expect(markers.length).toBe(testItems.length)
+			// Premier onglet actif, les autres inactifs
+			expect(markers[0].attributes('data-active')).toBe('true')
+			for (let i = 1; i < markers.length; i++) {
+				expect(markers[i].attributes('data-active')).toBe('false')
+			}
+
+			// Changer d'onglet actif
+			const secondTab = wrapper.findAll('.sy-tabs__button')[1]
+			await secondTab.trigger('click')
+			await nextTick()
+
+			// Recalcule des marqueurs
+			markers = wrapper.findAll('[data-test="tab-prepend-slot"]')
+			expect(markers[1].attributes('data-active')).toBe('true')
+			expect(markers[0].attributes('data-active')).toBe('false')
+		})
+
+		it('doit passer correctement item, index et isActive au slot tab-append', async () => {
+			const wrapper = createWrapper({
+				slots: {
+					'tab-append': `
+						<template #default="{ item, index, isActive }">
+							<span
+								data-test="tab-append-slot"
+								:data-index="index"
+								:data-value="item.value"
+								:data-active="isActive"
+							/>
+						</template>
+					`,
+				},
+			})
+
+			// Vérifier l'état initial : premier onglet actif
+			let markers = wrapper.findAll('[data-test="tab-append-slot"]')
+			expect(markers.length).toBe(testItems.length)
+			expect(markers[0].attributes('data-active')).toBe('true')
+			for (let i = 1; i < markers.length; i++) {
+				expect(markers[i].attributes('data-active')).toBe('false')
+			}
+
+			// Changer d'onglet actif
+			const thirdTab = wrapper.findAll('.sy-tabs__button')[2]
+			await thirdTab.trigger('click')
+			await nextTick()
+
+			// Recalcule des marqueurs
+			markers = wrapper.findAll('[data-test="tab-append-slot"]')
+			expect(markers[2].attributes('data-active')).toBe('true')
+			expect(markers[0].attributes('data-active')).toBe('false')
+		})
+	})
 })


### PR DESCRIPTION
## Description

Add tab-prepend / tab-append slot + stories + improve doc

## Stories

https://deploy-preview-1511--synapse-dev.netlify.app/?path=/story/composants-navigation-sytabs--with-tabs-prepend-slot
https://deploy-preview-1511--synapse-dev.netlify.app/?path=/story/composants-navigation-sytabs--with-tabs-append-slot
https://deploy-preview-1511--synapse-dev.netlify.app/?path=/story/composants-navigation-sytabs--with-tab-prepend-slot
https://deploy-preview-1511--synapse-dev.netlify.app/?path=/story/composants-navigation-sytabs--with-tab-append-slot

## Type de changement

<!-- Supprimez les options non pertinentes. -->

- Nouvelle fonctionnalité
- Correction de bug
- Changement cassant
- Refactoring
- Maintenance
- Documentation
- Ce changement nécessite une mise à jour de la documentation


## Checklist de validation RGAA

- [x] Testé avec navigation au clavier
- [x] Testé avec lecteur d'écran
- [x] Testé avec différentes tailles d'écran
- [x] Testé avec Tanaguru

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Le composant est conforme aux maquettes (tokens)
- [x] Le composant est fonctionnel
- [x] Le composant est responsive (mobile, tablet et desktop)
- [x] Le composant répond aux critères d'accessibilité (test Tanaguru + A11y linter)
- [x] J'ai effectué une review de mon propre code
- [x] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [x] J'ai mis en place une stories pour ma fonctionnalité / fix /...
- [x] Mes modifications ne génèrent aucun nouveau warning
- [x] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [x] Les tests unitaires passent localement avec mes modifications

## Checklist de validation du correctif RGAA

- [x] Conforme au critère RGAA concerné
- [x] Testé avec navigation au clavier
- [x] Testé avec lecteur d'écran
- [x] Testé avec différentes tailles d'écran
- [x] Pas de régression visuelle
- [x] Documentation mise à jour (ajout du doc + maj avancement) 
- [x] Breaking changes documentés