### PR TITLE
Feat/ 1487 Trop de caracteres casse le layout

### DIFF
--- a/src/components/Amelipro/AmeliproBtn/AmeliproBtn.vue
+++ b/src/components/Amelipro/AmeliproBtn/AmeliproBtn.vue
@@ -378,5 +378,9 @@
 			margin-top: 2px;
 		}
 	}
+
+  & .amelipro-custom-btn {
+    white-space: normal;
+  }
 }
 </style>

--- a/src/components/Amelipro/AmeliproBtn/AmeliproBtn.vue
+++ b/src/components/Amelipro/AmeliproBtn/AmeliproBtn.vue
@@ -379,8 +379,8 @@
 		}
 	}
 
-  & .amelipro-custom-btn {
-    white-space: normal;
-  }
+	& .amelipro-custom-btn {
+		white-space: normal;
+	}
 }
 </style>

--- a/src/components/Amelipro/AmeliproHeader/AmeliproHeader.vue
+++ b/src/components/Amelipro/AmeliproHeader/AmeliproHeader.vue
@@ -489,6 +489,6 @@
 :deep(.v-btn) {
 	&.text-service-title {
 		display: block;
-  }
+	}
 }
 </style>

--- a/src/components/Amelipro/AmeliproHeader/AmeliproHeader.vue
+++ b/src/components/Amelipro/AmeliproHeader/AmeliproHeader.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-	import { type PropType, computed, ref, useSlots } from 'vue'
+	import { computed, type PropType, ref, useSlots } from 'vue'
 	import AmeliproBtn from '../AmeliproBtn/AmeliproBtn.vue'
 	import AmeliproHeaderBar from './AmeliproHeaderBar/AmeliproHeaderBar.vue'
 	import type { AmeliproHeaderInfos } from './types'
@@ -489,7 +489,6 @@
 :deep(.v-btn) {
 	&.text-service-title {
 		display: block;
-		white-space: unset;
-	}
+  }
 }
 </style>

--- a/src/components/Amelipro/AmeliproStateTile/AmeliproStateTile.vue
+++ b/src/components/Amelipro/AmeliproStateTile/AmeliproStateTile.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-	import { type PropType, computed } from 'vue'
+	import { computed, type PropType } from 'vue'
 	import AmeliproIcon from '../AmeliproIcon/AmeliproIcon.vue'
 	import { AmeliproStateTileTypes } from './AmeliproStateTileTypes'
 	import type { IndexedObject } from '../types'
@@ -305,7 +305,10 @@
 	display: flex;
 	flex-direction: column;
 	background-color: apTokens.$ap-white;
-	white-space: normal;
+
+  & span {
+    white-space: normal;
+  }
 
 	&:hover {
 		& .amelipro-state-tile__pdf-download {

--- a/src/components/Amelipro/AmeliproStateTile/AmeliproStateTile.vue
+++ b/src/components/Amelipro/AmeliproStateTile/AmeliproStateTile.vue
@@ -306,9 +306,9 @@
 	flex-direction: column;
 	background-color: apTokens.$ap-white;
 
-  & span {
-    white-space: normal;
-  }
+	& span {
+		white-space: normal;
+	}
 
 	&:hover {
 		& .amelipro-state-tile__pdf-download {

--- a/src/components/Amelipro/StructureMenu/StructureBtn/StructureBtn.vue
+++ b/src/components/Amelipro/StructureMenu/StructureBtn/StructureBtn.vue
@@ -52,9 +52,9 @@
 .v-btn {
 	letter-spacing: unset;
 
-  & :deep(.v-btn__content) {
-    white-space: normal !important;
-  }
+	& :deep(.v-btn__content) {
+		white-space: normal !important;
+	}
 
 	& :deep(.v-btn__overlay),
 	& :deep(.v-btn__underlay) {

--- a/src/components/Amelipro/StructureMenu/StructureBtn/StructureBtn.vue
+++ b/src/components/Amelipro/StructureMenu/StructureBtn/StructureBtn.vue
@@ -52,6 +52,10 @@
 .v-btn {
 	letter-spacing: unset;
 
+  & :deep(.v-btn__content) {
+    white-space: normal !important;
+  }
+
 	& :deep(.v-btn__overlay),
 	& :deep(.v-btn__underlay) {
 		display: none !important;

--- a/src/components/Amelipro/StructureMenu/StructureTabs/StructureTabs.vue
+++ b/src/components/Amelipro/StructureMenu/StructureTabs/StructureTabs.vue
@@ -115,7 +115,7 @@
 					:key="index"
 					ref="structureBtns"
 					:aria-selected="selected === index ? 'true' : 'false'"
-					class="mr-0 mr-sm-3 mb-2 mb-sm-0"
+					class="mr-0 mr-sm-3 mb-2 mb-sm-1"
 					:controls="`structure-panel-${index}`"
 					role="tab"
 					:selected="index === selected"
@@ -134,7 +134,7 @@
 			v-for="(tab, index) in tabs"
 			:id="`structure-panel-${index}`"
 			:key="index"
-			class="mt-4"
+			class="mt-3"
 			:role="tabs.length > 1 ? 'tabpanel' : undefined"
 			:tabindex="selected === index && tabs.length > 1 ? 0 : -1"
 		>

--- a/src/components/Amelipro/StructureMenu/StructureTabs/StructureTabs.vue
+++ b/src/components/Amelipro/StructureMenu/StructureTabs/StructureTabs.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 	import type { IStructureTabs, StructureTab } from './types'
-	import { type PropType, computed, nextTick, ref } from 'vue'
+	import { computed, nextTick, type PropType, ref } from 'vue'
 	import StructureBtn from '../StructureBtn/StructureBtn.vue'
 	import StructureList from '../StructureList/StructureList.vue'
 	import { locales } from './locales'
@@ -109,8 +109,7 @@
 			>
 				{{ locales.label }}
 			</p>
-
-			<div class="d-flex flex-column flex-sm-row">
+			<div class="d-flex flex-column flex-sm-row flex-sm-wrap">
 				<StructureBtn
 					v-for="(item, index) in tabs"
 					:key="index"

--- a/src/components/Amelipro/StructureMenu/StructureTabs/tests/__snapshots__/StructureTabs.spec.ts.snap
+++ b/src/components/Amelipro/StructureMenu/StructureTabs/tests/__snapshots__/StructureTabs.spec.ts.snap
@@ -27,6 +27,7 @@ exports[`StructureTabs > render correctly 1`] = `
       d-flex
       flex-column
       flex-sm-row
+      flex-sm-wrap
     ">
       <button
         aria-controls="structure-panel-0"

--- a/src/components/Amelipro/StructureMenu/StructureTabs/tests/__snapshots__/StructureTabs.spec.ts.snap
+++ b/src/components/Amelipro/StructureMenu/StructureTabs/tests/__snapshots__/StructureTabs.spec.ts.snap
@@ -36,7 +36,7 @@ exports[`StructureTabs > render correctly 1`] = `
           bg-ap-blue-darken-2
           elevation-0
           mb-2
-          mb-sm-0
+          mb-sm-1
           mr-0
           mr-sm-3
           structure-btn
@@ -72,7 +72,7 @@ exports[`StructureTabs > render correctly 1`] = `
           bg-ap-grey-lighten-3
           elevation-0
           mb-2
-          mb-sm-0
+          mb-sm-1
           mr-0
           mr-sm-3
           structure-btn
@@ -104,7 +104,7 @@ exports[`StructureTabs > render correctly 1`] = `
     </div>
   </div>
   <div
-    class="mt-4"
+    class="mt-3"
     id="structure-panel-0"
     role="tabpanel"
     tabindex="0"
@@ -462,7 +462,7 @@ exports[`StructureTabs > render correctly 1`] = `
     </div>
   </div>
   <div
-    class="mt-4"
+    class="mt-3"
     id="structure-panel-1"
     role="tabpanel"
     tabindex="-1"

--- a/src/components/Amelipro/StructureMenu/tests/__snapshots__/StructureMenu.spec.ts.snap
+++ b/src/components/Amelipro/StructureMenu/tests/__snapshots__/StructureMenu.spec.ts.snap
@@ -309,6 +309,7 @@ exports[`StructureMenu > render correctly 1`] = `
               d-flex
               flex-column
               flex-sm-row
+              flex-sm-wrap
             ">
               <button
                 aria-controls="structure-panel-0"

--- a/src/components/Amelipro/StructureMenu/tests/__snapshots__/StructureMenu.spec.ts.snap
+++ b/src/components/Amelipro/StructureMenu/tests/__snapshots__/StructureMenu.spec.ts.snap
@@ -318,7 +318,7 @@ exports[`StructureMenu > render correctly 1`] = `
                   bg-ap-blue-darken-2
                   elevation-0
                   mb-2
-                  mb-sm-0
+                  mb-sm-1
                   mr-0
                   mr-sm-3
                   structure-btn
@@ -354,7 +354,7 @@ exports[`StructureMenu > render correctly 1`] = `
                   bg-ap-grey-lighten-3
                   elevation-0
                   mb-2
-                  mb-sm-0
+                  mb-sm-1
                   mr-0
                   mr-sm-3
                   structure-btn
@@ -386,7 +386,7 @@ exports[`StructureMenu > render correctly 1`] = `
             </div>
           </div>
           <div
-            class="mt-4"
+            class="mt-3"
             id="structure-panel-0"
             role="tabpanel"
             tabindex="0"
@@ -744,7 +744,7 @@ exports[`StructureMenu > render correctly 1`] = `
             </div>
           </div>
           <div
-            class="mt-4"
+            class="mt-3"
             id="structure-panel-1"
             role="tabpanel"
             tabindex="-1"

--- a/src/components/Amelipro/UserMenu/UserMenu.vue
+++ b/src/components/Amelipro/UserMenu/UserMenu.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-	import { type PropType, computed, ref } from 'vue'
+	import { computed, type PropType, ref } from 'vue'
 	import AmeliproBtn from '../AmeliproBtn/AmeliproBtn.vue'
 	import AmeliproIconBtn from '../AmeliproIconBtn/AmeliproIconBtn.vue'
 	import UserMenuDetails from './UserMenuDetails/UserMenuDetails.vue'
@@ -145,7 +145,8 @@
 	}
 
 	.user-menu {
-		position: relative;
+    position: relative;
+    overflow-wrap: break-word;
 	}
 
 	.user-menu-popover {

--- a/src/components/Amelipro/UserMenu/UserMenu.vue
+++ b/src/components/Amelipro/UserMenu/UserMenu.vue
@@ -145,8 +145,8 @@
 	}
 
 	.user-menu {
-    position: relative;
-    overflow-wrap: break-word;
+		position: relative;
+		overflow-wrap: break-word;
 	}
 
 	.user-menu-popover {


### PR DESCRIPTION
## Description

Si le texte est trop long, il devrait aller à la ligne.
Il impacte les composants:
AmeliproStructureMenu
AmeliproHeader
AmeliproButton
UserMenu
AmeliproStateTile

## Type de changement
- Correction de bug

## Checklist

- [x] Ma Pull Request pointe vers la bonne branche
- [x] Le composant est fonctionnel
- [x] J'ai effectué une review de mon propre code
