### PR TITLE
RatingPicker mettre la couleur du texte iso maquettes

### DIFF
--- a/src/components/RatingPicker/EmotionPicker/EmotionPicker.vue
+++ b/src/components/RatingPicker/EmotionPicker/EmotionPicker.vue
@@ -248,7 +248,6 @@
 	font-weight: 700;
 	font-size: 1rem;
 	line-height: 150%;
-	color: tokens.$colors-text-base;
 }
 
 .sy-emotion-picker__item--active .sy-emotion-picker__item-title {


### PR DESCRIPTION
## Description

Dans les maquettes figma, le texte du EmotionPicker est de la couleur de l’icône. Cette PR supprime le couleur du texte pour qu'il adopte la couleur de l'icône tel que défini sur l'élément parent.
