### PR TITLE
SyCheckbox: correction des messagesId

### DIFF
--- a/src/components/Customs/SyCheckbox/SyCheckbox.vue
+++ b/src/components/Customs/SyCheckbox/SyCheckbox.vue
@@ -214,7 +214,7 @@
 
 		// Create messageId for checkboxes with IDs
 		if (props.id) {
-			return `${props.id}-messages`
+			return `${props.id}`
 		}
 		return undefined
 	})


### PR DESCRIPTION
Avant: 
<img width="1858" height="1052" alt="image" src="https://github.com/user-attachments/assets/4ccc7c4c-c626-4f65-82f4-07446c6e437c" />

Apres: 
<img width="1856" height="1052" alt="image" src="https://github.com/user-attachments/assets/1ee8be69-18ce-4f96-b6bb-7816c0554dc4" />


