### PR TITLE
Feat/1489 ameliprofilepreview telecharge tout seul

### DIFF
--- a/src/components/Amelipro/AmeliproFilePreview/AmeliproFilePreview.mdx
+++ b/src/components/Amelipro/AmeliproFilePreview/AmeliproFilePreview.mdx
@@ -1,4 +1,4 @@
-import { Controls, Canvas, Meta } from '@storybook/blocks';
+import {Canvas, Controls, Meta} from '@storybook/blocks';
 
 import * as AmeliproFilePreviewStories from './AmeliproFilePreview.stories';
 
@@ -7,6 +7,8 @@ import * as AmeliproFilePreviewStories from './AmeliproFilePreview.stories';
 # AmeliproFilePreview
 
 L’élément `AmeliproFilePreview` est utilisé pour afficher un aperçu de fichier dans Amelipro
+
+<Canvas of={AmeliproFilePreviewStories.Info}/>
 
 <Canvas of={AmeliproFilePreviewStories.Default} />
 

--- a/src/components/Amelipro/AmeliproFilePreview/AmeliproFilePreview.mdx
+++ b/src/components/Amelipro/AmeliproFilePreview/AmeliproFilePreview.mdx
@@ -1,4 +1,4 @@
-import {Canvas, Controls, Meta} from '@storybook/blocks';
+import {Canvas, Controls, Meta, Story} from '@storybook/blocks';
 
 import * as AmeliproFilePreviewStories from './AmeliproFilePreview.stories';
 
@@ -8,7 +8,7 @@ import * as AmeliproFilePreviewStories from './AmeliproFilePreview.stories';
 
 L’élément `AmeliproFilePreview` est utilisé pour afficher un aperçu de fichier dans Amelipro
 
-<Canvas of={AmeliproFilePreviewStories.Info}/>
+<Story of={AmeliproFilePreviewStories.Info}/>
 
 <Canvas of={AmeliproFilePreviewStories.Default} />
 

--- a/src/components/Amelipro/AmeliproFilePreview/AmeliproFilePreview.stories.ts
+++ b/src/components/Amelipro/AmeliproFilePreview/AmeliproFilePreview.stories.ts
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/vue3'
 import AmeliproFilePreview from './AmeliproFilePreview.vue'
+import SyAlert from '@/components/SyAlert/SyAlert.vue'
 
 const meta = {
 	argTypes: {
@@ -62,10 +63,30 @@ export const Default: Story = {
 			return { args }
 		},
 		template: `
-<AmeliproFilePreview
+          <AmeliproFilePreview
 	v-bind="args"
 />
 		`,
 	}),
 
+}
+
+export const Info: Story = {
+	render: (args) => {
+		return {
+			components: { SyAlert },
+			setup() {
+				return { args }
+			},
+			template: `
+              <SyAlert v-model="args.modelValue" :type="args.type" :variant="tonal" :closable="false">
+                <template #default>La prop <strong>iframeTitle</strong> a été remplacée par
+                  <strong>pdfDisplayTitle</strong>.
+                </template>
+                </template>
+              </SyAlert>
+            `,
+		}
+	},
+	tags: ['!dev'],
 }

--- a/src/components/Amelipro/AmeliproFilePreview/AmeliproFilePreview.stories.ts
+++ b/src/components/Amelipro/AmeliproFilePreview/AmeliproFilePreview.stories.ts
@@ -83,7 +83,6 @@ export const Info: Story = {
                 <template #default>La prop <strong>iframeTitle</strong> a été remplacée par
                   <strong>pdfDisplayTitle</strong>.
                 </template>
-                </template>
               </SyAlert>
             `,
 		}

--- a/src/components/Amelipro/AmeliproFilePreview/AmeliproFilePreview.stories.ts
+++ b/src/components/Amelipro/AmeliproFilePreview/AmeliproFilePreview.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/vue3'
 import AmeliproFilePreview from './AmeliproFilePreview.vue'
-import SyAlert from '@/components/SyAlert/SyAlert.vue'
+import AmeliproMessage from '../AmeliproMessage/AmeliproMessage.vue'
 
 const meta = {
 	argTypes: {
@@ -74,16 +74,14 @@ export const Default: Story = {
 export const Info: Story = {
 	render: (args) => {
 		return {
-			components: { SyAlert },
+			components: { AmeliproMessage },
 			setup() {
 				return { args }
 			},
 			template: `
-              <SyAlert v-model="args.modelValue" :type="args.type" :variant="tonal" :closable="false">
-                <template #default>La prop <strong>iframeTitle</strong> a été remplacée par
-                  <strong>pdfDisplayTitle</strong>.
-                </template>
-              </SyAlert>
+              <AmeliproMessage>
+                La prop <strong>iframeTitle</strong> a été remplacée par <strong>pdfDisplayTitle</strong>.
+              </AmeliproMessage>
             `,
 		}
 	},

--- a/src/components/Amelipro/AmeliproFilePreview/AmeliproFilePreview.stories.ts
+++ b/src/components/Amelipro/AmeliproFilePreview/AmeliproFilePreview.stories.ts
@@ -8,10 +8,10 @@ const meta = {
 		fileName: { description: 'Nom du fichier PDF' },
 		fileSrc: { description: 'Url du fichier PDF' },
 		foldable: { description: 'Transforme la carte en carte dépliante' },
-		iframeTitle: { description: 'Titre de l’iframe contenant l’aperçu du fichier' },
+		pdfDisplayTitle: { description: 'Titre pour l’élément <object> affichant l’aperçu du fichier PDF' },
 		isOpen: { description: 'Statut par défaut de la carte dépliante' },
 		linkTitle: { description: 'Titre du lien de téléchargement du fichier, il doit reprendre l’intitulé du bouton et informer si possible sur le format du fichier à télécharger ainsi que sur sa taille (exemple : Télécharger le fichier au format PDF - 3Mo)' },
-		previewHeight: { description: 'Hauteur de l’iframe' },
+		previewHeight: { description: `Hauteur de l'aperçu PDF` },
 		uniqueId: { description: 'Identifiant unique' },
 	},
 	component: AmeliproFilePreview,
@@ -28,7 +28,7 @@ export const Default: Story = {
 		fileName: 'Nom du fichier',
 		fileSrc: '/amelipro/pdf/charte-pour-pdf.pdf',
 		foldable: false,
-		iframeTitle: 'Aperçu du fichier PDF',
+		pdfDisplayTitle: 'Aperçu du fichier PDF',
 		isOpen: false,
 		linkTitle: 'Télécharger le fichier au Format PDF',
 		previewHeight: 550,
@@ -45,7 +45,7 @@ export const Default: Story = {
 		file-name="Nom du fichier"
 		file-src="/amelipro/pdf/charte-pour-pdf.pdf"
 		:foldable="false"
-		iframe-title="Aperçu du fichier PDF"
+		pdfDisplayTitle="Aperçu du fichier PDF"
 		:is-open="false"
 		link-title="Télécharger le fichier au Format PDF"
 		:preview-height="550"

--- a/src/components/Amelipro/AmeliproFilePreview/AmeliproFilePreview.vue
+++ b/src/components/Amelipro/AmeliproFilePreview/AmeliproFilePreview.vue
@@ -26,7 +26,7 @@
 			type: Boolean,
 			default: false,
 		},
-		iframeTitle: {
+		pdfDisplayTitle: {
 			type: String,
 			default: 'Aperçu du fichier PDF',
 		},
@@ -100,13 +100,12 @@
 			</template>
 
 			<template #default>
-				<iframe
+				<object
 					v-if="mdAndUp"
-					:id="`${uniqueId}-iframe`"
-					class="amelipro-file-preview__iframe"
+					:id="`${uniqueId}-pdf-display`"
+					:aria-label="pdfDisplayTitle"
 					:height="previewHeight"
-					:src="fileSrc"
-					:title="iframeTitle"
+					:data="fileSrc"
 					type="application/pdf"
 					width="100%"
 				/>

--- a/src/components/Amelipro/AmeliproFilePreview/__tests__/AmeliproFilePreview.spec.ts
+++ b/src/components/Amelipro/AmeliproFilePreview/__tests__/AmeliproFilePreview.spec.ts
@@ -1,5 +1,5 @@
 import { mount } from '@vue/test-utils'
-import { expect, describe, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import AmeliproFilePreview from '../AmeliproFilePreview.vue'
 
 describe('AmeliproFilePreview', () => {
@@ -11,7 +11,7 @@ describe('AmeliproFilePreview', () => {
 				fileName: 'file name',
 				fileSrc: 'file-src',
 				foldable: true,
-				iframeTitle: 'Modified iframe title',
+				pdfDisplayTitle: 'Modified pdf display title',
 				isOpen: true,
 				linkTitle: 'Modified link title',
 				previewHeight: 400,

--- a/src/components/Amelipro/AmeliproFilePreview/__tests__/__snapshots__/AmeliproFilePreview.spec.ts.snap
+++ b/src/components/Amelipro/AmeliproFilePreview/__tests__/__snapshots__/AmeliproFilePreview.spec.ts.snap
@@ -193,15 +193,14 @@ exports[`AmeliproFilePreview > render correctly 1`] = `
           border-top-color: #DDDEDE;
         "
       >
-        <iframe
-          class="amelipro-file-preview__iframe"
+        <object
+          aria-label="Modified pdf display title"
+          data="file-src"
           height="400"
-          id="pdf-preview-unique-id-iframe"
-          src="file-src"
-          title="Modified iframe title"
+          id="pdf-preview-unique-id-pdf-display"
           type="application/pdf"
           width="100%"
-        ></iframe>
+        ></object>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Description
le composant ameliproFlePreview.vue lance le téléchargement du PDF tout seul et n'affiche pas l'aperçu

## Type de changement

- Correction de bug

## Checklist

- [ ] Ma Pull Request pointe vers la bonne branche
- [ ] Le composant est fonctionnel
- [ ] J'ai effectué une review de mon propre code
