### PR TITLE
DatePicker: fix range display 

### DIFF
--- a/dev/Playground.vue
+++ b/dev/Playground.vue
@@ -1,26 +1,2 @@
-<script setup lang="ts">
-	import { ref } from 'vue'
-	import DatePicker from '@/components/DatePicker/ComplexDatePicker/ComplexDatePicker.vue'
-	import CalendarDatePicker from '@/components/DatePicker/CalendarDatePicker/CalendarDatePicker.vue'
-
-	const dateRange = ref<[string, string] | null>(null)
-	const dateRange2 = ref<[string, string] | null>(null)
-</script>
-
 <template>
-	<DatePicker
-		v-model="dateRange"
-		placeholder="Sélectionner une période (combined)"
-		format="DD/MM/YYYY"
-		display-range
-		use-combined-mode
-	/>
-  {{ dateRange }}
-	<DatePicker
-		v-model="dateRange2"
-		placeholder="Sélectionner une période (calendar)"
-		format="DD/MM/YYYY"
-		display-range
-	/>
-  {{ dateRange2 }}
 </template>

--- a/dev/Playground.vue
+++ b/dev/Playground.vue
@@ -1,2 +1,26 @@
+<script setup lang="ts">
+	import { ref } from 'vue'
+	import DatePicker from '@/components/DatePicker/ComplexDatePicker/ComplexDatePicker.vue'
+	import CalendarDatePicker from '@/components/DatePicker/CalendarDatePicker/CalendarDatePicker.vue'
+
+	const dateRange = ref<[string, string] | null>(null)
+	const dateRange2 = ref<[string, string] | null>(null)
+</script>
+
 <template>
+	<DatePicker
+		v-model="dateRange"
+		placeholder="Sélectionner une période (combined)"
+		format="DD/MM/YYYY"
+		display-range
+		use-combined-mode
+	/>
+  {{ dateRange }}
+	<DatePicker
+		v-model="dateRange2"
+		placeholder="Sélectionner une période (calendar)"
+		format="DD/MM/YYYY"
+		display-range
+	/>
+  {{ dateRange2 }}
 </template>

--- a/src/components/DatePicker/ComplexDatePicker/ComplexDatePicker.vue
+++ b/src/components/DatePicker/ComplexDatePicker/ComplexDatePicker.vue
@@ -897,10 +897,6 @@
 			if (visible) {
 				// Réinitialiser le view mode à l'ouverture pour éviter les problèmes de navigation
 				resetViewMode()
-				// En mode plage, reconstruire systématiquement la plage complète à partir
-				// du modèle externe lors de l'ouverture, afin de restaurer le
-				// surlignage complet dans le calendrier même si selectedDates a été
-				// réduit aux seules bornes ailleurs.
 				if (props.displayRange && props.modelValue) {
 					if (Array.isArray(props.modelValue) && props.modelValue.length >= 2) {
 						const [startStr, endStr] = props.modelValue

--- a/src/components/DatePicker/ComplexDatePicker/ComplexDatePicker.vue
+++ b/src/components/DatePicker/ComplexDatePicker/ComplexDatePicker.vue
@@ -710,6 +710,9 @@
 		if (props.readonly) return
 
 		if (eventOrValue instanceof Event) {
+			// Activer la saisie manuelle uniquement lorsqu'un véritable input utilisateur se produit (et non au simple focus du champ).
+			isManualInputActive.value = true
+			hasInteracted.value = true
 			inputHandler.handleInput(eventOrValue)
 			return
 		}
@@ -894,6 +897,22 @@
 			if (visible) {
 				// Réinitialiser le view mode à l'ouverture pour éviter les problèmes de navigation
 				resetViewMode()
+				// En mode plage, reconstruire systématiquement la plage complète à partir
+				// du modèle externe lors de l'ouverture, afin de restaurer le
+				// surlignage complet dans le calendrier même si selectedDates a été
+				// réduit aux seules bornes ailleurs.
+				if (props.displayRange && props.modelValue) {
+					if (Array.isArray(props.modelValue) && props.modelValue.length >= 2) {
+						const [startStr, endStr] = props.modelValue
+						const rf = returnFormat.value
+						const startDate = startStr ? parseDate(startStr, rf) || parseDate(startStr, props.format) : null
+						const endDate = endStr ? parseDate(endStr, rf) || parseDate(endStr, props.format) : null
+						if (startDate && endDate) {
+							const allDates = dateSelectionResult.generateDateRange(startDate, endDate)
+							selectedDates.value = allDates
+						}
+					}
+				}
 				nextTick(() => {
 					customizeMonthButton()
 					markHolidayDays()

--- a/src/components/DatePicker/ComplexDatePicker/ComplexDatePicker.vue
+++ b/src/components/DatePicker/ComplexDatePicker/ComplexDatePicker.vue
@@ -731,7 +731,6 @@
 			}
 		}
 
-		// Cas non-plage ou saisie encore incomplète : garder la validation simple
 		validateDates()
 	}
 

--- a/src/components/DatePicker/ComplexDatePicker/ComplexDatePicker.vue
+++ b/src/components/DatePicker/ComplexDatePicker/ComplexDatePicker.vue
@@ -401,16 +401,21 @@
 		if (!props.noCalendar && newValue) displayFormattedDate.value = newValue
 	})
 
-	const updateSelectedDates = (date: Date | null) => {
-		if (date !== null) {
-			const validationResult = validateField(date, props.customRules, props.customWarningRules)
+	const updateSelectedDates = (
+		input: Date | Date[] | string | string[] | null | undefined,
+	) => {
+		// Conserver la validation existante uniquement pour les sélections unitaires via le calendrier
+		if (input instanceof Date) {
+			const validationResult = validateField(input, props.customRules, props.customWarningRules)
 			if (validationResult.hasError) {
 				errors.value = validationResult.state.errors
 				return
 			}
 		}
-		dateSelectionResult.updateSelectedDates(date)
-		// Validate immediately to surface messages
+
+		// Déléguer entièrement la mise à jour (y compris les plages) au composable
+		dateSelectionResult.updateSelectedDates(input)
+		// Valider immédiatement pour afficher les messages
 		queueMicrotask(() => validateDates(true))
 	}
 
@@ -717,19 +722,17 @@
 		if (props.displayRange && typeof eventOrValue === 'string') {
 			if (eventOrValue.includes(' - ')) {
 				const [startDateStr = '', endDateStr = ''] = eventOrValue.split(' - ').map(s => s.trim())
+				// Ne déléguer au composable que lorsque les deux dates sont complètes
 				if (startDateStr && endDateStr && !endDateStr.includes('_')) {
-					const startDate = parseDate(startDateStr, props.format)
-					const endDate = parseDate(endDateStr, props.format)
-					if (startDate && endDate) {
-						selectedDates.value = [startDate, endDate]
-						validateDates()
-					}
+					// Laisser useDateSelection générer toutes les dates intermédiaires
+					updateSelectedDates(eventOrValue)
+					return
 				}
 			}
 		}
-		else {
-			validateDates()
-		}
+
+		// Cas non-plage ou saisie encore incomplète : garder la validation simple
+		validateDates()
 	}
 
 	/**

--- a/src/components/DatePicker/DateTextInput/DateTextInput.vue
+++ b/src/components/DatePicker/DateTextInput/DateTextInput.vue
@@ -854,8 +854,7 @@
 					}
 				}
 				else {
-					selectedDates.value = null
-					if (props.modelValue !== null) emitModel(null)
+					// Ne pas effacer selectedDates ici : tant que le champ n'est pas réellement vidé (cas déjà géré plus haut dans le watcher), on conserve la dernière sélection valide pour que le surlignage de la plage reste visible dans le calendrier.
 				}
 
 				emit('input', result.formattedValue)

--- a/src/components/DatePicker/composables/tests/useDatePickerVisibility.spec.ts
+++ b/src/components/DatePicker/composables/tests/useDatePickerVisibility.spec.ts
@@ -229,8 +229,6 @@ describe('useDatePickerVisibility', () => {
 
 			expect(isDatePickerVisible.value).toBe(true)
 			expect(mockEmitFocus).toHaveBeenCalledTimes(1)
-			expect(isManualInputActive.value).toBe(true)
-			expect(hasInteracted.value).toBe(true)
 		})
 
 		it('ne devrait pas ouvrir le CalendarMode si textFieldActivator=false', () => {
@@ -249,8 +247,6 @@ describe('useDatePickerVisibility', () => {
 
 			expect(isDatePickerVisible.value).toBe(false)
 			expect(mockEmitFocus).toHaveBeenCalledTimes(1)
-			expect(isManualInputActive.value).toBe(true)
-			expect(hasInteracted.value).toBe(true)
 		})
 	})
 

--- a/src/components/DatePicker/composables/tests/useInputHandler.spec.ts
+++ b/src/components/DatePicker/composables/tests/useInputHandler.spec.ts
@@ -435,7 +435,10 @@ describe('useInputHandler', () => {
 		})
 
 		updateSelectedDatesFromFormattedValue('invalid')
-		expect(selectedDates.value).toBeNull()
+		// En mode plage, une valeur invalide mais non vide ne doit plus effacer
+		// la sélection existante : on conserve la dernière plage valide pour que
+		// le surlignage reste visible dans le calendrier.
+		expect(selectedDates.value).toEqual([expect.any(Date), null])
 	})
 
 	it('updateSelectedDatesFromFormattedValue in single mode sets a single Date or null', () => {

--- a/src/components/DatePicker/composables/tests/useInputHandler.spec.ts
+++ b/src/components/DatePicker/composables/tests/useInputHandler.spec.ts
@@ -435,9 +435,6 @@ describe('useInputHandler', () => {
 		})
 
 		updateSelectedDatesFromFormattedValue('invalid')
-		// En mode plage, une valeur invalide mais non vide ne doit plus effacer
-		// la sélection existante : on conserve la dernière plage valide pour que
-		// le surlignage reste visible dans le calendrier.
 		expect(selectedDates.value).toEqual([expect.any(Date), null])
 	})
 

--- a/src/components/DatePicker/composables/useDatePickerVisibility.ts
+++ b/src/components/DatePicker/composables/useDatePickerVisibility.ts
@@ -30,8 +30,6 @@ export const useDatePickerVisibility = (options: {
 		readonly = false,
 		textFieldActivator = false,
 		isDatePickerVisible,
-		isManualInputActive,
-		hasInteracted,
 		updateAccessibility,
 		validateDates,
 		emitClosed,
@@ -86,8 +84,6 @@ export const useDatePickerVisibility = (options: {
 		}
 		// Always emit the focus event
 		emitFocus()
-		isManualInputActive.value = true
-		hasInteracted.value = true
 	}
 
 	/**

--- a/src/components/DatePicker/composables/useInputHandler.ts
+++ b/src/components/DatePicker/composables/useInputHandler.ts
@@ -273,15 +273,26 @@ export function useInputHandler(options: InputHandlerOptions) {
 	const updateSelectedDatesFromFormattedValue = (formattedInput: string) => {
 		if (displayRange) {
 			const [startDate, endDate] = parseRangeInputForSelectedDates(formattedInput)
+			// Ne jamais effacer la sélection existante tant que l'utilisateur
+			// n'a pas réellement vidé le champ. Si la saisie est non vide mais
+			// ne permet pas encore d'extraire une date valide, on conserve
+			// selectedDates tel quel pour garder le surlignage de la dernière
+			// plage valide dans le calendrier.
 			if (startDate && endDate) {
-				selectedDates.value = [startDate, endDate]
+				// Générer toutes les dates intermédiaires pour que le calendrier
+				// affiche bien l'intégralité de la plage (et pas uniquement les
+				// bornes de début/fin).
+				const allDates = generateDateRange(startDate, endDate)
+				selectedDates.value = allDates
 			}
 			else if (startDate) {
 				selectedDates.value = [startDate, null]
 			}
-			else {
+			else if (!formattedInput || formattedInput.trim() === '') {
 				selectedDates.value = null
 			}
+			// Sinon : saisie non vide mais encore invalide/incomplète →
+			// ne pas toucher à selectedDates.
 		}
 		else {
 			const date = parseDate(formattedInput, format)

--- a/src/components/DatePicker/composables/useInputHandler.ts
+++ b/src/components/DatePicker/composables/useInputHandler.ts
@@ -273,15 +273,7 @@ export function useInputHandler(options: InputHandlerOptions) {
 	const updateSelectedDatesFromFormattedValue = (formattedInput: string) => {
 		if (displayRange) {
 			const [startDate, endDate] = parseRangeInputForSelectedDates(formattedInput)
-			// Ne jamais effacer la sélection existante tant que l'utilisateur
-			// n'a pas réellement vidé le champ. Si la saisie est non vide mais
-			// ne permet pas encore d'extraire une date valide, on conserve
-			// selectedDates tel quel pour garder le surlignage de la dernière
-			// plage valide dans le calendrier.
 			if (startDate && endDate) {
-				// Générer toutes les dates intermédiaires pour que le calendrier
-				// affiche bien l'intégralité de la plage (et pas uniquement les
-				// bornes de début/fin).
 				const allDates = generateDateRange(startDate, endDate)
 				selectedDates.value = allDates
 			}
@@ -291,8 +283,6 @@ export function useInputHandler(options: InputHandlerOptions) {
 			else if (!formattedInput || formattedInput.trim() === '') {
 				selectedDates.value = null
 			}
-			// Sinon : saisie non vide mais encore invalide/incomplète →
-			// ne pas toucher à selectedDates.
 		}
 		else {
 			const date = parseDate(formattedInput, format)

--- a/src/composables/validation/tests/useValidatable.spec.ts
+++ b/src/composables/validation/tests/useValidatable.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable vue/one-component-per-file */
 import { describe, it, expect, vi } from 'vitest'
 import { defineComponent, h } from 'vue'
 import { mount } from '@vue/test-utils'


### PR DESCRIPTION
## Description

```vue
<script setup lang="ts">
	import { ref } from 'vue'
	import DatePicker from '@/components/DatePicker/ComplexDatePicker/ComplexDatePicker.vue'
	import CalendarDatePicker from '@/components/DatePicker/CalendarDatePicker/CalendarDatePicker.vue'

	const dateRange = ref<[string, string] | null>(null)
	const dateRange2 = ref<[string, string] | null>(null)
</script>

<template>
	<DatePicker
		v-model="dateRange"
		placeholder="Sélectionner une période (combined)"
		format="DD/MM/YYYY"
		display-range
		use-combined-mode
	/>
	{{ dateRange }}
	<DatePicker
		v-model="dateRange2"
		placeholder="Sélectionner une période (calendar)"
		format="DD/MM/YYYY"
		display-range
	/>
	{{ dateRange2 }}
</template>
``` 