### PR TITLE
improve isNotBeforeToday rule

### DIFF
--- a/src/utils/rules/isNotBeforeToday/IsNotBeforeToday.mdx
+++ b/src/utils/rules/isNotBeforeToday/IsNotBeforeToday.mdx
@@ -89,7 +89,7 @@ isNotBeforeTodayFn(
 	errorMessages?: {
 		default: string;
 	}
-): (value: string) => true | string;
+): (value: string | Date) => true | string;
 
 `} />
 
@@ -100,7 +100,7 @@ isNotBeforeTodayFn(
 
 ### Valeurs de retour
 
-Retourne une fonction qui prend en paramètre une chaîne de caractères représentant une date et retourne `true` si la date n'est pas antérieur à la date du jour, sinon retourne un message d'erreur.
+Retourne une fonction qui prend en paramètre une chaîne de caractères ou un objet `Date` représentant une date et retourne `true` si la date n'est pas antérieure à la date du jour, sinon retourne un message d'erreur.
 
 ## Exemples
 

--- a/src/utils/rules/isNotBeforeToday/index.ts
+++ b/src/utils/rules/isNotBeforeToday/index.ts
@@ -18,10 +18,25 @@ export function isNotBeforeTodayFn(
 		if (!value) {
 			return true
 		}
+		const today = formatDate(dayjs())
 
-		return (
-			(typeof value === 'string' && !isDateBefore(formatDate(dayjs()), value)) || ruleMessage(errorMessages, 'default')
-		)
+		if (value instanceof Date) {
+			const formattedValue = formatDate(dayjs(value))
+
+			return (
+				!isDateBefore(today, formattedValue)
+				|| ruleMessage(errorMessages, 'default')
+			)
+		}
+
+		if (typeof value === 'string') {
+			return (
+				!isDateBefore(today, value)
+				|| ruleMessage(errorMessages, 'default')
+			)
+		}
+
+		return ruleMessage(errorMessages, 'default')
 	}
 }
 

--- a/src/utils/rules/isNotBeforeToday/tests/notBeforeToday.spec.ts
+++ b/src/utils/rules/isNotBeforeToday/tests/notBeforeToday.spec.ts
@@ -8,6 +8,9 @@ const DATE_FORMAT = 'DD/MM/YYYY'
 const pastDate = dayjs().subtract(1, 'year').format(DATE_FORMAT)
 const futureDate = dayjs().add(1, 'year').format(DATE_FORMAT)
 const today = dayjs().format(DATE_FORMAT)
+const pastDateObject = dayjs().subtract(1, 'year').toDate()
+const futureDateObject = dayjs().add(1, 'year').toDate()
+const todayDateObject = dayjs().toDate()
 
 describe('isNotBeforeToday', () => {
 	it('returns an error when the date is past', () => {
@@ -32,5 +35,21 @@ describe('isNotBeforeToday', () => {
 
 	it('returns true when value is today', () => {
 		expect(isNotBeforeToday(today)).toBe(true)
+	})
+
+	it('returns an error when the value is a past Date object', () => {
+		expect(typeof isNotBeforeToday(pastDateObject)).toBe('string')
+	})
+
+	it('returns true when the value is a future Date object', () => {
+		expect(isNotBeforeToday(futureDateObject)).toBe(true)
+	})
+
+	it('returns true when the value is today as a Date object', () => {
+		expect(isNotBeforeToday(todayDateObject)).toBe(true)
+	})
+
+	it('returns an error when the value is neither a string nor a Date', () => {
+		expect(typeof isNotBeforeToday(123)).toBe('string')
 	})
 })


### PR DESCRIPTION
```` <script lang='ts' setup>
  import DatePicker from '@/components/DatePicker/CalendarMode/DatePicker.vue';
  import { isNotBeforeTodayFn } from '@/utils/rules/'
  import { ref } from 'vue'
const date = ref();
const rules = [
  {
    type: 'custom',
    options: {
      validate: isNotBeforeTodayFn(),
    }
  }
 ]
</script>
<template>
    <DatePicker
            v-model="date"
            :custom-rules="rules"
            label="Date"
            :show-success-messages="false"
          />
</template>