### PR TITLE
1682 - Changer couleur btn secondaire

### DIFF
--- a/src/components/Amelipro/AmeliproPatientLogin/AmeliproPatientLoginForm/AmeliproPatientLoginForm.vue
+++ b/src/components/Amelipro/AmeliproPatientLogin/AmeliproPatientLoginForm/AmeliproPatientLoginForm.vue
@@ -83,6 +83,14 @@
 		},
 	})
 
+  const isSecondaryBtnProps = {
+    bordered: true,
+    color: 'ap-white',
+    hoverColor: 'ap-blue-lighten-3',
+    textColor: 'ap-blue-darken-1',
+  }
+
+
 	const vitalCardBtnText = computed(() => (props.autoCompleteCardItems ? 'Lire carte virtuelle' : 'Lire la carte'))
 
 	const clickVitalCard = () => emit('click:vital-card', `${props.uniqueId}-vital-card-btn`)
@@ -154,6 +162,7 @@
 					class="w-100"
 					:disabled="disableBtnAppVitalCard"
 					:unique-id="`${uniqueId}-vital-card-app-btn`"
+          v-bind="noVitalCard ? undefined : isSecondaryBtnProps"
 					@click="clickVitalCardApp"
 				>
 					Lire appli carte vitale

--- a/src/components/Amelipro/AmeliproPatientLogin/AmeliproPatientLoginForm/AmeliproPatientLoginForm.vue
+++ b/src/components/Amelipro/AmeliproPatientLogin/AmeliproPatientLoginForm/AmeliproPatientLoginForm.vue
@@ -83,13 +83,12 @@
 		},
 	})
 
-  const isSecondaryBtnProps = {
-    bordered: true,
-    color: 'ap-white',
-    hoverColor: 'ap-blue-lighten-3',
-    textColor: 'ap-blue-darken-1',
-  }
-
+	const isSecondaryBtnProps = {
+		bordered: true,
+		color: 'ap-white',
+		hoverColor: 'ap-blue-lighten-3',
+		textColor: 'ap-blue-darken-1',
+	}
 
 	const vitalCardBtnText = computed(() => (props.autoCompleteCardItems ? 'Lire carte virtuelle' : 'Lire la carte'))
 
@@ -162,7 +161,7 @@
 					class="w-100"
 					:disabled="disableBtnAppVitalCard"
 					:unique-id="`${uniqueId}-vital-card-app-btn`"
-          v-bind="noVitalCard ? undefined : isSecondaryBtnProps"
+					v-bind="noVitalCard ? undefined : isSecondaryBtnProps"
 					@click="clickVitalCardApp"
 				>
 					Lire appli carte vitale


### PR DESCRIPTION
## Description

Changement de couleur du bouton `Lire appli carte vitale` en `Secondary` si le bouton `Lire la carte` est visible

<img width="982" height="637" alt="image" src="https://github.com/user-attachments/assets/9fcbae78-2ec9-4251-84a6-88ed4375fc35" />
<img width="979" height="388" alt="image" src="https://github.com/user-attachments/assets/ff61c919-7239-4a53-8572-4f026f315264" />


## Type de changement

- Correction de bug

## Checklist

- [x]  Ma Pull Request pointe vers la bonne branche
- [x]  Le composant est fonctionnel
- [x]  J'ai effectué une review de mon propre code