### PR TITLE
Feat/1685 textfield evolution

### DIFF
--- a/src/components/Amelipro/AmeliproTextField/AmeliproTextField.stories.ts
+++ b/src/components/Amelipro/AmeliproTextField/AmeliproTextField.stories.ts
@@ -23,7 +23,7 @@ const meta = {
 		'horizontal': { description: 'Passe le champ au format horizontal' },
 		'inputMaxWidth': { description: 'Gère la largeur maximale du champ, attend une valeur et une unité valide css (ex : 400px ou 25%)' },
 		'inputMinWidth': { description: 'Gère la largeur minimale du champ, attend une valeur et une unité valide css (ex : 400px ou 25%)' },
-        'isValidationList': {description: 'Affiche une liste des règles à valider (uniquemenent avec type email et password)'},
+		'isValidationList': { description: 'Affiche une liste des règles à valider (uniquemenent avec type email et password)' },
 		'label': { description: 'Défini le label du champ' },
 		'labelInfo': { description: 'Permet d\'ajouter des infos à la suite du libellé du champ' },
 		'labelMaxWidth': { description: 'Gère la largeur maximale du label, attend une valeur et une unité valide css (ex : 400px ou 25%)' },
@@ -835,24 +835,24 @@ export const Validation: Story = {
 }
 
 export const ValidationList: Story = {
-    args: {
-        label: 'Champ avec liste de validation validation',
-        modelValue: '',
-        uniqueId: 'list-validation',
-        type: 'password',
-        isValidationList: true,
-        rules: [
-            v => String(v ?? '').length >= 12 || 'Au moins 12 caractères',
-            v => ((/[A-Z]/.test(String(v ?? '')) && /[a-z]/.test(String(v ?? '')))) || 'Au moins une majuscule (A-Z) et une minuscule (a-z)',
-            v => /\d/.test(String(v ?? '')) || 'Au moins un chiffre (0-9)',
-            v => /[!@#$%^&*?./:;]/.test(String(v ?? '')) || 'Au moins un caractère spécial (! @ # $ % ^ & * ? . / : ;)'
-        ],
-    },
-    parameters: {
-        sourceCode: [
-            {
-                name: 'Template',
-                code: `<template>
+	args: {
+		label: 'Champ avec liste de validation validation',
+		modelValue: '',
+		uniqueId: 'list-validation',
+		type: 'password',
+		isValidationList: true,
+		rules: [
+			v => String(v ?? '').length >= 12 || 'Au moins 12 caractères',
+			v => ((/[A-Z]/.test(String(v ?? '')) && /[a-z]/.test(String(v ?? '')))) || 'Au moins une majuscule (A-Z) et une minuscule (a-z)',
+			v => /\d/.test(String(v ?? '')) || 'Au moins un chiffre (0-9)',
+			v => /[!@#$%^&*?./:;]/.test(String(v ?? '')) || 'Au moins un caractère spécial (! @ # $ % ^ & * ? . / : ;)',
+		],
+	},
+	parameters: {
+		sourceCode: [
+			{
+				name: 'Template',
+				code: `<template>
 	<p>Le champ utilise la prop <code>rules</code> pour valider la saisie ainsi que le prop <code>isValidationList</code> pour afficher la liste des règles à valider.</p>
 	<AmeliproTextField
 		v-model="model"
@@ -868,28 +868,28 @@ export const ValidationList: Story = {
 ]"
 	/>
 </template>`,
-            },
-            {
-                name: 'Script',
-                code: `<script setup lang="ts">
+			},
+			{
+				name: 'Script',
+				code: `<script setup lang="ts">
 	import { AmeliproTextField } from '@cnamts/synapse'
 	import { ref } from 'vue'
 
 	const model = ref()
 </script>`,
-            },
-        ],
-    },
-    render: args => ({
-        components: {AmeliproTextField},
-        setup() {
-            const model = ref()
-            watch(() => args.modelValue, (newValue) => {
-                model.value = newValue
-            })
-            return {args, model}
-        },
-        template: `
+			},
+		],
+	},
+	render: args => ({
+		components: { AmeliproTextField },
+		setup() {
+			const model = ref()
+			watch(() => args.modelValue, (newValue) => {
+				model.value = newValue
+			})
+			return { args, model }
+		},
+		template: `
           <p>Le champ utilise la prop <code>rules</code> pour valider la saisie ainsi que le prop
             <code>isValidationList</code>
             pour afficher la liste des règles à valider.</p>
@@ -898,5 +898,5 @@ export const ValidationList: Story = {
               v-model="model"
           />
         `,
-    }),
+	}),
 }

--- a/src/components/Amelipro/AmeliproTextField/AmeliproTextField.stories.ts
+++ b/src/components/Amelipro/AmeliproTextField/AmeliproTextField.stories.ts
@@ -23,6 +23,7 @@ const meta = {
 		'horizontal': { description: 'Passe le champ au format horizontal' },
 		'inputMaxWidth': { description: 'Gère la largeur maximale du champ, attend une valeur et une unité valide css (ex : 400px ou 25%)' },
 		'inputMinWidth': { description: 'Gère la largeur minimale du champ, attend une valeur et une unité valide css (ex : 400px ou 25%)' },
+        'isValidationList': {description: 'Affiche une liste des règles à valider (uniquemenent avec type email et password)'},
 		'label': { description: 'Défini le label du champ' },
 		'labelInfo': { description: 'Permet d\'ajouter des infos à la suite du libellé du champ' },
 		'labelMaxWidth': { description: 'Gère la largeur maximale du label, attend une valeur et une unité valide css (ex : 400px ou 25%)' },
@@ -831,4 +832,71 @@ export const Validation: Story = {
 />
 `,
 	}),
+}
+
+export const ValidationList: Story = {
+    args: {
+        label: 'Champ avec liste de validation validation',
+        modelValue: '',
+        uniqueId: 'list-validation',
+        type: 'password',
+        isValidationList: true,
+        rules: [
+            v => String(v ?? '').length >= 12 || 'Au moins 12 caractères',
+            v => ((/[A-Z]/.test(String(v ?? '')) && /[a-z]/.test(String(v ?? '')))) || 'Au moins une majuscule (A-Z) et une minuscule (a-z)',
+            v => /\d/.test(String(v ?? '')) || 'Au moins un chiffre (0-9)',
+            v => /[!@#$%^&*?./:;]/.test(String(v ?? '')) || 'Au moins un caractère spécial (! @ # $ % ^ & * ? . / : ;)'
+        ],
+    },
+    parameters: {
+        sourceCode: [
+            {
+                name: 'Template',
+                code: `<template>
+	<p>Le champ utilise la prop <code>rules</code> pour valider la saisie ainsi que le prop <code>isValidationList</code> pour afficher la liste des règles à valider.</p>
+	<AmeliproTextField
+		v-model="model"
+		label="Champ avec validation"
+		unique-id="text-validation"
+		type="password"
+		isValidationList
+		:rules="[
+  v => String(v ?? '').length >= 12 || 'Au moins 12 caractères',
+  v => ((/[A-Z]/.test(String(v ?? '')) && /[a-z]/.test(String(v ?? '')))) || 'Au moins une majuscule (A-Z) et une minuscule (a-z)',
+  v => /\\d/.test(String(v ?? '')) || 'Au moins un chiffre (0-9)',
+  v => /[!@#$%^&*?./:;]/.test(String(v ?? '')) || 'Au moins un caractère spécial (! @ # $ % ^ & * ? . / : ;)'
+]"
+	/>
+</template>`,
+            },
+            {
+                name: 'Script',
+                code: `<script setup lang="ts">
+	import { AmeliproTextField } from '@cnamts/synapse'
+	import { ref } from 'vue'
+
+	const model = ref()
+</script>`,
+            },
+        ],
+    },
+    render: args => ({
+        components: {AmeliproTextField},
+        setup() {
+            const model = ref()
+            watch(() => args.modelValue, (newValue) => {
+                model.value = newValue
+            })
+            return {args, model}
+        },
+        template: `
+          <p>Le champ utilise la prop <code>rules</code> pour valider la saisie ainsi que le prop
+            <code>isValidationList</code>
+            pour afficher la liste des règles à valider.</p>
+          <AmeliproTextField
+              v-bind="args"
+              v-model="model"
+          />
+        `,
+    }),
 }

--- a/src/components/Amelipro/AmeliproTextField/AmeliproTextField.stories.ts
+++ b/src/components/Amelipro/AmeliproTextField/AmeliproTextField.stories.ts
@@ -857,7 +857,7 @@ export const ValidationList: Story = {
 	<AmeliproTextField
 		v-model="model"
 		label="Champ avec validation"
-		unique-id="text-validation"
+		unique-id="list-validation"
 		type="password"
 		isValidationList
 		:rules="[

--- a/src/components/Amelipro/AmeliproTextField/AmeliproTextField.vue
+++ b/src/components/Amelipro/AmeliproTextField/AmeliproTextField.vue
@@ -464,16 +464,16 @@
 		opacity: 1 !important;
 	}
 
-  .amelipro-validation-rules {
-    font-size: apTokens.$font-size-xs;
-    color: apTokens.$ap-grey;
+	.amelipro-validation-rules {
+		font-size: apTokens.$font-size-xs;
+		color: apTokens.$ap-grey;
 
-    .amelipro-validation-rule {
-      &.is-valid {
-        color: apTokens.$ap-turquoise-darken1;
-      }
-    }
-  }
+		.amelipro-validation-rule {
+			&.is-valid {
+				color: apTokens.$ap-turquoise-darken1;
+			}
+		}
+	}
 
 	.amelipro-text-field__label {
 		font-size: apTokens.$font-size-xs;

--- a/src/components/Amelipro/AmeliproTextField/AmeliproTextField.vue
+++ b/src/components/Amelipro/AmeliproTextField/AmeliproTextField.vue
@@ -11,6 +11,7 @@
 	import { notAfterDate } from '@/utils/amelipro/rules/notAfterDate'
 	import { notBeforeDate } from '@/utils/amelipro/rules/notBeforeDate'
 	import { isRequired } from '@/utils/rules/isRequired'
+import {mdiEye, mdiEyeOff} from '@mdi/js'
 
 	const props = defineProps({
 		required: {
@@ -130,8 +131,10 @@
 		},
 	})
 
+const show = ref(false)
 	const inputTextField = ref<InputTextField>({ errorMessages: [], isValid: true })
 	const messagesToDisplay = computed(() => inputTextField.value.errorMessages)
+const isPassword = computed(() => props.type === 'password')
 	defineExpose({ messagesToDisplay })
 
 	const inputValue = computed({
@@ -143,8 +146,23 @@
 
 	const browserType = window?.navigator?.userAgent ?? ''
 	const isBrowserSafari = (/^((?!chrome|android).)*safari/i).test(browserType)
-	const computedType = computed<string>(() => (isBrowserSafari && props.disabledDateForSafari && props.type === 'date' ? 'text' : props.type))
-	const focused = ref(false)
+const computedType = computed<string>(() => {
+  if (props.type === 'password') {
+    return show.value ? 'text' : 'password'
+  }
+
+  if (
+      isBrowserSafari &&
+      props.disabledDateForSafari &&
+      props.type === 'date'
+  ) {
+    return 'text'
+  }
+
+  return props.type
+})
+
+const focused = ref(false)
 	const errorId = computed<string>(() => `${props.uniqueId}-error`)
 	const displayError = computed(() => (inputTextField.value?.isValid !== null && !inputTextField.value?.isValid) && (inputTextField.value?.errorMessages && inputTextField.value?.errorMessages.length > 0))
 	const inputRules = computed<ValidationRule[]>(() => {
@@ -301,7 +319,7 @@
 				v-model="inputValue"
 				:aria-describedby="displayError ? errorId : undefined"
 				:aria-invalid="displayError ? true : undefined"
-				:required="required"
+        :required="required"
 				:bg-color="disabled ? 'ap-grey-lighten-2' : 'ap-white'"
 				class="pt-0 amelipro-text-field"
 				:clearable="clearable"
@@ -323,6 +341,14 @@
 				@change="emitChangeEvent"
 				@focus="focused = true"
 			>
+        <template #append-inner v-if="isPassword">
+          <VIcon
+              :icon="show ? mdiEye : mdiEyeOff"
+              :color="disabled || readonly ? 'ap-grey-darken-1' : 'ap-blue-darken-1'"
+              class="amelipro-eye-icon"
+              @click="!disabled && !readonly && (show = !show)"
+          />
+        </template>
 				<template
 					v-if="$slots.append"
 					#append
@@ -372,6 +398,10 @@
 		& :deep(.v-field.v-field--variant-outlined.v-field--focused .v-field__outline) {
 			--v-field-border-width: 1px !important;
 		}
+	}
+
+	.amelipro-eye-icon {
+		opacity: 1 !important;
 	}
 
 	.amelipro-text-field__label {

--- a/src/components/Amelipro/AmeliproTextField/AmeliproTextField.vue
+++ b/src/components/Amelipro/AmeliproTextField/AmeliproTextField.vue
@@ -389,7 +389,7 @@
 					/>
 				</template>
 				<template
-					v-if="$slots.appen"
+            v-if="$slots.append"
 					#append
 				>
 					<slot name="append" />

--- a/src/components/Amelipro/AmeliproTextField/AmeliproTextField.vue
+++ b/src/components/Amelipro/AmeliproTextField/AmeliproTextField.vue
@@ -11,7 +11,7 @@
 	import { notAfterDate } from '@/utils/amelipro/rules/notAfterDate'
 	import { notBeforeDate } from '@/utils/amelipro/rules/notBeforeDate'
 	import { isRequired } from '@/utils/rules/isRequired'
-import {mdiEye, mdiEyeOff} from '@mdi/js'
+	import { mdiCheck, mdiClose, mdiEye, mdiEyeOff } from '@mdi/js'
 
 	const props = defineProps({
 		required: {
@@ -69,6 +69,10 @@ import {mdiEye, mdiEyeOff} from '@mdi/js'
 		inputMinWidth: {
 			type: String,
 			default: undefined,
+		},
+		isValidationList: {
+			type: Boolean,
+			default: false,
 		},
 		label: {
 			type: String,
@@ -131,10 +135,10 @@ import {mdiEye, mdiEyeOff} from '@mdi/js'
 		},
 	})
 
-const show = ref(false)
+	const show = ref(false)
 	const inputTextField = ref<InputTextField>({ errorMessages: [], isValid: true })
 	const messagesToDisplay = computed(() => inputTextField.value.errorMessages)
-const isPassword = computed(() => props.type === 'password')
+	const isPassword = computed(() => props.type === 'password')
 	defineExpose({ messagesToDisplay })
 
 	const inputValue = computed({
@@ -146,23 +150,23 @@ const isPassword = computed(() => props.type === 'password')
 
 	const browserType = window?.navigator?.userAgent ?? ''
 	const isBrowserSafari = (/^((?!chrome|android).)*safari/i).test(browserType)
-const computedType = computed<string>(() => {
-  if (props.type === 'password') {
-    return show.value ? 'text' : 'password'
-  }
+	const computedType = computed<string>(() => {
+		if (props.type === 'password') {
+			return show.value ? 'text' : 'password'
+		}
 
-  if (
-      isBrowserSafari &&
-      props.disabledDateForSafari &&
-      props.type === 'date'
-  ) {
-    return 'text'
-  }
+		if (
+			isBrowserSafari
+			&& props.disabledDateForSafari
+			&& props.type === 'date'
+		) {
+			return 'text'
+		}
 
-  return props.type
-})
+		return props.type
+	})
 
-const focused = ref(false)
+	const focused = ref(false)
 	const errorId = computed<string>(() => `${props.uniqueId}-error`)
 	const displayError = computed(() => (inputTextField.value?.isValid !== null && !inputTextField.value?.isValid) && (inputTextField.value?.errorMessages && inputTextField.value?.errorMessages.length > 0))
 	const inputRules = computed<ValidationRule[]>(() => {
@@ -192,6 +196,38 @@ const focused = ref(false)
 			}
 		}
 		return rules
+	})
+
+	const isRulesType = computed(() =>
+		props.type === 'password' || props.type === 'email',
+	)
+
+	const rulesTitle = computed(() => {
+		if (props.type === 'password') return 'Votre mot de passe doit respecter les règles suivantes :'
+		if (props.type === 'email') return 'Votre e-mail doit respecter les règles suivantes :'
+		return ''
+	})
+
+	function getRuleLabel(rule: ValidationRule): string {
+		const result = rule('') // valeur volontairement invalide
+
+		return typeof result === 'string' ? result : ''
+	}
+
+	const rulesState = computed(() => {
+		if (!isRulesType.value || !props.rules) {
+			return []
+		}
+
+		return props.rules.map((rule, index) => {
+			const valid = rule(inputValue.value) === true
+
+			return {
+				key: index,
+				label: getRuleLabel(rule),
+				valid,
+			}
+		})
 	})
 
 	const emit = defineEmits(['change', 'update:model-value'])
@@ -319,7 +355,7 @@ const focused = ref(false)
 				v-model="inputValue"
 				:aria-describedby="displayError ? errorId : undefined"
 				:aria-invalid="displayError ? true : undefined"
-        :required="required"
+				:required="required"
 				:bg-color="disabled ? 'ap-grey-lighten-2' : 'ap-white'"
 				class="pt-0 amelipro-text-field"
 				:clearable="clearable"
@@ -327,7 +363,7 @@ const focused = ref(false)
 				:counter="counter"
 				density="compact"
 				:disabled="disabled"
-				:hide-details="hideErrorMessage || fullWidthErrorMsg"
+				:hide-details="hideErrorMessage || fullWidthErrorMsg || props.isValidationList"
 				:max="maxDate || maxNumber"
 				:min="minDate || minNumber"
 				:placeholder="placeholder"
@@ -341,16 +377,19 @@ const focused = ref(false)
 				@change="emitChangeEvent"
 				@focus="focused = true"
 			>
-        <template #append-inner v-if="isPassword">
-          <VIcon
-              :icon="show ? mdiEye : mdiEyeOff"
-              :color="disabled || readonly ? 'ap-grey-darken-1' : 'ap-blue-darken-1'"
-              class="amelipro-eye-icon"
-              @click="!disabled && !readonly && (show = !show)"
-          />
-        </template>
 				<template
-					v-if="$slots.append"
+					v-if="isPassword && inputValue"
+					#append-inner
+				>
+					<VIcon
+						:icon="show ? mdiEye : mdiEyeOff"
+						:color="disabled || readonly ? 'ap-grey-darken-1' : 'ap-blue-darken-1'"
+						class="amelipro-eye-icon"
+						@click="!disabled && !readonly && (show = !show)"
+					/>
+				</template>
+				<template
+					v-if="$slots.appen"
 					#append
 				>
 					<slot name="append" />
@@ -383,6 +422,27 @@ const focused = ref(false)
 			</p>
 		</AmeliproMessage>
 	</div>
+	<div
+		v-if="props.isValidationList && isRulesType && rulesState.length"
+		class="amelipro-validation-rules"
+	>
+		<div class="mb-1">
+			{{ rulesTitle }}
+		</div>
+		<div
+			v-for="rule in rulesState"
+			:key="rule.key"
+			class="d-flex align-center mb-1 amelipro-validation-rule"
+			:class="{ 'is-valid': rule.valid, 'is-invalid': !rule.valid }"
+		>
+			<VIcon
+				:icon="rule.valid ? mdiCheck : mdiClose"
+				size="18"
+				class="mr-2"
+			/>
+			<div>{{ rule.label }}</div>
+		</div>
+	</div>
 </template>
 
 <style lang="scss" scoped>
@@ -403,6 +463,17 @@ const focused = ref(false)
 	.amelipro-eye-icon {
 		opacity: 1 !important;
 	}
+
+  .amelipro-validation-rules {
+    font-size: apTokens.$font-size-xs;
+    color: apTokens.$ap-grey;
+
+    .amelipro-validation-rule {
+      &.is-valid {
+        color: apTokens.$ap-turquoise-darken1;
+      }
+    }
+  }
 
 	.amelipro-text-field__label {
 		font-size: apTokens.$font-size-xs;

--- a/src/components/Amelipro/AmeliproTextField/AmeliproTextField.vue
+++ b/src/components/Amelipro/AmeliproTextField/AmeliproTextField.vue
@@ -389,7 +389,7 @@
 					/>
 				</template>
 				<template
-            v-if="$slots.append"
+					v-if="$slots.append"
 					#append
 				>
 					<slot name="append" />

--- a/src/components/Amelipro/AmeliproTextField/__tests__/AmeliproTextField.spec.ts
+++ b/src/components/Amelipro/AmeliproTextField/__tests__/AmeliproTextField.spec.ts
@@ -155,10 +155,10 @@ const expectedPropOptions: ExpectedPropOptions<typeof AmeliproTextField> = {
 		type: String,
 		default: undefined,
 	},
-    isValidationList: {
-        type: Boolean,
-        default: false,
-    },
+	isValidationList: {
+		type: Boolean,
+		default: false,
+	},
 	label: {
 		type: String,
 		required: true,
@@ -276,20 +276,20 @@ describe('AmeliproTextField', () => {
 			vueWrapper = shallowMount(AmeliproTextField, { props: requiredPropValues() })
 		})
 
-        it('prop uniqueId sets attribute id on root container', async () => {
-            const defaultId = testHelper.default('uniqueId')
-            let container = vueWrapper.find(`#${defaultId}-container`)
+		it('prop uniqueId sets attribute id on root container', async () => {
+			const defaultId = testHelper.default('uniqueId')
+			let container = vueWrapper.find(`#${defaultId}-container`)
 
-            expect(container.exists()).toBe(true)
-            expect(container.attributes('id')).toBe(`${defaultId}-container`)
+			expect(container.exists()).toBe(true)
+			expect(container.attributes('id')).toBe(`${defaultId}-container`)
 
-            const {uniqueId} = modifiedPropValues()
-            await vueWrapper.setProps({uniqueId})
+			const { uniqueId } = modifiedPropValues()
+			await vueWrapper.setProps({ uniqueId })
 
-            container = vueWrapper.find(`#${uniqueId}-container`)
-            expect(container.exists()).toBe(true)
-            expect(container.attributes('id')).toBe(`${uniqueId}-container`)
-        })
+			container = vueWrapper.find(`#${uniqueId}-container`)
+			expect(container.exists()).toBe(true)
+			expect(container.attributes('id')).toBe(`${uniqueId}-container`)
+		})
 
 		it('prop label sets label text', async () => {
 			expect(vueWrapper.find('.amelipro-text-field__label').text()).toContain(testHelper.default('label'))

--- a/src/components/Amelipro/AmeliproTextField/__tests__/AmeliproTextField.spec.ts
+++ b/src/components/Amelipro/AmeliproTextField/__tests__/AmeliproTextField.spec.ts
@@ -155,6 +155,10 @@ const expectedPropOptions: ExpectedPropOptions<typeof AmeliproTextField> = {
 		type: String,
 		default: undefined,
 	},
+    isValidationList: {
+        type: Boolean,
+        default: false,
+    },
 	label: {
 		type: String,
 		required: true,
@@ -272,12 +276,20 @@ describe('AmeliproTextField', () => {
 			vueWrapper = shallowMount(AmeliproTextField, { props: requiredPropValues() })
 		})
 
-		it('prop uniqueId sets attribute id on root container', async () => {
-			expect(vueWrapper.attributes('id')).toBe(`${testHelper.default('uniqueId')}-container`)
-			const { uniqueId } = modifiedPropValues()
-			await vueWrapper.setProps({ uniqueId })
-			expect(vueWrapper.attributes('id')).toBe(`${testHelper.modified('uniqueId')}-container`)
-		})
+        it('prop uniqueId sets attribute id on root container', async () => {
+            const defaultId = testHelper.default('uniqueId')
+            let container = vueWrapper.find(`#${defaultId}-container`)
+
+            expect(container.exists()).toBe(true)
+            expect(container.attributes('id')).toBe(`${defaultId}-container`)
+
+            const {uniqueId} = modifiedPropValues()
+            await vueWrapper.setProps({uniqueId})
+
+            container = vueWrapper.find(`#${uniqueId}-container`)
+            expect(container.exists()).toBe(true)
+            expect(container.attributes('id')).toBe(`${uniqueId}-container`)
+        })
 
 		it('prop label sets label text', async () => {
 			expect(vueWrapper.find('.amelipro-text-field__label').text()).toContain(testHelper.default('label'))

--- a/src/components/Amelipro/AmeliproTextField/__tests__/__snapshots__/AmeliproTextField.spec.ts.snap
+++ b/src/components/Amelipro/AmeliproTextField/__tests__/__snapshots__/AmeliproTextField.spec.ts.snap
@@ -140,4 +140,5 @@ exports[`AmeliproTextField > Snapshots > renders the component with only require
   </div>
   <!-- v-if -->
 </div>
+<!-- v-if -->
 `;

--- a/src/components/Amelipro/AmeliproTextField/__tests__/__snapshots__/AmeliproTextField.spec.ts.snap
+++ b/src/components/Amelipro/AmeliproTextField/__tests__/__snapshots__/AmeliproTextField.spec.ts.snap
@@ -81,6 +81,7 @@ exports[`AmeliproTextField > Snapshots > renders the component with all properti
   </div>
   <!-- v-if -->
 </div>
+<!-- v-if -->
 `;
 
 exports[`AmeliproTextField > Snapshots > renders the component with only required properties filled in 1`] = `


### PR DESCRIPTION
## Description

Faire évoluer le composant `AmeliproTextField` pour y ajouter une liste de validation quand le type est `email `ou `password`

<img width="982" height="271" alt="image" src="https://github.com/user-attachments/assets/73c63483-07af-4b71-ae99-d9a81ce6a7f1" />

https://www.figma.com/design/gcoHNuRxPDBSrItpEn7f70/Amelipro-design-system-V2?node-id=2191-34391&t=mIpE2pnfyd4l200B-4

## Type de changement

- Nouvelle fonctionnalité

## Checklist

- [x]  Ma Pull Request pointe vers la bonne branche
- [x]  Le composant est fonctionnel
- [x]  J'ai effectué une review de mon propre code