### PR TITLE
DIALOGBOX: enlever l'ombre du bouton valider

### DIFF
--- a/src/components/DialogBox/DialogBox.stories.ts
+++ b/src/components/DialogBox/DialogBox.stories.ts
@@ -718,7 +718,7 @@ export const VuetifyOptions: Story = {
 				rounded: 'xl',
 			},
 			cardTitle: {
-				class: 'pa-4 mb-4 accent--text',
+				class: 'pa-5 mb-4 accent--text',
 			},
 			closeBtn: {
 				class: {
@@ -801,7 +801,7 @@ export const VuetifyOptions: Story = {
 							rounded: 'xl',
 						},
 						cardTitle: {
-							class: 'pa-4 mb-4 accent--text',
+							class: 'pa-5 mb-4 accent--text',
 						},
 						closeBtn: {
 							class: {

--- a/src/components/DialogBox/DialogBox.stories.ts
+++ b/src/components/DialogBox/DialogBox.stories.ts
@@ -718,7 +718,7 @@ export const VuetifyOptions: Story = {
 				rounded: 'xl',
 			},
 			cardTitle: {
-				class: 'pa-0 mb-4 accent--text',
+				class: 'pa-4 mb-4 accent--text',
 			},
 			closeBtn: {
 				class: {
@@ -801,7 +801,7 @@ export const VuetifyOptions: Story = {
 							rounded: 'xl',
 						},
 						cardTitle: {
-							class: 'pa-0 mb-4 accent--text',
+							class: 'pa-4 mb-4 accent--text',
 						},
 						closeBtn: {
 							class: {

--- a/src/components/DialogBox/DialogBox.vue
+++ b/src/components/DialogBox/DialogBox.vue
@@ -240,7 +240,7 @@
 @use '@/assets/tokens' as *;
 
 .sy-dialog-box-actions :deep(.v-btn) {
-  box-shadow: none;
+	box-shadow: none;
 }
 
 .sy-dialog-box-title {

--- a/src/components/DialogBox/DialogBox.vue
+++ b/src/components/DialogBox/DialogBox.vue
@@ -188,6 +188,7 @@
 			<div
 				v-if="!props.hideActions"
 				v-bind="options.cardActions"
+				:class="options.actionsSlot?.class"
 				class="sy-dialog-box-actions-ctn"
 			>
 				<VSpacer v-bind="options.actionsSpacer" />
@@ -237,6 +238,10 @@
 
 <style lang="scss" scoped>
 @use '@/assets/tokens' as *;
+
+.sy-dialog-box-actions :deep(.v-btn) {
+  box-shadow: none;
+}
 
 .sy-dialog-box-title {
 	line-height: normal;

--- a/src/components/DialogBox/config.ts
+++ b/src/components/DialogBox/config.ts
@@ -21,5 +21,7 @@ export const config = {
 	},
 	confirmBtn: {
 		color: 'primary',
+		elevation: 0,
+
 	},
 } as const

--- a/src/components/DialogBox/config.ts
+++ b/src/components/DialogBox/config.ts
@@ -24,4 +24,7 @@ export const config = {
 		elevation: 0,
 
 	},
+	actionsSlot: {
+		class: 'sy-dialog-box-actions',
+	},
 } as const


### PR DESCRIPTION
## Description

supprimer l'ombre du bouton valider


## Type de changement

- Correction de bug

## Checklist de validation RGAA

- [ ] Testé avec navigation au clavier
- [ ] Testé avec lecteur d'écran
- [ ] Testé avec différentes tailles d'écran
- [ ] Testé avec Tanaguru

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [ ] Ma Pull Request pointe vers la bonne branche
- [ ] Le composant est conforme aux maquettes (tokens)
- [ ] Le composant est fonctionnel
- [ ] Le composant est responsive (mobile, tablet et desktop)
- [ ] Le composant répond aux critères d'accessibilité (test Tanaguru + A11y linter)
- [ ] J'ai effectué une review de mon propre code
- [ ] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai mis en place une stories pour ma fonctionnalité / fix /...
- [ ] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [ ] Les tests unitaires passent localement avec mes modifications

## Checklist de validation du correctif RGAA

- [ ] Conforme au critère RGAA concerné
- [ ] Testé avec navigation au clavier
- [ ] Testé avec lecteur d'écran
- [ ] Testé avec différentes tailles d'écran
- [ ] Pas de régression visuelle
- [ ] Documentation mise à jour (ajout du doc + maj avancement) 
- [ ] Breaking changes documentés