### PR TITLE
SyTextField fix du compteur de caractères

### DIFF
--- a/src/components/Customs/SyTextField/SyTextField.vue
+++ b/src/components/Customs/SyTextField/SyTextField.vue
@@ -581,6 +581,7 @@
 			:bg-color="props.bgColor"
 			:center-affix="props.centerAffix"
 			:color="props.color"
+			:counter="props.counter"
 			:counter-value="props.counterValue"
 			:density="props.density"
 			:direction="props.direction"


### PR DESCRIPTION
SyTextField fix du compteur de caractères

```
<script setup lang="ts">
	import SyTextField from '@/components/Customs/SyTextField/SyTextField.vue'
	import { ref } from 'vue'
	const inputValue = ref('')
	const rules = [
		{ type: 'maxLength', options: { length: 20, message: 'Ne doit pas dépasser 20 caractères' } },
	]
</script>

<template>
	<SyTextField
		v-model="inputValue"
		label="Playground TextField"
		:counter="20"
		:display-persistent-counter="true"
		:custom-rules="rules"
	/>
</template>

```