### PR TITLE
SyCheckbox: incoherences graphiques

### DIFF
--- a/src/components/Customs/SyCheckbox/SyCheckbox.stories.ts
+++ b/src/components/Customs/SyCheckbox/SyCheckbox.stories.ts
@@ -611,7 +611,6 @@ export const CustomColors: Story = {
 				code: `
 <div>
   <SyCheckbox v-model="checked1" label="Couleur primaire (par défaut)" />
-  <SyCheckbox v-model="checked2" label="Couleur secondaire" color="secondary" />
   <SyCheckbox v-model="checked3" label="Couleur succès" color="success" />
   <SyCheckbox v-model="checked4" label="Couleur erreur" color="error" />
   <SyCheckbox v-model="checked5" label="Couleur avertissement" color="warning" />
@@ -640,7 +639,6 @@ Le composant SyCheckbox peut être personnalisé avec différentes couleurs pour
 		template: `
 			<div>
 				<SyCheckbox v-model="checked1" label="Couleur primaire (par défaut)" />
-				<SyCheckbox v-model="checked2" label="Couleur secondaire" color="secondary" />
 				<SyCheckbox v-model="checked3" label="Couleur succès" color="success" />
 				<SyCheckbox v-model="checked4" label="Couleur erreur" color="error" />
 				<SyCheckbox v-model="checked5" label="Couleur avertissement" color="warning" />

--- a/src/components/Customs/SyCheckbox/SyCheckbox.stories.ts
+++ b/src/components/Customs/SyCheckbox/SyCheckbox.stories.ts
@@ -33,7 +33,7 @@ const meta = {
 		},
 		color: {
 			control: 'select',
-			options: ['primary', 'secondary', 'success', 'error', 'warning'],
+			options: ['primary', 'success', 'error', 'warning'],
 			description: 'Couleur de la case à cocher',
 		},
 		indeterminate: {

--- a/src/components/Customs/SyCheckbox/SyCheckbox.vue
+++ b/src/components/Customs/SyCheckbox/SyCheckbox.vue
@@ -364,10 +364,10 @@
 </template>
 
 <style>
-
 :deep(.v-input--dirty .v-selection-control__input) {
 	color: v-bind('props.color');
 }
+
 :deep(.v-checkbox--indeterminate .v-selection-control__input) {
 	color: v-bind('props.color');
 }

--- a/src/components/Customs/SyCheckbox/SyCheckbox.vue
+++ b/src/components/Customs/SyCheckbox/SyCheckbox.vue
@@ -352,9 +352,8 @@
 </template>
 
 <style>
-
-.v-input--dirty.v-checkbox .v-icon--size-default{
---v-medium-emphasis-opacity:1 !important;
+.v-input--dirty.v-checkbox .v-icon--size-default {
+	--v-medium-emphasis-opacity: 1 !important;
 }
 
 :deep(.v-checkbox--indeterminate .v-selection-control__input .v-selection-control__input-icon) {

--- a/src/components/Customs/SyCheckbox/SyCheckbox.vue
+++ b/src/components/Customs/SyCheckbox/SyCheckbox.vue
@@ -3,6 +3,7 @@
 	import { useValidation, type ValidationRule } from '@/composables/validation/useValidation'
 	import { useValidatable } from '@/composables/validation/useValidatable'
 	import { locales } from './locales'
+	import { cnamSemanticTokens } from '@/designTokens/tokens/cnam/cnamSemantic'
 
 	const props = withDefaults(
 		defineProps<{
@@ -13,6 +14,8 @@
 			ariaLabelledby?: string
 			title?: string
 			color?: string
+			colorIndeterminate?: string
+			colorDefault?: string
 			disabled?: boolean
 			readonly?: boolean
 			required?: boolean
@@ -43,6 +46,8 @@
 			ariaLabelledby: undefined,
 			title: undefined,
 			color: 'primary',
+			colorIndeterminate: '#6D8DC2',
+			colorDefault: cnamSemanticTokens.colors.border.darker,
 			disabled: false,
 			readonly: false,
 			required: false,
@@ -307,6 +312,7 @@
 			:aria-labelledby="props.ariaLabelledby"
 			:title="props.title"
 			:color="props.color"
+			:base-color="internalIndeterminate ? props.colorIndeterminate : colorDefault"
 			:disabled="props.disabled"
 			:readonly="props.readonly"
 			:hide-details="props.hideDetails"
@@ -345,13 +351,10 @@
 	</div>
 </template>
 
-<style scoped>
-:deep(.v-selection-control--dirty .v-selection-control__input) {
-	color: v-bind('props.color');
-}
+<style>
 
-:deep(.v-checkbox--indeterminate .v-selection-control__input) {
-	color: v-bind('props.color');
+.v-input--dirty.v-checkbox .v-icon--size-default{
+--v-medium-emphasis-opacity:1 !important;
 }
 
 :deep(.v-checkbox--indeterminate .v-selection-control__input .v-selection-control__input-icon) {

--- a/src/components/Customs/SyCheckbox/SyCheckbox.vue
+++ b/src/components/Customs/SyCheckbox/SyCheckbox.vue
@@ -210,6 +210,21 @@
 		return model.value ? 'true' : 'false'
 	})
 
+	const labelColor = computed(() => {
+		if (props.disabled) return cnamSemanticTokens.colors.text.disabled
+		switch (props.color) {
+		case 'error':
+			return 'rgb(var(--v-theme-error))'
+		case 'success':
+			return 'rgb(var(--v-theme-success))'
+		case 'warning':
+			return 'rgb(var(--v-theme-warning))'
+		case 'primary':
+		default:
+			return cnamSemanticTokens.colors.text.base
+		}
+	})
+
 	// Propriétés ARIA personnalisées pour éviter les conflits
 	const messageId = computed(() => {
 		// Don't create messageId if aria-labelledby is provided
@@ -312,6 +327,7 @@
 			:aria-labelledby="props.ariaLabelledby"
 			:title="props.title"
 			:color="props.color"
+			:style="{ color: labelColor }"
 			:base-color="internalIndeterminate ? props.colorIndeterminate : colorDefault"
 			:disabled="props.disabled"
 			:readonly="props.readonly"

--- a/src/components/Customs/SyCheckbox/SyCheckbox.vue
+++ b/src/components/Customs/SyCheckbox/SyCheckbox.vue
@@ -14,8 +14,6 @@
 			ariaLabelledby?: string
 			title?: string
 			color?: string
-			colorIndeterminate?: string
-			colorDefault?: string
 			disabled?: boolean
 			readonly?: boolean
 			required?: boolean
@@ -46,8 +44,6 @@
 			ariaLabelledby: undefined,
 			title: undefined,
 			color: 'primary',
-			colorIndeterminate: '#6D8DC2',
-			colorDefault: cnamSemanticTokens.colors.border.darker,
 			disabled: false,
 			readonly: false,
 			required: false,
@@ -220,8 +216,9 @@
 		case 'warning':
 			return 'rgb(var(--v-theme-warning))'
 		case 'primary':
-		default:
 			return cnamSemanticTokens.colors.text.base
+		default:
+			return ''
 		}
 	})
 
@@ -328,7 +325,6 @@
 			:title="props.title"
 			:color="props.color"
 			:style="{ color: labelColor }"
-			:base-color="internalIndeterminate ? props.colorIndeterminate : colorDefault"
 			:disabled="props.disabled"
 			:readonly="props.readonly"
 			:hide-details="props.hideDetails"
@@ -368,8 +364,12 @@
 </template>
 
 <style>
-.v-input--dirty.v-checkbox .v-icon--size-default {
-	--v-medium-emphasis-opacity: 1 !important;
+
+:deep(.v-input--dirty .v-selection-control__input) {
+	color: v-bind('props.color');
+}
+:deep(.v-checkbox--indeterminate .v-selection-control__input) {
+	color: v-bind('props.color');
 }
 
 :deep(.v-checkbox--indeterminate .v-selection-control__input .v-selection-control__input-icon) {


### PR DESCRIPTION
## Description

La couleur de la case parent n'est pas cohérente >> bluelighten40
la couleur des boxes de manière générique n'est pas la même que sur Figma >> border/darken : #222324
Labels couleurs associés au differentes modes, warning, error, primary


## Type de changement

- Correction de bug

## Checklist de validation RGAA

- [ ] Testé avec navigation au clavier
- [ ] Testé avec lecteur d'écran
- [ ] Testé avec différentes tailles d'écran
- [ ] Testé avec Tanaguru

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [ ] Ma Pull Request pointe vers la bonne branche
- [ ] Le composant est conforme aux maquettes (tokens)
- [ ] Le composant est fonctionnel
- [ ] Le composant est responsive (mobile, tablet et desktop)
- [ ] Le composant répond aux critères d'accessibilité (test Tanaguru + A11y linter)
- [ ] J'ai effectué une review de mon propre code
- [ ] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai mis en place une stories pour ma fonctionnalité / fix /...
- [ ] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [ ] Les tests unitaires passent localement avec mes modifications

## Checklist de validation du correctif RGAA

- [ ] Conforme au critère RGAA concerné
- [ ] Testé avec navigation au clavier
- [ ] Testé avec lecteur d'écran
- [ ] Testé avec différentes tailles d'écran
- [ ] Pas de régression visuelle
- [ ] Documentation mise à jour (ajout du doc + maj avancement) 
- [ ] Breaking changes documentés