### PR TITLE
ALL: ajoute regle globale pour le letter spacing a 0

### DIFF
--- a/src/assets/overrides/_typography.scss
+++ b/src/assets/overrides/_typography.scss
@@ -193,4 +193,18 @@
 	.link-label {
 		font-size: $font-size-link-label;
 	}
+
+	/* forcr letter-spacing à 0 */
+  body,
+  p,
+  span,
+  label,
+  input,
+  textarea,
+  select,
+  .v-field__input,
+  .v-label,
+  .v-messages__message {
+    letter-spacing: 0 !important;
+  }
 }

--- a/src/assets/overrides/_typography.scss
+++ b/src/assets/overrides/_typography.scss
@@ -195,7 +195,7 @@
 	}
 
 	/* forcr letter-spacing à 0 */
- 	body,
+	body,
 	p,
 	span,
 	label,

--- a/src/assets/overrides/_typography.scss
+++ b/src/assets/overrides/_typography.scss
@@ -195,16 +195,23 @@
 	}
 
 	/* forcr letter-spacing à 0 */
-  body,
-  p,
-  span,
-  label,
-  input,
-  textarea,
-  select,
-  .v-field__input,
-  .v-label,
-  .v-messages__message {
-    letter-spacing: 0 !important;
-  }
+ 	body,
+	p,
+	span,
+	label,
+	input,
+	textarea,
+	select,
+	button,
+	h1,
+	h2,
+	h3,
+	h4,
+	h5,
+	h6,
+	.v-field__input,
+	.v-label,
+	.v-messages__message {
+		letter-spacing: 0 !important;
+	}
 }


### PR DESCRIPTION
## Description
De manière générale l'interlettrage du texte (sur les buttons, les message des nirfields et autres ...) est à 0,5 ou 1 alors qu'il devrait être à 0.

## Type de changement
- Anomalie graphique

## Checklist de validation RGAA

- [ ] Testé avec navigation au clavier
- [ ] Testé avec lecteur d'écran
- [ ] Testé avec différentes tailles d'écran
- [ ] Testé avec Tanaguru

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [ ] Ma Pull Request pointe vers la bonne branche
- [ ] Le composant est conforme aux maquettes (tokens)
- [ ] Le composant est fonctionnel
- [ ] Le composant est responsive (mobile, tablet et desktop)
- [ ] Le composant répond aux critères d'accessibilité (test Tanaguru + A11y linter)
- [ ] J'ai effectué une review de mon propre code
- [ ] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai mis en place une stories pour ma fonctionnalité / fix /...
- [ ] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [ ] Les tests unitaires passent localement avec mes modifications

## Checklist de validation du correctif RGAA

- [ ] Conforme au critère RGAA concerné
- [ ] Testé avec navigation au clavier
- [ ] Testé avec lecteur d'écran
- [ ] Testé avec différentes tailles d'écran
- [ ] Pas de régression visuelle
- [ ] Documentation mise à jour (ajout du doc + maj avancement) 
- [ ] Breaking changes documentés