### PR TITLE
SyIcon: replace VIcon to SyIcon

### DIFF
--- a/src/components/BackBtn/BackBtn.vue
+++ b/src/components/BackBtn/BackBtn.vue
@@ -2,6 +2,7 @@
 	import { mdiArrowLeft } from '@mdi/js'
 	import { computed } from 'vue'
 	import { locales } from './locales'
+	import SyIcon from '@/components/Customs/SyIcon/SyIcon.vue'
 
 	const props = withDefaults(defineProps<{
 		hideBackIcon?: boolean
@@ -35,14 +36,14 @@
 		:style="{ backgroundColor: buttonBgColor }"
 	>
 		<slot name="icon">
-			<VIcon
+			<SyIcon
 				v-if="!props.hideBackIcon"
+				:icon="mdiArrowLeft"
+				decorative
 				:color="iconColor"
 				:class="{ 'ml-n1': isDark }"
 				class="mr-1"
-			>
-				{{ mdiArrowLeft }}
-			</VIcon>
+			/>
 		</slot>
 
 		<slot>

--- a/src/components/BackToTopBtn/BackToTopBtn.vue
+++ b/src/components/BackToTopBtn/BackToTopBtn.vue
@@ -8,6 +8,7 @@
 
 	import { locales } from './locales'
 	import { config } from './config'
+	import SyIcon from '@/components/Customs/SyIcon/SyIcon.vue'
 
 	import { type VBtn } from 'vuetify/components'
 
@@ -116,9 +117,11 @@
 			</span>
 
 			<slot name="icon">
-				<VIcon v-bind="options.icon">
-					{{ mdiArrowUp }}
-				</VIcon>
+				<SyIcon
+					v-bind="options.icon"
+					:icon="mdiArrowUp"
+					decorative
+				/>
 			</slot>
 		</VBtn>
 	</VFadeTransition>

--- a/src/components/Captcha/Captcha.vue
+++ b/src/components/Captcha/Captcha.vue
@@ -11,6 +11,7 @@
 	import volumeUp from './icons/volumeUp.vue'
 	import { locales as defaultLocales } from './locales'
 	import { type CaptchaType, type StateType } from './types'
+	import SyIcon from '@/components/Customs/SyIcon/SyIcon.vue'
 
 	const props = withDefaults(defineProps<{
 		urlCreate: string
@@ -202,7 +203,10 @@
 					@click="toggleAudio"
 				>
 					<span v-if="isPlaying">
-						<VIcon>{{ mdiPause }}</VIcon>
+						<SyIcon
+							:icon="mdiPause"
+							decorative
+						/>
 						{{ locales.pause }}
 					</span>
 

--- a/src/components/Captcha/CaptchaAlert.vue
+++ b/src/components/Captcha/CaptchaAlert.vue
@@ -2,6 +2,7 @@
 	import { mdiAlertCircleOutline, mdiAutorenew } from '@mdi/js'
 	import { useAttrs } from 'vue'
 	import type { locales as defaultLocales } from './locales'
+	import SyIcon from '@/components/Customs/SyIcon/SyIcon.vue'
 
 	defineProps<{
 		locales: typeof defaultLocales
@@ -22,12 +23,12 @@
 			v-bind="attrs"
 		>
 			<template #prepend>
-				<VIcon
+				<SyIcon
 					color="error"
 					class="mr-2"
-				>
-					{{ errorIcon }}
-				</VIcon>
+					:icon="errorIcon"
+					decorative
+				/>
 			</template>
 
 			<span>
@@ -44,9 +45,10 @@
 					<p class="d-sr-only">
 						{{ locales.renew }}
 					</p>
-					<VIcon>
-						{{ renewIcon }}
-					</VIcon>
+					<SyIcon
+						:icon="renewIcon"
+						decorative
+					/>
 				</VBtn>
 			</template>
 		</VAlert>

--- a/src/components/CookiesSelection/CookiesInformation/CookiesInformation.vue
+++ b/src/components/CookiesSelection/CookiesInformation/CookiesInformation.vue
@@ -108,6 +108,7 @@
 				<SyIcon
 					:icon="open ? mdiChevronUp : mdiChevronDown"
 					class="mr-2"
+					data-test="chevron"
 					decorative
 				/>
 			</summary>

--- a/src/components/CookiesSelection/CookiesInformation/CookiesInformation.vue
+++ b/src/components/CookiesSelection/CookiesInformation/CookiesInformation.vue
@@ -109,7 +109,6 @@
 					:icon="open ? mdiChevronUp : mdiChevronDown"
 					class="mr-2"
 					data-test="chevron"
-					decorative
 				/>
 			</summary>
 

--- a/src/components/CookiesSelection/CookiesInformation/CookiesInformation.vue
+++ b/src/components/CookiesSelection/CookiesInformation/CookiesInformation.vue
@@ -6,6 +6,7 @@
 	import CookiesTable from '../CookiesTable/CookiesTable.vue'
 	import type { CookieTypes, Cookie } from '../types'
 	import { locales } from './locales'
+	import SyIcon from '@/components/Customs/SyIcon/SyIcon.vue'
 
 	defineProps<{
 		type: CookieTypes
@@ -104,12 +105,11 @@
 			<summary class="mb-1">
 				{{ open ? locales.hideInformation : locales.showInformation }}
 
-				<VIcon
+				<SyIcon
+					:icon="open ? mdiChevronUp : mdiChevronDown"
 					class="mr-2"
-					data-test="chevron"
-				>
-					{{ open ? mdiChevronUp : mdiChevronDown }}
-				</VIcon>
+					decorative
+				/>
 			</summary>
 
 			<CookiesTable

--- a/src/components/CookiesSelection/CookiesInformation/CookiesInformation.vue
+++ b/src/components/CookiesSelection/CookiesInformation/CookiesInformation.vue
@@ -109,6 +109,7 @@
 					:icon="open ? mdiChevronUp : mdiChevronDown"
 					class="mr-2"
 					data-test="chevron"
+					decorative
 				/>
 			</summary>
 

--- a/src/components/CopyBtn/CopyBtn.vue
+++ b/src/components/CopyBtn/CopyBtn.vue
@@ -7,6 +7,7 @@
 
 	import { locales } from './locales'
 	import { config } from './config'
+	import SyIcon from '@/components/Customs/SyIcon/SyIcon.vue'
 
 	const props = withDefaults(defineProps<CustomizableOptions & {
 		ariaLabel?: string
@@ -106,9 +107,11 @@
 					@click="copy"
 				>
 					<slot name="icon">
-						<VIcon v-bind="options.icon">
-							{{ copyIcon }}
-						</VIcon>
+						<SyIcon
+							v-bind="options.icon"
+							:icon="copyIcon"
+							decorative
+						/>
 					</slot>
 				</VBtn>
 			</template>

--- a/src/components/Customs/Selects/SyInputSelect/SyInputSelect.vue
+++ b/src/components/Customs/Selects/SyInputSelect/SyInputSelect.vue
@@ -4,6 +4,7 @@
 	import useCustomizableOptions, { type CustomizableOptions } from '@/composables/useCustomizableOptions'
 	import { useValidation, type ValidationRule } from '@/composables/validation/useValidation'
 	import defaultOptions from './config'
+	import SyIcon from '@/components/Customs/SyIcon/SyIcon.vue'
 
 	const props = withDefaults(defineProps<CustomizableOptions & {
 		modelValue?: Record<string, unknown> | string | null
@@ -253,21 +254,20 @@
 			@keydown.space.prevent="toggleMenu"
 		>
 			<span :class="{ 'error--text': hasError }">{{ selectedItemText }}</span>
-			<VIcon
+			<SyIcon
 				v-if="hasError"
 				class="ml-2"
 				color="error"
-			>
-				{{ mdiInformation }}
-			</VIcon>
-			<VIcon> {{ mdiChevronDown }}</VIcon>
-			<VIcon
+				:icon="mdiInformation"
+			/>
+			<SyIcon :icon="mdiChevronDown" />
+			<SyIcon
 				v-if="selectedItemText && props.clearable"
+				:icon="mdiCloseCircle"
 				aria-label="Supprimer"
+				role="button"
 				@click.stop.prevent="selectItem(null)"
-			>
-				{{ mdiCloseCircle }}
-			</VIcon>
+			/>
 		</div>
 		<VList
 			v-if="isOpen"

--- a/src/components/Customs/Selects/SyInputSelect/SyInputSelect.vue
+++ b/src/components/Customs/Selects/SyInputSelect/SyInputSelect.vue
@@ -259,8 +259,12 @@
 				class="ml-2"
 				color="error"
 				:icon="mdiInformation"
+				decorative
 			/>
-			<SyIcon :icon="mdiChevronDown" />
+			<SyIcon
+				:icon="mdiChevronDown"
+				decorative
+			/>
 			<SyIcon
 				v-if="selectedItemText && props.clearable"
 				:icon="mdiCloseCircle"

--- a/src/components/Customs/SyIcon/SyIcon.vue
+++ b/src/components/Customs/SyIcon/SyIcon.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-	import { vRgaaSvgFix } from '../../../directives/rgaaSvgFix'
+	import type { IconValue } from 'vuetify/lib/composables/icons.mjs'
+	import { vRgaaSvgFix } from '@/directives/rgaaSvgFix'
 	import { computed, onMounted, watch } from 'vue'
 
 	/**
@@ -17,14 +18,14 @@
 	/**
 	 * Vérifie si une icône non décorative a un label
 	 */
-	const checkAccessibility = (icon: string, decorative: boolean | undefined, label: string | undefined) => {
+	const checkAccessibility = (icon: IconValue, decorative: boolean | undefined, label: string | undefined) => {
 		if (decorative === false && !label) {
 			console.error(`L'icône "${icon}" n'est pas décorative, mais aucun texte alternatif (label) n'a été fourni.`)
 		}
 	}
 
 	const props = defineProps<{
-		icon: string
+		icon: IconValue
 		label?: string
 		decorative?: boolean
 		role?: 'img' | 'button' | 'presentation'

--- a/src/components/DownloadBtn/DownloadBtn.vue
+++ b/src/components/DownloadBtn/DownloadBtn.vue
@@ -7,6 +7,7 @@
 	import { computed, ref, useAttrs } from 'vue'
 	import { config } from './config'
 	import { locales as defaultLocales } from './locales'
+	import SyIcon from '@/components/Customs/SyIcon/SyIcon.vue'
 
 	type State = 'idle' | 'loading' | 'success' | 'error'
 
@@ -101,12 +102,12 @@
 		@click="download"
 	>
 		<slot name="icon">
-			<VIcon
+			<SyIcon
 				v-bind="options.icon"
+				:icon="mdiDownload"
 				:color="iconColor"
-			>
-				{{ mdiDownload }}
-			</VIcon>
+				decorative
+			/>
 		</slot>
 
 		<slot />

--- a/src/components/FileList/UploadItem/UploadItem.vue
+++ b/src/components/FileList/UploadItem/UploadItem.vue
@@ -84,6 +84,7 @@
 							:icon="mdiAlertCircle"
 							:size="cnamContextualTokens.iconSize.default"
 							color="error"
+							decorative
 						/>
 
 						<SyIcon
@@ -91,6 +92,7 @@
 							:icon="mdiCheckCircle"
 							:size="cnamContextualTokens.iconSize.default"
 							color="success"
+							decorative
 						/>
 
 						<SyIcon
@@ -98,6 +100,7 @@
 							:size="cnamContextualTokens.iconSize.default"
 							color="primary"
 							:icon="mdiFile"
+							decorative
 						/>
 					</slot>
 				</span>
@@ -134,6 +137,7 @@
 						<SyIcon
 							color="primary"
 							:icon="mdiTrayArrowUp"
+							decorative
 						/>
 					</template>
 				</VBtn>
@@ -148,6 +152,7 @@
 						<SyIcon
 							color="primary"
 							:icon="mdiEyeOutline"
+							decorative
 						/>
 					</template>
 				</VBtn>
@@ -162,6 +167,7 @@
 						<SyIcon
 							color="error"
 							:icon="mdiDeleteOutline"
+							decorative
 						/>
 					</template>
 				</VBtn>

--- a/src/components/FileList/UploadItem/UploadItem.vue
+++ b/src/components/FileList/UploadItem/UploadItem.vue
@@ -9,6 +9,7 @@
 	} from '@mdi/js'
 	import { cnamContextualTokens } from '@/designTokens/tokens/cnam/cnamContextual'
 	import { locales as defaultLocales } from './locales'
+	import SyIcon from '@/components/Customs/SyIcon/SyIcon.vue'
 
 	type FileState = 'initial' | 'success' | 'error' | 'loading'
 
@@ -78,25 +79,26 @@
 							{{ locales.error }}
 						</span>
 
-						<VIcon
+						<SyIcon
 							v-if="state === 'error'"
+							:icon="mdiAlertCircle"
 							:size="cnamContextualTokens.iconSize.default"
-							:aria-label="locales.error"
 							color="error"
-						>{{ mdiAlertCircle }}</VIcon>
+						/>
 
-						<VIcon
+						<SyIcon
 							v-else-if="state === 'success'"
+							:icon="mdiCheckCircle"
 							:size="cnamContextualTokens.iconSize.default"
-							:aria-label="locales.success"
 							color="success"
-						>{{ mdiCheckCircle }}</VIcon>
+						/>
 
-						<VIcon
+						<SyIcon
 							v-else
 							:size="cnamContextualTokens.iconSize.default"
 							color="primary"
-						>{{ mdiFile }}</VIcon>
+							:icon="mdiFile"
+						/>
 					</slot>
 				</span>
 				<div>
@@ -129,11 +131,10 @@
 				>
 					<span>Importer</span>
 					<template #prepend>
-						<VIcon
+						<SyIcon
 							color="primary"
-						>
-							{{ mdiTrayArrowUp }}
-						</VIcon>
+							:icon="mdiTrayArrowUp"
+						/>
 					</template>
 				</VBtn>
 				<VBtn
@@ -144,11 +145,10 @@
 				>
 					<span>{{ locales.see }}</span>
 					<template #prepend>
-						<VIcon
+						<SyIcon
 							color="primary"
-						>
-							{{ mdiEyeOutline }}
-						</VIcon>
+							:icon="mdiEyeOutline"
+						/>
 					</template>
 				</VBtn>
 				<VBtn
@@ -159,11 +159,10 @@
 				>
 					<span>{{ locales.delete }}</span>
 					<template #prepend>
-						<VIcon
+						<SyIcon
 							color="error"
-						>
-							{{ mdiDeleteOutline }}
-						</VIcon>
+							:icon="mdiDeleteOutline"
+						/>
 					</template>
 				</VBtn>
 			</div>

--- a/src/components/FileUpload/FileUploadContent.vue
+++ b/src/components/FileUpload/FileUploadContent.vue
@@ -3,6 +3,7 @@
 	import { locales } from './locales'
 	import { mdiCloudUpload } from '@mdi/js'
 	import { computed } from 'vue'
+	import SyIcon from '@/components/Customs/SyIcon/SyIcon.vue'
 
 	const props = defineProps<{
 		allowedExtensions: string[]
@@ -31,12 +32,12 @@
 		<slot
 			name="icon"
 		>
-			<VIcon
+			<SyIcon
 				size="40"
 				color="primary"
-			>
-				{{ mdiCloudUpload }}
-			</VIcon>
+				:icon="mdiCloudUpload"
+				decorative
+			/>
 		</slot>
 
 		<span

--- a/src/components/FilterInline/FilterInline.vue
+++ b/src/components/FilterInline/FilterInline.vue
@@ -64,6 +64,7 @@
 						size="small"
 						class="ml-1"
 						:icon="isActive ? mdiChevronUp : mdiChevronDown"
+						decorative
 					/>
 				</VBtn>
 			</template>

--- a/src/components/FilterInline/FilterInline.vue
+++ b/src/components/FilterInline/FilterInline.vue
@@ -4,6 +4,7 @@
 	import { toRef } from 'vue'
 	import ChipList from '../ChipList/ChipList.vue'
 	import { locales as defaultLocales } from './locales'
+	import SyIcon from '@/components/Customs/SyIcon/SyIcon.vue'
 
 	const props = withDefaults(defineProps<{
 		modelValue?: FilterProp
@@ -59,12 +60,11 @@
 
 					{{ filter.title }}
 
-					<VIcon
+					<SyIcon
 						size="small"
 						class="ml-1"
-					>
-						{{ isActive ? mdiChevronUp : mdiChevronDown }}
-					</VIcon>
+						:icon="isActive ? mdiChevronUp : mdiChevronDown"
+					/>
 				</VBtn>
 			</template>
 

--- a/src/components/FranceConnectBtn/FranceConnectBtn.vue
+++ b/src/components/FranceConnectBtn/FranceConnectBtn.vue
@@ -3,6 +3,7 @@
 	import { computed } from 'vue'
 	import { useTheme } from 'vuetify'
 	import { locales } from './locales'
+	import SyIcon from '@/components/Customs/SyIcon/SyIcon.vue'
 
 	const props = withDefaults(defineProps<{
 		href: string
@@ -85,13 +86,12 @@
 			:aria-label="locales.infoLinkAriaLabel(isConnectPlus)"
 		>
 			{{ locales.infoLinkLabel(isConnectPlus) }}
-
-			<VIcon
+			<SyIcon
+				name="external-link"
 				size="1em"
+				:icon="mdiOpenInNew"
 				class="sy-france-connect-info-link-icon"
-			>
-				{{ mdiOpenInNew }}
-			</VIcon>
+			/>
 		</a>
 	</div>
 </template>

--- a/src/components/FranceConnectBtn/FranceConnectBtn.vue
+++ b/src/components/FranceConnectBtn/FranceConnectBtn.vue
@@ -91,6 +91,7 @@
 				size="1em"
 				:icon="mdiOpenInNew"
 				class="sy-france-connect-info-link-icon"
+				decorative
 			/>
 		</a>
 	</div>

--- a/src/components/FranceConnectBtn/tests/__snapshots__/FranceConnectBtn.spec.ts.snap
+++ b/src/components/FranceConnectBtn/tests/__snapshots__/FranceConnectBtn.spec.ts.snap
@@ -73,6 +73,7 @@ exports[`FranceConnectBtn > renders correctly 1`] = `
       v-icon
       v-theme--light
     "
+    name="external-link"
     style="
       font-size: 1em;
       height: 1em;
@@ -162,6 +163,7 @@ exports[`FranceConnectBtn > renders correctly in black 1`] = `
         v-icon
         v-theme--dark
       "
+      name="external-link"
       style="
         font-size: 1em;
         height: 1em;
@@ -247,6 +249,7 @@ exports[`FranceConnectBtn > renders correctly with connect-plus 1`] = `
       v-icon
       v-theme--light
     "
+    name="external-link"
     style="
       font-size: 1em;
       height: 1em;

--- a/src/components/LangBtn/LangBtn.vue
+++ b/src/components/LangBtn/LangBtn.vue
@@ -7,6 +7,7 @@
 	import useCustomizableOptions, { type CustomizableOptions } from '@/composables/useCustomizableOptions'
 	import defaultOptions from './config'
 	import type { VBtn, VListItem } from 'vuetify/components'
+	import SyIcon from '@/components/Customs/SyIcon/SyIcon.vue'
 
 	const props = withDefaults(defineProps<CustomizableOptions & {
 		modelValue?: string
@@ -148,13 +149,12 @@
 					class="vd-lang-btn"
 				>
 					{{ currentLangData.name }}
-					<VIcon
+					<SyIcon
 						v-if="!hideDownArrow"
 						v-bind="options.icon"
 						class="ml-1"
-					>
-						{{ mdiMenuDown }}
-					</VIcon>
+						:icon="mdiMenuDown"
+					/>
 				</VBtn>
 			</template>
 			<VList

--- a/src/components/LangBtn/LangBtn.vue
+++ b/src/components/LangBtn/LangBtn.vue
@@ -154,6 +154,7 @@
 						v-bind="options.icon"
 						class="ml-1"
 						:icon="mdiMenuDown"
+						decorative
 					/>
 				</VBtn>
 			</template>

--- a/src/components/NotificationBar/Notification/Notification.vue
+++ b/src/components/NotificationBar/Notification/Notification.vue
@@ -98,7 +98,7 @@
 					{{ props.closeBtnText }}
 				</template>
 				<template v-else>
-					<VIcon :icon="mdiClose" />
+					<SyIcon	:icon="mdiClose" />
 				</template>
 			</VBtn>
 		</div>

--- a/src/components/PasswordField/PasswordField.vue
+++ b/src/components/PasswordField/PasswordField.vue
@@ -305,7 +305,7 @@
 					@keydown.space.prevent="togglePasswordVisibility"
 					@keydown.enter.prevent="togglePasswordVisibility"
 				>
-					<VIcon
+					<SyIcon
 						:icon="showEyeIcon ? eyeIcon : eyeOffIcon"
 						color="rgb(0 0 0 / 70%)"
 						:aria-hidden="true"

--- a/src/components/PasswordField/PasswordField.vue
+++ b/src/components/PasswordField/PasswordField.vue
@@ -309,6 +309,7 @@
 						:icon="showEyeIcon ? eyeIcon : eyeOffIcon"
 						color="rgb(0 0 0 / 70%)"
 						:aria-hidden="true"
+						decorative
 					/>
 				</v-button>
 			</div>

--- a/src/components/SearchListField/SearchListField.vue
+++ b/src/components/SearchListField/SearchListField.vue
@@ -118,6 +118,7 @@
 				<SyIcon
 					:icon="mdiMagnify"
 					class="mr-1"
+					decorative
 				/>
 			</template>
 		</SyTextField>

--- a/src/components/SearchListField/SearchListField.vue
+++ b/src/components/SearchListField/SearchListField.vue
@@ -7,6 +7,7 @@
 
 	import { SyTextField, SyCheckbox } from '@/components'
 	import slugify from 'slugify'
+	import SyIcon from '@/components/Customs/SyIcon/SyIcon.vue'
 
 	const props = defineProps({
 		modelValue: {
@@ -114,9 +115,10 @@
 			:bg-color="props.bgColor"
 		>
 			<template #prepend-inner>
-				<VIcon class="mr-1">
-					{{ mdiMagnify }}
-				</VIcon>
+				<SyIcon
+					:icon="mdiMagnify"
+					class="mr-1"
+				/>
 			</template>
 		</SyTextField>
 

--- a/src/components/SyAlert/SyAlert.vue
+++ b/src/components/SyAlert/SyAlert.vue
@@ -9,6 +9,7 @@
 		mdiClose,
 	} from '@mdi/js'
 	import type { VIcon } from 'vuetify/components'
+	import SyIcon from '@/components/Customs/SyIcon/SyIcon.vue'
 
 	defineOptions({
 		inheritAttrs: false,
@@ -75,9 +76,9 @@
 			<template #prepend>
 				<VIcon
 					ref="alertIcon"
+					v-rgaa-svg-fix
 					class="alert-icon"
 					size="1.5rem"
-					role="presentation"
 				>
 					<slot name="icon">
 						{{ prependIcon }}
@@ -102,12 +103,10 @@
 					class="alert-close-btn"
 					@click="dismissAlert"
 				>
-					<VIcon
+					<SyIcon
 						size="large"
-					>
-						{{ mdiClose }}
-					</VIcon>
-
+						:icon="mdiClose"
+					/>
 					<span>
 						{{ locales.close }}
 					</span>

--- a/src/components/SyAlert/SyAlert.vue
+++ b/src/components/SyAlert/SyAlert.vue
@@ -106,6 +106,7 @@
 					<SyIcon
 						size="large"
 						:icon="mdiClose"
+						decorative
 					/>
 					<span>
 						{{ locales.close }}

--- a/src/components/TableToolbar/TableToolbar.vue
+++ b/src/components/TableToolbar/TableToolbar.vue
@@ -99,6 +99,7 @@
 				<SyIcon
 					v-bind="options.addIcon"
 					:icon="mdiPlus"
+					decorative
 				/>
 
 				<span

--- a/src/components/TableToolbar/TableToolbar.vue
+++ b/src/components/TableToolbar/TableToolbar.vue
@@ -5,6 +5,7 @@
 	import { useDisplay, useTheme } from 'vuetify'
 	import { config } from './config'
 	import { locales as defaultLocales } from './locales'
+	import SyIcon from '@/components/Customs/SyIcon/SyIcon.vue'
 
 	const props = withDefaults(defineProps<{
 		nbTotal?: number
@@ -95,9 +96,10 @@
 				data-test-id="add-btn"
 				@click="$emit('add')"
 			>
-				<VIcon v-bind="options.addIcon">
-					{{ mdiPlus }}
-				</VIcon>
+				<SyIcon
+					v-bind="options.addIcon"
+					:icon="mdiPlus"
+				/>
 
 				<span
 					v-show="!display.xs.value"

--- a/src/components/Tables/common/TableHeader.vue
+++ b/src/components/Tables/common/TableHeader.vue
@@ -232,6 +232,7 @@
 				:icon="headerParams.getSortIcon(column)"
 				:title="locales.columnOrder(column.title!)"
 				:aria-label="locales.columnOrder(column.title!)"
+				decorative
 				@click="headerParams.toggleSort(column)"
 			/>
 			<div

--- a/src/components/Tables/common/TableHeader.vue
+++ b/src/components/Tables/common/TableHeader.vue
@@ -2,6 +2,7 @@
 	import { computed, nextTick, onMounted, ref, inject, watch, type Ref, onUnmounted } from 'vue'
 	import type { VDataTable, VDataTableServer } from 'vuetify/components'
 	import { locales } from './locales'
+	import SyIcon from '@/components/Customs/SyIcon/SyIcon.vue'
 
 	type HeaderPropsRaw = {
 		class?: string | string[]
@@ -225,7 +226,7 @@
 			v-if="header!.sortable"
 			class="sort-container d-flex align-center"
 		>
-			<VIcon
+			<SyIcon
 				class="v-data-table-header__sort-icon"
 				:class="{ 'text-primary opacity-100' : isColumnSorted }"
 				:icon="headerParams.getSortIcon(column)"

--- a/src/components/Tables/common/organizeColumns/OrganizeColumns.vue
+++ b/src/components/Tables/common/organizeColumns/OrganizeColumns.vue
@@ -5,6 +5,7 @@
 	import { watch } from 'vue'
 	import type { DataTableHeaders } from '../types'
 	import { sortHeaders } from './sortHeaders'
+	import SyIcon from '@/components/Customs/SyIcon/SyIcon.vue'
 
 	const headers = defineModel<DataTableHeaders[]>(
 		'headers',
@@ -147,9 +148,10 @@
 					aria-haspopup="menu"
 					:aria-controls="isMenuOpen ? columnsMenuId : undefined"
 				>
-					<VIcon size="large">
-						{{ mdiTableEdit }}
-					</VIcon>
+					<SyIcon
+						:icon="mdiTableEdit"
+						size="large"
+					/>
 				</VBtn>
 			</template>
 			<VCard min-width="300">
@@ -186,9 +188,10 @@
 										header.hidden = !header.hidden
 									}"
 								>
-									<VIcon>
-										{{ header.hidden ? mdiEyeOff : mdiEye }}
-									</VIcon>
+									<SyIcon
+										:icon="header.hidden ? mdiEyeOff : mdiEye"
+										decorative
+									/>
 								</VBtn>
 							</div>
 							<div class="d-flex ga-2 pa-2">
@@ -207,11 +210,11 @@
 										color="primary"
 										@click="left(header)"
 									>
-										<VIcon
+										<SyIcon
+											:icon="mdiChevronUp"
+											decorative
 											size="x-large"
-										>
-											{{ mdiChevronUp }}
-										</VIcon>
+										/>
 									</VBtn>
 									<VBtn
 										:title="locales.moveColumnRight(header.title as string)"
@@ -221,11 +224,11 @@
 										color="primary"
 										@click="right(header)"
 									>
-										<VIcon
+										<SyIcon
+											:icon="mdiChevronDown"
+											decorative
 											size="x-large"
-										>
-											{{ mdiChevronDown }}
-										</VIcon>
+										/>
 									</VBtn>
 								</VBtnGroup>
 							</div>

--- a/src/components/Tables/common/organizeColumns/OrganizeColumns.vue
+++ b/src/components/Tables/common/organizeColumns/OrganizeColumns.vue
@@ -151,6 +151,7 @@
 					<SyIcon
 						:icon="mdiTableEdit"
 						size="large"
+						decorative
 					/>
 				</VBtn>
 			</template>

--- a/src/components/Usages/Usages.vue
+++ b/src/components/Usages/Usages.vue
@@ -2,6 +2,7 @@
 	import { type CustomizableOptions } from '@/composables/useCustomizableOptions'
 	import { checkIcon, croixIcon } from '@/constants/icons'
 	import { ref } from 'vue'
+	import SyIcon from '@/components/Customs/SyIcon/SyIcon.vue'
 
 	withDefaults(defineProps<CustomizableOptions & {
 		items1?: string[]
@@ -31,7 +32,7 @@
 				style="display: flex;"
 				class="d-flex check-text"
 			>
-				<VIcon :icon="iconCheck" />
+				<SyIcon :icon="iconCheck" />
 				<p class="font-weight-bold mb-2">
 					À faire
 				</p>
@@ -54,7 +55,7 @@
 			class="m-2 p-2 v-col-auto not-check"
 		>
 			<div class="d-flex not-check-text">
-				<VIcon :icon="iconCross" />
+				<SyIcon :icon="iconCross" />
 				<p class="font-weight-bold mb-2">
 					À ne pas faire
 				</p>

--- a/src/components/UserMenuBtn/UserMenuBtn.vue
+++ b/src/components/UserMenuBtn/UserMenuBtn.vue
@@ -6,6 +6,7 @@
 	import { mdiAccount, mdiLoginVariant } from '@mdi/js'
 	import useCustomizableOptions, { type CustomizableOptions } from '@/composables/useCustomizableOptions'
 	import { defaultOptions } from './config'
+	import SyIcon from '@/components/Customs/SyIcon/SyIcon.vue'
 
 	type MenuItem = { text: string, value: string, link?: string, to?: RouteLocationRaw }
 
@@ -55,14 +56,13 @@
 		class="user-menu-btn"
 	>
 		<template #append-icon>
-			<VIcon
+			<SyIcon
 				v-if="!hideUserIcon"
+				:icon="mdiAccount"
 				:size="isMobileView ? 'x-large' : 'default'"
 				class="vd-user-icon mr-0 pa-2"
 				v-bind="options['icon']"
-			>
-				{{ mdiAccount }}
-			</VIcon>
+			/>
 		</template>
 		<template #footer-list-item>
 			<slot>
@@ -73,7 +73,7 @@
 					@click="$emit('logout')"
 				>
 					<div class="d-flex">
-						<VIcon
+						<SyIcon
 							:icon="mdiLoginVariant"
 							class="mr-4"
 							v-bind="options['logoutIcon']"

--- a/src/components/UserMenuBtn/UserMenuBtn.vue
+++ b/src/components/UserMenuBtn/UserMenuBtn.vue
@@ -58,6 +58,7 @@
 		<template #append-icon>
 			<SyIcon
 				v-if="!hideUserIcon"
+				decorative
 				:icon="mdiAccount"
 				:size="isMobileView ? 'x-large' : 'default'"
 				class="vd-user-icon mr-0 pa-2"
@@ -77,6 +78,7 @@
 							:icon="mdiLoginVariant"
 							class="mr-4"
 							v-bind="options['logoutIcon']"
+							decorative
 						/>
 						<VListItemTitle class="logout">
 							{{ props.logoutText }}


### PR DESCRIPTION
## Description
Peut-être un non sujet)

Vous avez fait un composant SyIcon qui est un wrapper autour du VIcon.

Le composant SyIcon respect les normes RGAA comme indiqué dans la documentation https://cnam-design-system.netlify.app/?path=/docs/composants-donn%C3%A9es-syicon--docs

Sur le code des composants que j'ai regardé, je vois l'utilisation de VIcon, je me demande s'il ne serait pas + adéquate d'utiliser SyIcon partout à la place des VIcon.

Quelques exemples :

    https://github.com/assurance-maladie-digital/design-system-v3/blob/dev/src/components/SyAlert/SyAlert.vue#L76
    https://github.com/assurance-maladie-digital/design-system-v3/blob/dev/src/components/UserMenuBtn/UserMenuBtn.vue#L57
    https://github.com/assurance-maladie-digital/design-system-v3/blob/dev/src/components/NotificationBar/NotificationBar.vue#L178

## Type de changement

- Refactoring

## Checklist de validation RGAA

- [ ] Testé avec navigation au clavier
- [ ] Testé avec lecteur d'écran
- [ ] Testé avec différentes tailles d'écran
- [ ] Testé avec Tanaguru

## Checklist

<!-- Vérifiez chaque point de la checklist et cochez-le s'il est appliqué. -->

- [ ] Ma Pull Request pointe vers la bonne branche
- [ ] Le composant est conforme aux maquettes (tokens)
- [ ] Le composant est fonctionnel
- [ ] Le composant est responsive (mobile, tablet et desktop)
- [ ] Le composant répond aux critères d'accessibilité (test Tanaguru + A11y linter)
- [ ] J'ai effectué une review de mon propre code
- [ ] J'ai commenté mon code, en particulier dans les parties difficiles à comprendre
- [ ] J'ai mis en place une stories pour ma fonctionnalité / fix /...
- [ ] Mes modifications ne génèrent aucun nouveau warning
- [ ] J'ai ajouté des tests qui prouvent que mon correctif est efficace ou que ma fonctionnalité fonctionne
- [ ] Les tests unitaires passent localement avec mes modifications

## Checklist de validation du correctif RGAA

- [ ] Conforme au critère RGAA concerné
- [ ] Testé avec navigation au clavier
- [ ] Testé avec lecteur d'écran
- [ ] Testé avec différentes tailles d'écran
- [ ] Pas de régression visuelle
- [ ] Documentation mise à jour (ajout du doc + maj avancement) 
- [ ] Breaking changes documentés