### PR TITLE
Réorganisation des dépendances

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "postcss-html": "^1.7.0",
     "postcss-scss": "^4.0.9",
     "resize-observer-polyfill": "^1.5.1",
+    "sass-embedded": "1.83.0",
     "semantic-release": "^25.0.3",
     "storybook": "^8.5.6",
     "storybook-addon-vue-mdx": "^2.0.0",
@@ -119,8 +120,6 @@
     "deepmerge": "^4.3.1",
     "iso-639-1": "^3.1.3",
     "maska": "^3.0.3",
-    "sass-embedded": "1.83.0",
-    "sass-loader": "16.0.3",
     "slugify": "^1.6.6"
   },
   "publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,12 +31,6 @@ dependencies:
   maska:
     specifier: ^3.0.3
     version: 3.2.0
-  sass-embedded:
-    specifier: 1.83.0
-    version: 1.83.0
-  sass-loader:
-    specifier: 16.0.3
-    version: 16.0.3(sass-embedded@1.83.0)
   slugify:
     specifier: ^1.6.6
     version: 1.6.6
@@ -165,6 +159,9 @@ devDependencies:
   resize-observer-polyfill:
     specifier: ^1.5.1
     version: 1.5.1
+  sass-embedded:
+    specifier: 1.83.0
+    version: 1.83.0
   semantic-release:
     specifier: ^25.0.3
     version: 25.0.3(typescript@5.9.3)
@@ -5253,6 +5250,7 @@ packages:
 
   /neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+    dev: true
 
   /nerf-dart@1.0.0:
     resolution: {integrity: sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g==}
@@ -6312,31 +6310,6 @@ packages:
       sass-embedded-win32-arm64: 1.83.0
       sass-embedded-win32-ia32: 1.83.0
       sass-embedded-win32-x64: 1.83.0
-
-  /sass-loader@16.0.3(sass-embedded@1.83.0):
-    resolution: {integrity: sha512-gosNorT1RCkuCMyihv6FBRR7BMV06oKRAs+l4UMp1mlcVg9rWN6KMmUj3igjQwmYys4mDP3etEYJgiHRbgHCHA==}
-    engines: {node: '>= 18.12.0'}
-    peerDependencies:
-      '@rspack/core': 0.x || 1.x
-      node-sass: ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
-      sass: ^1.3.0
-      sass-embedded: '*'
-      webpack: ^5.0.0
-    peerDependenciesMeta:
-      '@rspack/core':
-        optional: true
-      node-sass:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      webpack:
-        optional: true
-    dependencies:
-      neo-async: 2.6.2
-      sass-embedded: 1.83.0
-    dev: false
 
   /saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}


### PR DESCRIPTION
- Supprimer sass-loader car inutile avec Vite
- Déplacer sass dans les dev-dependencies