### PR TITLE
fix: skip custom rules validation when date format is invalid in Date…

### DIFF
--- a/src/components/DatePicker/DateTextInput/DateTextInput.vue
+++ b/src/components/DatePicker/DateTextInput/DateTextInput.vue
@@ -651,7 +651,15 @@
 
 		if (inputValue.value) {
 			const formatValidationResult = validateDateFormatForSingleOrRange(inputValue.value)
-			const customRulesValidationResult = safeValidateField(inputValue.value, computed(() => props.customRules).value, computed(() => props.customWarningRules).value)
+			const emptyValidationResult: ValidationResult = {
+				hasError: false,
+				hasWarning: false,
+				hasSuccess: false,
+				state: { errors: [], warnings: [], successes: [] },
+			}
+			const customRulesValidationResult = formatValidationResult.isValid
+				? safeValidateField(inputValue.value, computed(() => props.customRules).value, computed(() => props.customWarningRules).value)
+				: emptyValidationResult
 
 			if (formatValidationResult.isValid && !customRulesValidationResult.hasError && !isRange.value) {
 				const parsedDate = dayjs(inputValue.value, displayFormat.value, true).toDate()


### PR DESCRIPTION
Pour tester: Lorsque j'ai un DatePicker qui a une rules custom se basant sur la saisie d'un autre champ, que je saisis dans cet autre champ puis que je saisie une date qui n'existe pas (ex. 35/14/2010), alors le message d'erreur affiché est "Date invalide" plutôt que "Format de date invalide (JJ/MM/AAAA)"
Si je ne saisie pas l'autre champ mais que je saisie directement la date invalide, alors j'ai le bon message d'erreur "Format de date invalide (JJ/MM/AAAA)"

```
<template>
<NirField
	v-model="nir"
	:nir-length="13"
	:display-key="false"
	:show-success-messages="false"
	required
	outlined
	persistent-hint
/>
<DatePicker
	ref="dateNaissance"
	v-model="dateNaissance"
	:custom-rules="dateNaissanceRules"
	is-birth-date
	label="Date de naissance"
	use-combined-mode
	display-append-icon
	outlined
	required
	:show-success-messages="false"
/>
</template>
<script lang='ts' setup>
	import DatePicker from '@/components/DatePicker/CalendarMode/DatePicker.vue'
import NirField from '@/components/Nirfield/Nirfield.vue'
import { computed, ref } from 'vue'

const nir = ref()
const dateNaissance = ref()
const dateNaissanceRules = computed(() => [
	{
		type: 'notAfterToday',
	},
	{
		type: 'custom',
		options: {
			validate: (value: string) => {
				return nirCoherent(value, nir.value)
			},
		},
	},
])

function nirCoherent(value: Value, nir: string | undefined) {
	if (!value) {
		return true
	}
	if (!nir) {
		return ruleMessage(defaultErrorMessages, 'nirMissing')
	}
	const date = format(value, 'dd/MM/yyyy')
	const isMonthValid = nir.substring(3, 5) === date.substring(3, 5)
	const isYearValid = nir.substring(1, 3) === date.substring(8)

	return (isMonthValid && isYearValid) || ruleMessage(defaultErrorMessages, 'default')
}

</script>
```
