### PR TITLE
fix: Correction of incorrect CookiesBanner Events

### DIFF
--- a/src/components/CookieBanner/CookieBanner.stories.ts
+++ b/src/components/CookieBanner/CookieBanner.stories.ts
@@ -49,7 +49,7 @@ const meta = {
 			description: 'Événement émis lors de l\'acceptation des cookies',
 			table: {
 				category: 'Events',
-				type: { summary: '' },
+				type: { summary: 'Partial<{ functional: boolean; analytics: boolean }>' },
 			},
 		},
 		'onReject': {
@@ -57,7 +57,7 @@ const meta = {
 			description: 'Événement émis lors du refus des cookies',
 			table: {
 				category: 'Events',
-				type: { summary: '' },
+				type: { summary: 'Partial<{ functional: boolean; analytics: boolean }>' },
 			},
 		},
 		'onCustomize': {
@@ -66,6 +66,14 @@ const meta = {
 			table: {
 				category: 'Events',
 				type: { summary: '' },
+			},
+		},
+		'onSubmit': {
+			action: 'submit',
+			description: 'Événement émis lors de la sauvegarde des préférences personnalisées',
+			table: {
+				category: 'Events',
+				type: { summary: 'Partial<Preferences>' },
 			},
 		},
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -226,12 +234,10 @@ export const Default: Story = {
 		onAccept: { action: 'accept' },
 		onReject: { action: 'reject' },
 		onCustomize: { action: 'customize' },
+		onSubmit: { action: 'submit' },
 	},
 	args: {
 		items,
-		onAccept: fn(),
-		onReject: fn(),
-		onCustomize: fn(),
 	},
 
 	render: (args) => {
@@ -258,9 +264,6 @@ export const Default: Story = {
 	},
 
 	parameters: {
-		a11y: {
-			disable: true,
-		},
 		sourceCode: [
 			{
 				name: 'Template',
@@ -356,9 +359,6 @@ export const WithoutCookiesItems: Story = {
 		}
 	},
 	parameters: {
-		a11y: {
-			disable: true,
-		},
 		sourceCode: [
 			{
 				name: 'Template',
@@ -411,9 +411,6 @@ export const BannerDescriptionSlot: Story = {
 		}
 	},
 	parameters: {
-		a11y: {
-			disable: true,
-		},
 		sourceCode: [
 			{
 				name: 'Template',
@@ -520,9 +517,6 @@ export const CookiesDescriptionSlots: Story = {
 		}
 	},
 	parameters: {
-		a11y: {
-			disable: true,
-		},
 		sourceCode: [
 			{
 				name: 'Template',
@@ -619,9 +613,6 @@ export const Customization: Story = {
 		}
 	},
 	parameters: {
-		a11y: {
-			disable: true,
-		},
 		sourceCode: [
 			{
 				name: 'Template',

--- a/src/components/CookieBanner/CookieBanner.vue
+++ b/src/components/CookieBanner/CookieBanner.vue
@@ -34,14 +34,34 @@
 		return display.smAndDown.value ? '100%' : 'auto'
 	})
 
+	type ConsentPayload = Partial<{ essentials: boolean, functional: boolean, analytics: boolean }>
+
+	function buildConsentPayload(value: boolean): ConsentPayload {
+		const payload: ConsentPayload = {}
+
+		if (props.items?.essentials !== undefined) {
+			payload.essentials = true
+		}
+
+		if (props.items?.functional !== undefined) {
+			payload.functional = value
+		}
+
+		if (props.items?.analytics !== undefined) {
+			payload.analytics = value
+		}
+
+		return payload
+	}
+
 	function reject(): void {
 		active.value = false
-		emits('reject')
+		emits('reject', buildConsentPayload(false))
 	}
 
 	function accept(): void {
 		active.value = false
-		emits('accept')
+		emits('accept', buildConsentPayload(true))
 	}
 
 	function customize(): void {
@@ -51,7 +71,11 @@
 		emits('customize')
 	}
 
-	function personalizeCookies(e: Record<string, unknown>) {
+	function personalizeCookies(e: ConsentPayload) {
+		if (props.items?.essentials !== undefined) {
+			e.essentials = true
+		}
+
 		emits('submit', e)
 		showCookiesSelection.value = false
 		active.value = false
@@ -167,13 +191,13 @@
 		<VSheet
 			ref="vsheetRef"
 			v-bind="options.banner"
-			:aria-label="locales.label"
 			class="vd-cookie-banner"
 		>
 			<div
 				ref="bannerRef"
 				class="vd-cookie-banner__inner"
 				role="dialog"
+				:aria-label="locales.label"
 			>
 				<div class="d-flex align-start flex-nowrap pa-0 mb-6">
 					<h2
@@ -214,7 +238,7 @@
 					<Transition name="height">
 						<div v-if="showCookiesSelection && items">
 							<CookiesSelection
-								:items
+								:items="items"
 								@submit="personalizeCookies"
 							>
 								<template

--- a/src/components/CookieBanner/CookieBanner.vue
+++ b/src/components/CookieBanner/CookieBanner.vue
@@ -34,24 +34,19 @@
 		return display.smAndDown.value ? '100%' : 'auto'
 	})
 
-	type ConsentPayload = Partial<{ essentials: boolean, functional: boolean, analytics: boolean }>
+	const itemKeys = computed(() => Object.keys(props.items ?? {}) as (keyof CookiesItems)[])
+
+	type ConsentPayload = Partial<Record<keyof CookiesItems, boolean>>
 
 	function buildConsentPayload(value: boolean): ConsentPayload {
-		const payload: ConsentPayload = {}
-
-		if (props.items?.essentials !== undefined) {
-			payload.essentials = true
+		if (!props.items) {
+			return {}
 		}
 
-		if (props.items?.functional !== undefined) {
-			payload.functional = value
-		}
-
-		if (props.items?.analytics !== undefined) {
-			payload.analytics = value
-		}
-
-		return payload
+		return itemKeys.value.reduce<ConsentPayload>((payload, key) => {
+			payload[key] = value
+			return payload
+		}, {})
 	}
 
 	function reject(): void {
@@ -72,10 +67,6 @@
 	}
 
 	function personalizeCookies(e: ConsentPayload) {
-		if (props.items?.essentials !== undefined) {
-			e.essentials = true
-		}
-
 		emits('submit', e)
 		showCookiesSelection.value = false
 		active.value = false

--- a/src/components/CookieBanner/accessibilite/Accessibility.mdx
+++ b/src/components/CookieBanner/accessibilite/Accessibility.mdx
@@ -1,15 +1,71 @@
-import { Meta, Story } from '@storybook/addon-docs';
-import * as CookiesStories from '../CookieBanner.stories.ts';
-import '@/stories/styles/shared.css';
+import { Meta, Primary } from '@storybook/blocks';
+import * as CookieBannerStories from '../CookieBanner.stories.ts';
+import AccessibilityIcon from '@/common/imgs/accessibility-svgrepo-com.svg';
+import {
+	AccessibilityGuideLayout,
+	CriteriaSection,
+	CriteriaCard,
+	DemoSection,
+	BestPracticesSection,
+	ResourcesSection,
+} from '@/stories/accessibility/AccessibilityGuideLayout.mdx';
 
-<Meta of={CookiesStories} />
+<Meta of={CookieBannerStories}/>
 
-<div className="header">
-  <h1>Accessibilité</h1>
-</div>
+<AccessibilityGuideLayout
+	componentName="CookieBanner"
+	iconSrc={AccessibilityIcon}
+	apgHref="https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/"
+>
+		<div class="mt-6">
+			<p>Rapport d’audit manuel : <a href="/audits/Cookies.xlsx" style={{ color:'#0C41BD' }}>Voir le rapport</a></p>
+			<p style={{ color: 'grey', fontSize: '14px', marginTop: '0px' }}>Correctifs associés (<a href="https://github.com/assurance-maladie-digital/design-system-v3/issues/806" target="_blank" style={{color:'#0C41BD'}}>issue #806</a>)</p>
+		</div>
+	<CriteriaSection>
+		<CriteriaCard icon="🧭" title="Structure et nom accessible">
+			<ul>
+				<li><strong>Rôle</strong> : <code>role="dialog"</code> sur le conteneur principal de la bannière.</li>
+				<li><strong>Nom accessible</strong> : <code>aria-label="Gestion des cookies"</code> (ou <code>aria-labelledby</code> pointant vers le titre).</li>
+				<li><strong>Hiérarchie</strong> : le titre est exposé (<code>h2</code>) et peut être référencé par <code>aria-labelledby</code> si besoin.</li>
+			</ul>
+		</CriteriaCard>
 
+		<CriteriaCard icon="⌨️" title="Navigation clavier">
+			<ul>
+				<li>Gestion de la touche <kbd>Tab</kbd> pour boucler le focus dans la bannière.</li>
+				<li>Échappe (<kbd>Esc</kbd>) ferme la bannière ou revient depuis la personnalisation.</li>
+				<li>Focus initial sur le bouton de fermeture à l’ouverture.</li>
+			</ul>
+		</CriteriaCard>
 
-<div class="mt-2">
-<p>Rapport d’audit manuel : <a href="/audits/Cookies.xlsx" style={{ color:'#0C41BD' }}>Voir le rapport</a></p>
-		<p style={{ color: 'grey', fontSize: '14px', marginTop: '0px' }}>Correctifs associés (<a href="https://github.com/assurance-maladie-digital/design-system-v3/issues/806" target="_blank" style={{color:'#0C41BD'}}>issue #806</a>)</p>
-</div>
+		<CriteriaCard icon="🦻" title="Événements et consentement">
+			<ul>
+				<li><strong>accept/reject</strong> : émettent les catégories configurables (via les items) et toujours <code>essentials: true</code> si fournis.</li>
+				<li><strong>submit</strong> : renvoie les préférences personnalisées + <code>essentials: true</code> le cas échéant.</li>
+				<li>Pas de chargement de cookies non essentiels avant l’<code>accept</code> ou <code>submit</code>.</li>
+			</ul>
+		</CriteriaCard>
+	</CriteriaSection>
+
+	<DemoSection componentName="CookieBanner">
+		<Primary />
+	</DemoSection>
+
+	<BestPracticesSection>
+		<ul>
+			<li>Ne surchargez pas la description : un paragraphe clair et concis.</li>
+			<li>Assurez un contraste suffisant des boutons et du fond de bannière.</li>
+			<li>Proposez un lien « En savoir plus » vers votre politique cookies.</li>
+			<li>Chargez les cookies non essentiels uniquement après <code>accept</code> ou <code>submit</code>.</li>
+			<li>Conservez la possibilité de rouvrir la bannière ou de modifier le choix ailleurs dans l’interface.</li>
+		</ul>
+	</BestPracticesSection>
+
+	<ResourcesSection>
+		<ul>
+			<li><a href="https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/" target="_blank" rel="noopener noreferrer">APG : Alert dialog</a></li>
+			<li><a href="https://www.cnil.fr/fr/cookies-traceurs-que-dit-la-loi" target="_blank" rel="noopener noreferrer">CNIL : Cookies et traceurs</a></li>
+			<li><a href="https://www.w3.org/WAI/WCAG21/quickref/" target="_blank" rel="noopener noreferrer">Référence rapide WCAG 2.1</a></li>
+		</ul>
+	</ResourcesSection>
+</AccessibilityGuideLayout>

--- a/src/components/CookieBanner/tests/CookieBanner.spec.ts
+++ b/src/components/CookieBanner/tests/CookieBanner.spec.ts
@@ -24,8 +24,14 @@ describe('CookieBanner', () => {
 		expect(wrapper.find('[data-test-id="customize"]').attributes('style')).toContain('100%')
 	})
 
-	it('emit a reject event when the reject btn is clicked', async () => {
+	it('emit a reject event with payload built from provided items', async () => {
 		const wrapper = mount(CookieBanner, {
+			props: {
+				items: {
+					enessentials: [],
+					functional: [],
+				},
+			},
 			global: {
 				stubs: {
 					Teleport: true,
@@ -35,11 +41,20 @@ describe('CookieBanner', () => {
 
 		await wrapper.find('[data-test-id="reject"]').trigger('click')
 
-		expect(wrapper.emitted()).toHaveProperty('reject')
+		expect(wrapper.emitted('reject')?.[0]?.[0]).toEqual({
+			enessentials: false,
+			functional: false,
+		})
 	})
 
-	it('emit a accept event when the accept btn is clicked', async () => {
+	it('emit an accept event with payload built from provided items', async () => {
 		const wrapper = mount(CookieBanner, {
+			props: {
+				items: {
+					functional: [],
+					analytics: [],
+				},
+			},
 			global: {
 				stubs: {
 					Teleport: true,
@@ -49,7 +64,10 @@ describe('CookieBanner', () => {
 
 		await wrapper.find('[data-test-id="accept"]').trigger('click')
 
-		expect(wrapper.emitted()).toHaveProperty('accept')
+		expect(wrapper.emitted('accept')?.[0]?.[0]).toEqual({
+			functional: true,
+			analytics: true,
+		})
 	})
 
 	it('does not close the dialog when the customize button is clicked and do not show the cookie form', async () => {
@@ -115,5 +133,31 @@ describe('CookieBanner', () => {
 		expect(wrapper.find('.vd-cookies-card').exists()).toBe(true)
 		expect(wrapper.find('.vd-cookies-card').html()).toMatchSnapshot()
 		expect(wrapper.emitted()).toHaveProperty('customize')
+	})
+
+	it('emits submit payload coming from CookiesSelection without altering categories', async () => {
+		const wrapper = mount(CookieBanner, {
+			props: {
+				items: {
+					functional: [],
+					analytics: [],
+				},
+			},
+			global: {
+				stubs: {
+					Teleport: true,
+				},
+			},
+		})
+
+		await wrapper.find('[data-test-id="customize"]').trigger('click')
+		await wrapper.vm.$nextTick()
+
+		const selection = wrapper.findComponent({ name: 'CookiesSelection' })
+		selection.vm.$emit('submit', { functional: true })
+
+		expect(wrapper.emitted('submit')?.[0]?.[0]).toEqual({
+			functional: true,
+		})
 	})
 })


### PR DESCRIPTION
Le composant émet toujours false quelque soit le choix de l'utilisateur : update:modelValue vient uniquement du composant pour indiquer sa fermeture. Dans accept() et personalizeCookies(), on fait active.value = false puis emits('update:modelValue', false) (via le defineModel). Le composant n’émet jamais true : c’est au parent (ou à la story) de passer v-model="true" pour l’ouvrir, puis le composant émet false quand on accepte/rejette/soumet pour le fermer.

 en cas de personnalisation des cookies, il revois un tableau vide: a tester en selectionnant accepter tous 