### PR TITLE
SyIcon: fix decorative prop default value and improve accessibility h…

### DIFF
--- a/src/components/Customs/SyIcon/SyIcon.a11y.spec.ts
+++ b/src/components/Customs/SyIcon/SyIcon.a11y.spec.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { describe, it } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { axe } from 'vitest-axe'
 import { assertNoA11yViolations } from '@tests/unit/accessibility/axeUtils'
@@ -19,7 +19,7 @@ describe('SyIcon – accessibility (axe)', () => {
 			global: {
 				stubs: {
 					'v-icon': {
-						template: '<span class="v-icon" role="img" :aria-label="ariaLabel"><slot></slot></span>',
+						template: '<span class="v-icon" :role="role" :aria-label="ariaLabel" :aria-hidden="ariaHidden"><svg><slot></slot></svg></span>',
 						props: ['color', 'size', 'role', 'aria-hidden', 'aria-label'],
 					},
 				},
@@ -31,6 +31,35 @@ describe('SyIcon – accessibility (axe)', () => {
 
 		const results = await axe(wrapper.element as HTMLElement)
 		assertNoA11yViolations(results, 'SyIcon – informative icon with label', {
+			ignoreRules: ['region'],
+		})
+	})
+
+	it('hides decorative icons from assistive tech (aria-hidden)', async () => {
+		const wrapper = mount(SyIcon, {
+			props: {
+				icon: 'mdi-star',
+				decorative: true,
+			},
+			global: {
+				stubs: {
+					'v-icon': {
+						template: '<span class="v-icon" :role="role" :aria-label="ariaLabel" :aria-hidden="ariaHidden"><svg><slot></slot></svg></span>',
+						props: ['color', 'size', 'role', 'aria-hidden', 'aria-label'],
+					},
+				},
+				directives: {
+					'rgaa-svg-fix': () => {},
+				},
+			},
+		})
+
+		const iconEl = wrapper.find('.v-icon')
+		expect(iconEl.attributes('aria-hidden')).toBe('true')
+
+		// Axe should not report a visible control with missing label since it is hidden
+		const results = await axe(wrapper.element as HTMLElement)
+		assertNoA11yViolations(results, 'SyIcon – decorative icon hidden from AT', {
 			ignoreRules: ['region'],
 		})
 	})

--- a/src/components/Customs/SyIcon/SyIcon.vue
+++ b/src/components/Customs/SyIcon/SyIcon.vue
@@ -34,10 +34,12 @@
 		size?: string
 	}>()
 
+	const resolvedDecorative = computed(() => props.decorative ?? true)
+
 	// Configuration pour la directive rgaaSvgFix
 	const rgaaSvgFixConfig = computed(() => {
 		return {
-			isDecorative: props.decorative,
+			isDecorative: resolvedDecorative.value,
 			role: props.role,
 			autoDetectButton: props.autoDetectButton,
 		}
@@ -45,16 +47,16 @@
 
 	// Vérification à l'initialisation du composant
 	onMounted(() => {
-		checkAccessibility(props.icon, props.decorative, props.label)
+		checkAccessibility(props.icon, resolvedDecorative.value, props.label)
 	})
 
 	// Vérification à chaque changement des props concernées
 	watch(
 		[() => props.decorative, () => props.label, () => props.icon],
-		([decorative, label, icon]) => {
+		([, label, icon]) => {
 			checkAccessibility(
 				icon as string,
-				decorative as boolean | undefined,
+				resolvedDecorative.value,
 				label as string | undefined,
 			)
 		},
@@ -67,8 +69,8 @@
 		:color="props.color"
 		:size="props.size"
 		:role="props.role"
-		:aria-label="props.decorative ? undefined : props.label"
-		:aria-hidden="props.decorative ? 'true' : undefined"
+		:aria-label="resolvedDecorative ? undefined : props.label"
+		:aria-hidden="resolvedDecorative ? 'true' : undefined"
 	>
 		{{ icon }}
 	</v-icon>

--- a/src/directives/rgaaSvgFix.ts
+++ b/src/directives/rgaaSvgFix.ts
@@ -247,13 +247,8 @@ function fixSvgAttributes(el: HTMLElement, config: RgaaSvgFixConfig) {
 			// Pour tous les SVG:
 			// 1. Toujours supprimer role="img"
 			svg.removeAttribute('role')
-			// 2. Toujours s'assurer que aria-hidden="true" est présent
-			if (config.isDecorative) {
-				svg.setAttribute('aria-hidden', 'true')
-			}
-			else {
-				svg.removeAttribute('aria-hidden')
-			}
+			// 2. Toujours masquer le SVG pour éviter un double énoncé, le conteneur porte le label si nécessaire
+			svg.setAttribute('aria-hidden', 'true')
 		}
 	}
 }


### PR DESCRIPTION
SyIcon est redevenu décoratif par défaut (decorative ?? true).
Du coup, si la prop n’est pas passée, l’icône est aria-hidden="true" avec role="presentation", ce qui évite les erreurs Tanaguru sur les icônes non labellisées.

Dans la directive v-rgaa-svg-fix, on masque systématiquement le <svg> interne (aria-hidden="true" et suppression du role).
Le conteneur porte déjà le rôle/label, donc ça évite la double restitution et l’alerte Tanaguru qui demandait role="img" sur le SVG.

Pourquoi :
Tanaguru considérait certaines icônes comme non décoratives parce que isDecorative était undefined, et remontait aussi un faux positif sur le role="img" du SVG. Ces changements corrigent ces deux cas.