### PR TITLE
SyAutocomplete: improve loading state

### DIFF
--- a/src/assets/overrides/_forms.scss
+++ b/src/assets/overrides/_forms.scss
@@ -12,3 +12,12 @@
 .v-radio .v-selection-control {
 	min-height: 40px;
 }
+
+// AP theme: inset the loader bar to match the larger field border-radius (12px)
+.theme-ap,
+.theme-ap2026 {
+	.v-field__loader .v-progress-linear {
+		margin-inline: 10px;
+		width: calc(100% - 20px);
+	}
+}

--- a/src/components/Captcha/tests/__snapshots__/Captcha.spec.ts.snap
+++ b/src/components/Captcha/tests/__snapshots__/Captcha.spec.ts.snap
@@ -100,61 +100,7 @@ exports[`Captcha > renders correctly in audio mode 1`] = `
             ">
               <div class="v-field__overlay"></div>
               <div class="v-field__loader">
-                <div
-                  aria-hidden="true"
-                  aria-valuemax="100"
-                  aria-valuemin="0"
-                  class="
-                    v-locale--is-ltr
-                    v-progress-linear
-                    v-theme--light
-                  "
-                  role="progressbar"
-                  style="
-                    top: 0px;
-                    height: 0px;
-                    --v-progress-linear-height: 2px;
-                  "
-                >
-                  <!---->
-                  <div
-                    class="
-                      bg-primary
-                      v-progress-linear__background
-                    "
-                    style="opacity: NaN;"
-                  ></div>
-                  <div
-                    class="
-                      bg-primary
-                      v-progress-linear__buffer
-                    "
-                    style="
-                      opacity: NaN;
-                      width: 0%;
-                    "
-                  ></div>
-                  <transition-stub
-                    appear="false"
-                    css="true"
-                    name="fade-transition"
-                    persisted="false"
-                  >
-                    <div class="v-progress-linear__indeterminate">
-                      <div class="
-                        bg-primary
-                        long
-                        v-progress-linear__indeterminate
-                      "></div>
-                      <div class="
-                        bg-primary
-                        short
-                        v-progress-linear__indeterminate
-                      "></div>
-                    </div>
-                  </transition-stub>
-                  <!---->
-                </div>
+                <!-- v-if -->
               </div>
               <div class="v-field__prepend-inner">
                 <!-- v-if -->
@@ -496,61 +442,7 @@ exports[`Captcha > renders correctly in image mode 1`] = `
             ">
               <div class="v-field__overlay"></div>
               <div class="v-field__loader">
-                <div
-                  aria-hidden="true"
-                  aria-valuemax="100"
-                  aria-valuemin="0"
-                  class="
-                    v-locale--is-ltr
-                    v-progress-linear
-                    v-theme--light
-                  "
-                  role="progressbar"
-                  style="
-                    top: 0px;
-                    height: 0px;
-                    --v-progress-linear-height: 2px;
-                  "
-                >
-                  <!---->
-                  <div
-                    class="
-                      bg-primary
-                      v-progress-linear__background
-                    "
-                    style="opacity: NaN;"
-                  ></div>
-                  <div
-                    class="
-                      bg-primary
-                      v-progress-linear__buffer
-                    "
-                    style="
-                      opacity: NaN;
-                      width: 0%;
-                    "
-                  ></div>
-                  <transition-stub
-                    appear="false"
-                    css="true"
-                    name="fade-transition"
-                    persisted="false"
-                  >
-                    <div class="v-progress-linear__indeterminate">
-                      <div class="
-                        bg-primary
-                        long
-                        v-progress-linear__indeterminate
-                      "></div>
-                      <div class="
-                        bg-primary
-                        short
-                        v-progress-linear__indeterminate
-                      "></div>
-                    </div>
-                  </transition-stub>
-                  <!---->
-                </div>
+                <!-- v-if -->
               </div>
               <div class="v-field__prepend-inner">
                 <!-- v-if -->

--- a/src/components/Customs/Selects/SyAutocomplete/SyAutocomplete.vue
+++ b/src/components/Customs/Selects/SyAutocomplete/SyAutocomplete.vue
@@ -485,6 +485,7 @@
 					:has-success="displayHasSuccess"
 					:required="required"
 					:display-asterisk="required && displayAsterisk"
+					:loading="loading"
 					:aria-label="hasChips ? label : undefined"
 					@click="openAndFocus"
 					@update:model-value="handleInput"
@@ -552,13 +553,7 @@
 				tabindex="-1"
 				@click.stop
 			>
-				<template v-if="loading">
-					<VListItem
-						title="Chargement..."
-						tag="li"
-					/>
-				</template>
-				<template v-else-if="filteredItems.length === 0 && !hideNoData">
+				<template v-if="filteredItems.length === 0 && !hideNoData && !loading">
 					<VListItem
 						:title="noDataText"
 						disabled

--- a/src/components/Customs/Selects/SyAutocomplete/accessibilite/Accessibilite.stories.ts
+++ b/src/components/Customs/Selects/SyAutocomplete/accessibilite/Accessibilite.stories.ts
@@ -1,7 +1,8 @@
 import type { StoryObj } from '@storybook/vue3'
-import { mdiKeyboard } from '@mdi/js'
+import { mdiKeyboard, mdiLoading } from '@mdi/js'
 
 const keyboardIcon = mdiKeyboard
+const loadingIcon = mdiLoading
 
 export default {
 	title: 'Composants/Formulaires/Selects/SyAutocomplete/Accessibility',
@@ -63,6 +64,44 @@ export const ComboboxKeyboardNavigation: StoryObj = {
 						</tbody>
 					</v-table>
 					<p style="margin-top: 16px;"><strong>Note:</strong> Le focus DOM reste toujours sur l'élément combobox, tandis que le focus visuel est géré via <code>aria-activedescendant</code>.</p>
+				</div>
+			`,
+		}
+	},
+}
+
+export const LoadingAccessibility: StoryObj = {
+	tags: ['!dev'],
+	render: () => {
+		return {
+			setup() {
+				return { loadingIcon }
+			},
+			template: `
+				<div>
+					<p>Lorsque la prop <code>loading</code> est à <code>true</code>, le composant affiche une barre de progression au bas du champ.</p>
+					<v-table density="compact" style="margin-top: 16px;">
+						<thead>
+							<tr>
+								<th>Comportement</th>
+								<th>Détail</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<td>Barre de progression accessible</td>
+								<td>La barre porte un <code>aria-label</code> nommant le champ (<em>« Chargement de [label] »</em>) afin que les lecteurs d’écran annoncent son état.</td>
+							</tr>
+							<tr>
+								<td>Message « Aucune option » masqué</td>
+								<td>Le message d’absence de résultats n’est pas affiché pendant le chargement, pour éviter de signaler à tort que la liste est vide.</td>
+							</tr>
+							<tr>
+								<td>Critère RGAA 4.1 / WCAG 4.1.2</td>
+								<td>Le rôle <code>progressbar</code> et son nom accessible satisfont le critère « Nom, rôle, valeur » pour les composants d’interface.</td>
+							</tr>
+						</tbody>
+					</v-table>
 				</div>
 			`,
 		}

--- a/src/components/Customs/Selects/SyAutocomplete/accessibilite/Accessibility.mdx
+++ b/src/components/Customs/Selects/SyAutocomplete/accessibilite/Accessibility.mdx
@@ -73,6 +73,11 @@ import '@/stories/styles/shared.css';
     <Story of={AccessStories.ComboboxKeyboardNavigation} />
   </div>
 
+  <div className="loading-section">
+    <h2>État de chargement</h2>
+    <Story of={AccessStories.LoadingAccessibility} />
+  </div>
+
   <div className="implementation-section">
     <h2>Spécificités d'implémentation</h2>
     <p>
@@ -172,7 +177,8 @@ import '@/stories/styles/shared.css';
     line-height: 1.5;
   }
 
-  .keyboard-section {
+  .keyboard-section,
+  .loading-section {
     background-color: #f0f7ff;
     padding: 20px;
     border-radius: 8px;

--- a/src/components/Customs/Selects/SyAutocomplete/tests/SyAutocomplete.a11y.spec.ts
+++ b/src/components/Customs/Selects/SyAutocomplete/tests/SyAutocomplete.a11y.spec.ts
@@ -89,6 +89,44 @@ describe('SyAutocomplete – accessibility (axe)', () => {
 		})
 	})
 
+	it('has no obvious axe violations when loading is true', async () => {
+		const wrapper = mount(SyAutocomplete, {
+			props: {
+				modelValue: null,
+				items,
+				label: 'Choisir une option',
+				textKey: 'text',
+				valueKey: 'value',
+				loading: true,
+			},
+		})
+
+		const results = await axe(wrapper.element as HTMLElement)
+		assertNoA11yViolations(results, 'SyAutocomplete – loading state', {
+			ignoreRules: ['region'],
+		})
+	})
+
+	it('has no obvious axe violations when loading is true with no label (chips mode)', async () => {
+		const wrapper = mount(SyAutocomplete, {
+			props: {
+				modelValue: ['1'],
+				items,
+				label: 'Options',
+				textKey: 'text',
+				valueKey: 'value',
+				multiple: true,
+				chips: true,
+				loading: true,
+			},
+		})
+
+		const results = await axe(wrapper.element as HTMLElement)
+		assertNoA11yViolations(results, 'SyAutocomplete – loading + chips', {
+			ignoreRules: ['region'],
+		})
+	})
+
 	it('has no obvious axe violations for selectionText with selection', async () => {
 		const wrapper = mount(SyAutocomplete, {
 			props: {

--- a/src/components/Customs/Selects/SyAutocomplete/tests/SyAutocomplete.spec.ts
+++ b/src/components/Customs/Selects/SyAutocomplete/tests/SyAutocomplete.spec.ts
@@ -395,6 +395,84 @@ describe('SyAutocomplete', () => {
 		})
 	})
 
+	describe('loading', () => {
+		it('shows progress bar when loading is true', async () => {
+			wrapper.unmount()
+			wrapper = mount(SyAutocomplete, {
+				props: {
+					modelValue: null,
+					items,
+					label: 'Test Loading',
+					textKey: 'text',
+					valueKey: 'value',
+					loading: true,
+					menuId,
+				},
+				attachTo: document.body,
+			})
+
+			await wrapper.vm.$nextTick()
+			const progressBar = wrapper.find('.v-progress-linear')
+			expect(progressBar.exists()).toBe(true)
+		})
+
+		it('does not show progress bar when loading is false', async () => {
+			await wrapper.vm.$nextTick()
+			const progressBar = wrapper.find('.v-progress-linear')
+			expect(progressBar.exists()).toBe(false)
+		})
+
+		it('hides no-data message while loading', async () => {
+			wrapper.unmount()
+			wrapper = mount(SyAutocomplete, {
+				props: {
+					modelValue: null,
+					items: [],
+					label: 'Test Loading No Data',
+					textKey: 'text',
+					valueKey: 'value',
+					loading: true,
+					menuId,
+				},
+				attachTo: document.body,
+			})
+
+			const input = wrapper.find('input')
+			await input.trigger('click')
+			await flushPromises()
+			await wrapper.vm.$nextTick()
+
+			// No-data item should not appear while loading
+			const noDataItem = document.body.querySelector(`#${menuId} .v-list-item`)
+			expect(noDataItem).toBeNull()
+		})
+
+		it('shows no-data message once loading is done and items is empty', async () => {
+			wrapper.unmount()
+			wrapper = mount(SyAutocomplete, {
+				props: {
+					modelValue: null,
+					items: [],
+					label: 'Test Loading Done',
+					textKey: 'text',
+					valueKey: 'value',
+					loading: false,
+					menuId,
+				},
+				attachTo: document.body,
+			})
+
+			const input = wrapper.find('input')
+			await input.trigger('click')
+			await flushPromises()
+			await wrapper.vm.$nextTick()
+
+			const listItems = document.body.querySelectorAll(`#${menuId} .v-list-item`)
+			const texts = Array.from(listItems).map(el => el.textContent?.trim())
+			expect(texts).toContain('Aucune option')
+		})
+	})
+
 	it('selects and deselects items in multiple mode (mouse + keyboard)', async () => {
 		wrapper.unmount()
 		wrapper = mount(SyAutocomplete, {

--- a/src/components/Customs/SyTextField/SyTextField.vue
+++ b/src/components/Customs/SyTextField/SyTextField.vue
@@ -795,6 +795,17 @@
 			<template #details>
 				<slot name="details" />
 			</template>
+
+			<template
+				v-if="props.loading"
+				#loader
+			>
+				<VProgressLinear
+					indeterminate
+					color="primary"
+					:aria-label="props.label ? `Chargement de ${props.label}` : 'Chargement en cours'"
+				/>
+			</template>
 		</VTextField>
 
 		<div

--- a/src/components/Customs/SyTextField/SyTextField.vue
+++ b/src/components/Customs/SyTextField/SyTextField.vue
@@ -796,13 +796,12 @@
 				<slot name="details" />
 			</template>
 
-			<template
-				v-if="props.loading"
-				#loader
-			>
+			<template #loader="{ color: loaderColor, isActive: loaderActive }">
 				<VProgressLinear
+					v-if="loaderActive"
 					indeterminate
-					color="primary"
+					rounded
+					:color="loaderColor"
 					:aria-label="props.label ? `Chargement de ${props.label}` : 'Chargement en cours'"
 				/>
 			</template>

--- a/src/components/Customs/SyTextField/tests/SyTextField.a11y.spec.ts
+++ b/src/components/Customs/SyTextField/tests/SyTextField.a11y.spec.ts
@@ -24,4 +24,21 @@ describe('SyTextField – accessibility (axe)', () => {
 			ignoreRules: ['region'],
 		})
 	})
+
+	it('has no obvious axe violations when loading is true', async () => {
+		const wrapper = mount(SyTextField, {
+			props: {
+				label: 'Nom',
+				modelValue: '',
+				loading: true,
+			},
+		})
+
+		const results = await axe(wrapper.element as HTMLElement)
+		assertNoA11yViolations(results, 'SyTextField – loading state', {
+			ignoreRules: ['region'],
+		})
+	})
+
+
 })

--- a/src/components/Customs/SyTextField/tests/SyTextField.a11y.spec.ts
+++ b/src/components/Customs/SyTextField/tests/SyTextField.a11y.spec.ts
@@ -39,6 +39,4 @@ describe('SyTextField – accessibility (axe)', () => {
 			ignoreRules: ['region'],
 		})
 	})
-
-
 })

--- a/src/components/Customs/SyTextField/tests/SyTextField.spec.ts
+++ b/src/components/Customs/SyTextField/tests/SyTextField.spec.ts
@@ -209,6 +209,42 @@ describe('SyTextField', () => {
 		expect(messages.text()).toContain('Attention : Test Field peut contenir une erreur')
 	})
 
+	describe('loading', () => {
+		it('shows progress bar when loading is true', async () => {
+			wrapper = mount(SyTextField, {
+				props: { loading: true, label: 'Nom' },
+			})
+			await wrapper.vm.$nextTick()
+			expect(wrapper.find('.v-progress-linear').exists()).toBe(true)
+		})
+
+		it('does not show progress bar when loading is false', async () => {
+			wrapper = mount(SyTextField, {
+				props: { loading: false, label: 'Nom' },
+			})
+			await wrapper.vm.$nextTick()
+			expect(wrapper.find('.v-progress-linear').exists()).toBe(false)
+		})
+
+		it('sets aria-label with field label when loading', async () => {
+			wrapper = mount(SyTextField, {
+				props: { loading: true, label: 'Nom' },
+			})
+			await wrapper.vm.$nextTick()
+			const bar = wrapper.find('.v-progress-linear')
+			expect(bar.attributes('aria-label')).toBe('Chargement de Nom')
+		})
+
+		it('sets generic aria-label when no label and loading', async () => {
+			wrapper = mount(SyTextField, {
+				props: { loading: true },
+			})
+			await wrapper.vm.$nextTick()
+			const bar = wrapper.find('.v-progress-linear')
+			expect(bar.attributes('aria-label')).toBe('Chargement en cours')
+		})
+	})
+
 	it('maintains input value without validation rules', async () => {
 		wrapper = mount(SyTextField)
 		const input = wrapper.find('input')


### PR DESCRIPTION
## Description

Afficher un loader au niveau de l'input du SyAutocomplete permettrait de savoir en un coup d'oeil que le champs est en cours de chargement. L'objectif est de rendre l'expérience plus fluide lors du chargement des données du champs.

## Stories

https://deploy-preview-1987--synapse-dev.netlify.app/?path=/story/composants-formulaires-selects-syautocomplete--loading-state

## Type de changement

<!-- Supprimez les options non pertinentes. -->

- Nouvelle fonctionnalité
- Correction de bug
- Changement cassant
- Refactoring
- Maintenance
- Documentation
- Ce changement nécessite une mise à jour de la documentation

## Definition of Done

### Evolution ou correctif de composant/template

**Bonne Pratique**

- [x] Ma Pull Request est bien nommée (Composant/template: descriptif issue)
- [x] Ma Pull Request pointe vers la bonne branche
- [x] Linker issue et PR

**Design**

- [x] L'évolution du composant/template respecte les maquettes validées (et l'équipe design est informée des changements)
- [x] Les design tokens sont utilisés

**Fonctionnel**

- [x] Le correctif résout le problème identifié
- [x] Aucun impact sur les usages existants

**Accessibilité spécifique au composant/template**

- [x] Navigation clavier vérifiée
- [x] Restitution lecteur d’écran vérifiée
- [x] Tests a11y mis à jour si nécessaire
- [x] Page accessibilité mise à jour si impact / crée si n’existe pas

**Documentation & Storybook**

- [x] Storybook mis à jour si nécessaire
- [x] Onglet A11Y sans erreur
- [x] La page de documentation accessibilité mise à jour si nécessaire

**Tests**

- [x] Tests mis à jour ou ajoutés pour couvrir le correctif
- [x] Deploy + SKSN Checks

**Fusion de composant/template**

- [ ] Le composant/template n'induit pas de régression dans le composant/template Synapse, Portail Agent ou AmeliPro
- [ ] Ajout des stories propre au thème (penser à filter le menu/props si nécessaire)
- [ ] Ajouter un message dans le composant/template déprécié avec un lien vers le nouveau