### PR TITLE
[Accordeon] Ajout du vmodel

### DIFF
--- a/src/components/Accordion/Accordion.mdx
+++ b/src/components/Accordion/Accordion.mdx
@@ -16,16 +16,6 @@ L'accordéon standard affiche une liste d'éléments avec un titre et un contenu
 
 <Canvas of={AccordionStories.Default} />
 
-<div className="header">
-  <h1>Accessibilité</h1>
-</div>
-
-Le composant Accordion respecte les normes d'accessibilité ARIA :
-
-- Chaque bouton de dévoilement est contenu dans un élément de titre (h1-h6)
-- Chaque bouton possède les attributs `aria-expanded` et `aria-controls`
-- Chaque section de contenu a l'attribut `role="region"` et `aria-labelledby` qui pointe vers l'ID du bouton
-
 ## API
 
 <Controls of={AccordionStories.Default} />

--- a/src/components/Accordion/Accordion.mdx
+++ b/src/components/Accordion/Accordion.mdx
@@ -16,6 +16,27 @@ L'accordéon standard affiche une liste d'éléments avec un titre et un contenu
 
 <Canvas of={AccordionStories.Default} />
 
+<div className="header">
+  <h1>Accessibilité</h1>
+</div>
+
+Le composant Accordion respecte les normes d'accessibilité ARIA :
+
+- Chaque bouton de dévoilement est contenu dans un élément de titre (h1-h6)
+- Chaque bouton possède les attributs `aria-expanded` et `aria-controls`
+- Chaque section de contenu a l'attribut `role="region"` et `aria-labelledby` qui pointe vers l'ID du bouton
+
+## API
+
+<Controls of={AccordionStories.Default} />
+
+## Événements
+
+### update:modelValue
+
+- **Type** : `(value: string[]) => void`
+- **Description** : Émis lors de l'ouverture ou la fermeture d'un élément. La valeur est le tableau mis à jour des identifiants des éléments ouverts.
+
 ## Contenu avec objet
 
 L'accordéon peut également afficher un contenu structuré sous forme d'objet avec un titre et un contenu détaillé.
@@ -46,27 +67,6 @@ La valeur est un tableau de chaînes correspondant aux `id` des éléments ouver
 Vous pouvez pré-ouvrir des éléments en initialisant le `v-model` avec les identifiants souhaités.
 
 <Canvas of={AccordionStories.PreOpened} />
-
-<div className="header">
-  <h1>Accessibilité</h1>
-</div>
-
-Le composant Accordion respecte les normes d'accessibilité ARIA :
-
-- Chaque bouton de dévoilement est contenu dans un élément de titre (h1-h6)
-- Chaque bouton possède les attributs `aria-expanded` et `aria-controls`
-- Chaque section de contenu a l'attribut `role="region"` et `aria-labelledby` qui pointe vers l'ID du bouton
-
-## API
-
-<Controls of={AccordionStories.Default} />
-
-## Événements
-
-### update:modelValue
-
-- **Type** : `(value: string[]) => void`
-- **Description** : Émis lors de l'ouverture ou la fermeture d'un élément. La valeur est le tableau mis à jour des identifiants des éléments ouverts.
 
 ## Exemple d'utilisation
 

--- a/src/components/Accordion/Accordion.mdx
+++ b/src/components/Accordion/Accordion.mdx
@@ -34,6 +34,19 @@ Vous pouvez également utiliser des slots pour personnaliser le rendu des titres
 
 <Canvas of={AccordionStories.WithSlots} />
 
+## Contrôle programmatique (v-model)
+
+Le composant supporte `v-model` pour contrôler programmatiquement les éléments ouverts.
+La valeur est un tableau de chaînes correspondant aux `id` des éléments ouverts.
+
+<Canvas of={AccordionStories.WithVModel} />
+
+## Éléments pré-ouverts
+
+Vous pouvez pré-ouvrir des éléments en initialisant le `v-model` avec les identifiants souhaités.
+
+<Canvas of={AccordionStories.PreOpened} />
+
 <div className="header">
   <h1>Accessibilité</h1>
 </div>
@@ -48,11 +61,21 @@ Le composant Accordion respecte les normes d'accessibilité ARIA :
 
 <Controls of={AccordionStories.Default} />
 
+## Événements
+
+### update:modelValue
+
+- **Type** : `(value: string[]) => void`
+- **Description** : Émis lors de l'ouverture ou la fermeture d'un élément. La valeur est le tableau mis à jour des identifiants des éléments ouverts.
+
 ## Exemple d'utilisation
 
 <Source dark code={`
 <script setup lang="ts">
+import { ref } from 'vue'
 import { Accordion } from '@cnamts/synapse'
+
+const openItems = ref<string[]>([])
 
 const accordionItems = [
   { id: 'item1', title: 'Section 1', content: 'Contenu de la section 1' },
@@ -71,6 +94,7 @@ const accordionItems = [
 <template>
   <main>
     <Accordion
+      v-model="openItems"
       :items="accordionItems"
       :heading-level="3"
     />

--- a/src/components/Accordion/Accordion.stories.ts
+++ b/src/components/Accordion/Accordion.stories.ts
@@ -398,8 +398,8 @@ export const WithVModel: Story = {
 
   <p>Éléments ouverts : {{ openItems }}</p>
 
-  <button @click="openAll">Tout ouvrir</button>
-  <button @click="closeAll">Tout fermer</button>
+  <v-btn variant="outlined" color="primary" @click="openAll">Tout ouvrir</v-btn>
+  <v-btn variant="outlined" color="primary" @click="closeAll">Tout fermer</v-btn>
 </template>`,
 			},
 		],
@@ -432,8 +432,8 @@ export const WithVModel: Story = {
 				</div>
 
 				<div class="mt-2 d-flex ga-2">
-					<v-btn variant="outlined" @click="openAll">Tout ouvrir</v-btn>
-					<v-btn variant="outlined" @click="closeAll">Tout fermer</v-btn>
+					<v-btn variant="outlined" color="primary" @click="openAll">Tout ouvrir</v-btn>
+					<v-btn variant="outlined" color="primary" @click="closeAll">Tout fermer</v-btn>
 				</div>
 			</div>
 		`,

--- a/src/components/Accordion/Accordion.stories.ts
+++ b/src/components/Accordion/Accordion.stories.ts
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/vue3'
+import { fn } from '@storybook/test'
 import Accordion from './Accordion.vue'
+import { ref } from 'vue'
 
 const meta: Meta<typeof Accordion> = {
 	title: 'Composants/Données/Accordion',
@@ -8,20 +10,40 @@ const meta: Meta<typeof Accordion> = {
 		layout: 'fullscreen',
 	},
 	argTypes: {
-		items: {
+		'items': {
 			control: { type: 'object' },
 			description: 'Liste des éléments de l\'accordéon',
 		},
-		headingLevel: {
+		'headingLevel': {
 			control: { type: 'number', min: 1, max: 6 },
 			description: 'Niveau de titre pour les boutons de dévoilement',
 			default: 3,
 		},
-		groupId: {
+		'groupId': {
 			control: { type: 'text' },
 			description: 'Identifiant de groupe pour synchroniser le focus entre plusieurs accordions',
 			default: 'default',
 		},
+		'modelValue': {
+			control: 'object',
+			description: 'Liste des identifiants des éléments ouverts (v-model)',
+			table: {
+				type: { summary: 'string[]' },
+				category: 'props',
+				defaultValue: { summary: '[]' },
+			},
+		},
+		'onUpdate:modelValue': {
+			action: 'update:modelValue',
+			description: 'Événement émis lors de l\'ouverture ou la fermeture d\'un élément',
+			table: {
+				type: { summary: '(value: string[]) => void' },
+				category: 'events',
+			},
+		},
+	},
+	args: {
+		'onUpdate:modelValue': fn(),
 	},
 }
 
@@ -335,6 +357,134 @@ export const WithSlots: Story = {
 						</div>
 					</template>
 				</Accordion>
+			</div>
+		`,
+	}),
+}
+
+export const WithVModel: Story = {
+	parameters: {
+		sourceCode: [
+			{
+				language: 'vue',
+				name: 'Template',
+				code: `<script setup lang="ts">
+  import { ref } from 'vue'
+  import { Accordion } from '@cnamts/synapse'
+
+  const openItems = ref<string[]>([])
+
+  const items = [
+    { id: 'item1', title: 'Section 1', content: 'Contenu de la section 1' },
+    { id: 'item2', title: 'Section 2', content: 'Contenu de la section 2' },
+    { id: 'item3', title: 'Section 3', content: 'Contenu de la section 3' },
+  ]
+
+  function openAll() {
+    openItems.value = items.map(i => i.id)
+  }
+
+  function closeAll() {
+    openItems.value = []
+  }
+</script>
+
+<template>
+  <Accordion
+    v-model="openItems"
+    :items="items"
+    :heading-level="3"
+  />
+
+  <p>Éléments ouverts : {{ openItems }}</p>
+
+  <button @click="openAll">Tout ouvrir</button>
+  <button @click="closeAll">Tout fermer</button>
+</template>`,
+			},
+		],
+	},
+	args: {
+		items: defaultItems,
+		headingLevel: 3,
+	},
+	render: args => ({
+		components: { Accordion },
+		setup() {
+			const openItems = ref<string[]>([])
+
+			const openAll = () => {
+				openItems.value = (args.items ?? []).map((i: { id: string }) => i.id)
+			}
+
+			const closeAll = () => {
+				openItems.value = []
+			}
+
+			return { args, openItems, openAll, closeAll }
+		},
+		template: `
+			<div class="pa-4">
+				<Accordion v-bind="args" v-model="openItems" />
+
+				<div class="mt-4" style="font-family: monospace; color: #666;">
+					Éléments ouverts : {{ openItems }}
+				</div>
+
+				<div class="mt-2 d-flex ga-2">
+					<v-btn variant="outlined" @click="openAll">Tout ouvrir</v-btn>
+					<v-btn variant="outlined" @click="closeAll">Tout fermer</v-btn>
+				</div>
+			</div>
+		`,
+	}),
+}
+
+export const PreOpened: Story = {
+	parameters: {
+		sourceCode: [
+			{
+				language: 'vue',
+				name: 'Template',
+				code: `<script setup lang="ts">
+  import { ref } from 'vue'
+  import { Accordion } from '@cnamts/synapse'
+
+  // Pré-ouvrir la section 2
+  const openItems = ref<string[]>(['item2'])
+</script>
+
+<template>
+  <Accordion
+    v-model="openItems"
+    :items="[
+      { id: 'item1', title: 'Section 1', content: 'Contenu de la section 1' },
+      { id: 'item2', title: 'Section 2', content: 'Contenu de la section 2' },
+      { id: 'item3', title: 'Section 3', content: 'Contenu de la section 3' },
+    ]"
+    :heading-level="3"
+  />
+</template>`,
+			},
+		],
+	},
+	args: {
+		items: defaultItems,
+		headingLevel: 3,
+	},
+	render: args => ({
+		components: { Accordion },
+		setup() {
+			const openItems = ref<string[]>(['item2'])
+			return { args, openItems }
+		},
+		template: `
+			<div class="pa-4">
+				<Accordion v-bind="args" v-model="openItems" />
+
+				<div class="mt-4" style="font-family: monospace; color: #666;">
+					Éléments ouverts : {{ openItems }}
+				</div>
 			</div>
 		`,
 	}),

--- a/src/components/Accordion/Accordion.vue
+++ b/src/components/Accordion/Accordion.vue
@@ -38,6 +38,8 @@
 		vuetifyOptions: () => ({}),
 	})
 
+	const openItems = defineModel<string[]>({ default: [] })
+
 	const options = useCustomizableOptions(config, props)
 
 	// Génération d'un ID unique pour cette instance d'accordéon
@@ -49,7 +51,7 @@
 		isItemOpen,
 		isItemFocused,
 		setFocus,
-	} = useAccordionState()
+	} = useAccordionState(openItems)
 
 	// Utilisation du composable pour gérer la communication entre accordéons
 	const { emitFocusChange } = useAccordionGroupCommunication(

--- a/src/components/Accordion/Accordion.vue
+++ b/src/components/Accordion/Accordion.vue
@@ -12,7 +12,7 @@
 	interface AccordionItem {
 		id: string
 		title: string
-		content: string | Record<string, unknown>
+		content?: string | Record<string, unknown>
 		headingLevel?: number
 		disabled?: boolean
 	}

--- a/src/components/Accordion/Accordion.vue
+++ b/src/components/Accordion/Accordion.vue
@@ -12,7 +12,7 @@
 	interface AccordionItem {
 		id: string
 		title: string
-		content?: string | Record<string, unknown>
+		content?: string | { title: string, content: string }
 		headingLevel?: number
 		disabled?: boolean
 	}

--- a/src/components/Accordion/Accordion.vue
+++ b/src/components/Accordion/Accordion.vue
@@ -2,7 +2,6 @@
 	import useCustomizableOptions, { type CustomizableOptions } from '@/composables/useCustomizableOptions'
 	import { config } from '@/components/Accordion/config'
 	import { mdiChevronRight } from '@mdi/js'
-
 	// Importation des composables
 	import useAccordionState from './composables/useAccordionState'
 	import useAccordionGroupCommunication from './composables/useAccordionGroupCommunication'
@@ -38,7 +37,7 @@
 		vuetifyOptions: () => ({}),
 	})
 
-	const openItems = defineModel<string[]>({ default: [] })
+	const openItems = defineModel<string[]>({ default: () => [] })
 
 	const options = useCustomizableOptions(config, props)
 

--- a/src/components/Accordion/Accordion.vue
+++ b/src/components/Accordion/Accordion.vue
@@ -169,13 +169,13 @@
 								{{ item.content }}
 							</p>
 						</template>
-						<template v-else>
+						<template v-else-if="typeof item.content === 'object' && item.content !== null && 'title' in item.content && 'content' in item.content">
 							<div class="sy-accordion-content-item">
 								<p class="sy-accordion-content-text">
-									<strong>{{ (item.content as any).title }}</strong>
+									<strong>{{ item.content.title }}</strong>
 								</p>
 								<p class="sy-accordion-content-text">
-									{{ (item.content as any).content }}
+									{{ item.content.content }}
 								</p>
 							</div>
 						</template>

--- a/src/components/Accordion/composables/__tests__/useAccordionState.spec.ts
+++ b/src/components/Accordion/composables/__tests__/useAccordionState.spec.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect } from 'vitest'
+import { ref } from 'vue'
 import useAccordionState from '../useAccordionState'
 
 describe('useAccordionState', () => {
 	describe('toggleItem', () => {
 		it('adds an item to openItems when it is not already open', () => {
-			const { toggleItem, isItemOpen, openItems } = useAccordionState()
+			const { toggleItem, isItemOpen, openItems } = useAccordionState(ref<string[]>([]))
 
 			toggleItem('item1')
 
@@ -13,7 +14,7 @@ describe('useAccordionState', () => {
 		})
 
 		it('removes an item from openItems when it is already open', () => {
-			const { toggleItem, isItemOpen, openItems } = useAccordionState()
+			const { toggleItem, isItemOpen, openItems } = useAccordionState(ref<string[]>([]))
 
 			// Ouvrir d'abord l'élément
 			toggleItem('item1')
@@ -29,7 +30,7 @@ describe('useAccordionState', () => {
 
 	describe('isItemOpen', () => {
 		it('returns true when the item is open', () => {
-			const { toggleItem, isItemOpen } = useAccordionState()
+			const { toggleItem, isItemOpen } = useAccordionState(ref<string[]>([]))
 
 			toggleItem('item1')
 
@@ -37,7 +38,7 @@ describe('useAccordionState', () => {
 		})
 
 		it('returns false when the item is not open', () => {
-			const { isItemOpen } = useAccordionState()
+			const { isItemOpen } = useAccordionState(ref<string[]>([]))
 
 			expect(isItemOpen('item1')).toBe(false)
 		})
@@ -45,7 +46,7 @@ describe('useAccordionState', () => {
 
 	describe('isItemFocused', () => {
 		it('returns true when the item is focused', () => {
-			const { setFocus, isItemFocused } = useAccordionState()
+			const { setFocus, isItemFocused } = useAccordionState(ref<string[]>([]))
 
 			setFocus('item1')
 
@@ -53,7 +54,7 @@ describe('useAccordionState', () => {
 		})
 
 		it('returns false when the item is not focused', () => {
-			const { isItemFocused } = useAccordionState()
+			const { isItemFocused } = useAccordionState(ref<string[]>([]))
 
 			expect(isItemFocused('item1')).toBe(false)
 		})
@@ -61,7 +62,7 @@ describe('useAccordionState', () => {
 
 	describe('setFocus', () => {
 		it('sets the focus on the specified item', () => {
-			const { setFocus, focusedItemId } = useAccordionState()
+			const { setFocus, focusedItemId } = useAccordionState(ref<string[]>([]))
 
 			setFocus('item1')
 
@@ -69,7 +70,7 @@ describe('useAccordionState', () => {
 		})
 
 		it('removes focus when null is passed', () => {
-			const { setFocus, focusedItemId } = useAccordionState()
+			const { setFocus, focusedItemId } = useAccordionState(ref<string[]>([]))
 
 			// D'abord définir le focus
 			setFocus('item1')
@@ -82,7 +83,7 @@ describe('useAccordionState', () => {
 		})
 
 		it('does nothing when the same item is already focused', () => {
-			const { setFocus, focusedItemId } = useAccordionState()
+			const { setFocus, focusedItemId } = useAccordionState(ref<string[]>([]))
 
 			setFocus('item1')
 			const originalFocusedItem = focusedItemId.value
@@ -96,7 +97,7 @@ describe('useAccordionState', () => {
 
 	describe('focus behavior during toggle', () => {
 		it('sets focus when opening an item', () => {
-			const { toggleItem, focusedItemId } = useAccordionState()
+			const { toggleItem, focusedItemId } = useAccordionState(ref<string[]>([]))
 
 			toggleItem('item1')
 
@@ -104,7 +105,7 @@ describe('useAccordionState', () => {
 		})
 
 		it('maintains focus when closing a non-focused item', () => {
-			const { toggleItem, setFocus, focusedItemId } = useAccordionState()
+			const { toggleItem, setFocus, focusedItemId } = useAccordionState(ref<string[]>([]))
 
 			// Ouvrir deux éléments
 			toggleItem('item1')
@@ -128,7 +129,7 @@ describe('useAccordionState', () => {
 		})
 
 		it('removes focus when closing the focused item', () => {
-			const { toggleItem, focusedItemId } = useAccordionState()
+			const { toggleItem, focusedItemId } = useAccordionState(ref<string[]>([]))
 
 			// Ouvrir un élément (qui sera automatiquement focalisé)
 			toggleItem('item1')
@@ -139,6 +140,33 @@ describe('useAccordionState', () => {
 
 			// Le focus doit être retiré
 			expect(focusedItemId.value).toBeNull()
+		})
+	})
+
+	describe('external ref synchronization', () => {
+		it('uses the provided ref for openItems', () => {
+			const externalRef = ref<string[]>(['item1'])
+			const { isItemOpen } = useAccordionState(externalRef)
+
+			expect(isItemOpen('item1')).toBe(true)
+		})
+
+		it('mutates the provided ref when toggling', () => {
+			const externalRef = ref<string[]>([])
+			const { toggleItem } = useAccordionState(externalRef)
+
+			toggleItem('item1')
+
+			expect(externalRef.value).toContain('item1')
+		})
+
+		it('reflects external changes to the ref', () => {
+			const externalRef = ref<string[]>([])
+			const { isItemOpen } = useAccordionState(externalRef)
+
+			externalRef.value = ['item2']
+
+			expect(isItemOpen('item2')).toBe(true)
 		})
 	})
 })

--- a/src/components/Accordion/composables/useAccordionState.ts
+++ b/src/components/Accordion/composables/useAccordionState.ts
@@ -18,7 +18,7 @@ export default function useAccordionState(openItems: Ref<string[]>): AccordionSt
 
 		const index = openItems.value.indexOf(itemId)
 		if (index === -1) {
-			openItems.value = [...openItems.value, itemId]
+			openItems.value.push(itemId)
 			setFocus(itemId)
 		}
 		else {

--- a/src/components/Accordion/composables/useAccordionState.ts
+++ b/src/components/Accordion/composables/useAccordionState.ts
@@ -9,8 +9,7 @@ export interface AccordionState {
 	setFocus: (itemId: string | null) => void
 }
 
-export default function useAccordionState(): AccordionState {
-	const openItems = ref<string[]>([])
+export default function useAccordionState(openItems: Ref<string[]>): AccordionState {
 	const focusedItemId = ref<string | null>(null)
 
 	const toggleItem = (itemId: string) => {
@@ -19,11 +18,11 @@ export default function useAccordionState(): AccordionState {
 
 		const index = openItems.value.indexOf(itemId)
 		if (index === -1) {
-			openItems.value.push(itemId)
+			openItems.value = [...openItems.value, itemId]
 			setFocus(itemId)
 		}
 		else {
-			openItems.value.splice(index, 1)
+			openItems.value = openItems.value.filter(id => id !== itemId)
 			if (!wasFocused) {
 				setFocus(itemId)
 			}

--- a/src/components/Accordion/composables/useAccordionState.ts
+++ b/src/components/Accordion/composables/useAccordionState.ts
@@ -1,4 +1,4 @@
-import { ref } from 'vue'
+import { ref, type Ref } from 'vue'
 
 export interface AccordionState {
 	openItems: { value: string[] }

--- a/src/components/Accordion/tests/accordion.spec.ts
+++ b/src/components/Accordion/tests/accordion.spec.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
 import { mount, shallowMount } from '@vue/test-utils'
-
 import Accordion from '../Accordion.vue'
 import { config } from '../config'
 
@@ -23,7 +22,7 @@ describe('Accordion', () => {
 
 	it('renders correctly', () => {
 		const wrapper = shallowMount(Accordion, {
-			propsData: {
+			props: {
 				items: defaultItems,
 				headingLevel: 2,
 			},
@@ -34,7 +33,7 @@ describe('Accordion', () => {
 
 	it('renders the correct number of accordion items', () => {
 		const wrapper = mount(Accordion, {
-			propsData: {
+			props: {
 				items: defaultItems,
 				headingLevel: 2,
 			},
@@ -47,7 +46,7 @@ describe('Accordion', () => {
 	it('uses the correct heading level', () => {
 		const headingLevel = 3
 		const wrapper = mount(Accordion, {
-			propsData: {
+			props: {
 				items: defaultItems,
 				headingLevel,
 			},
@@ -59,7 +58,7 @@ describe('Accordion', () => {
 
 	it('toggles content visibility when button is clicked', async () => {
 		const wrapper = mount(Accordion, {
-			propsData: {
+			props: {
 				items: defaultItems,
 				headingLevel: 2,
 			},
@@ -82,7 +81,7 @@ describe('Accordion', () => {
 
 	it('renders string content correctly', () => {
 		const wrapper = mount(Accordion, {
-			propsData: {
+			props: {
 				items: [defaultItems[0]!],
 				headingLevel: 2,
 			},
@@ -97,7 +96,7 @@ describe('Accordion', () => {
 
 	it('renders object content correctly', async () => {
 		const wrapper = mount(Accordion, {
-			propsData: {
+			props: {
 				items: [defaultItems[2]!],
 				headingLevel: 2,
 			},
@@ -114,7 +113,7 @@ describe('Accordion', () => {
 
 	it('has correct accessibility attributes', () => {
 		const wrapper = mount(Accordion, {
-			propsData: {
+			props: {
 				items: defaultItems,
 				headingLevel: 2,
 			},
@@ -137,7 +136,7 @@ describe('Accordion', () => {
 
 	it('updates aria-expanded attribute when toggled', async () => {
 		const wrapper = mount(Accordion, {
-			propsData: {
+			props: {
 				items: defaultItems,
 				headingLevel: 2,
 			},
@@ -155,7 +154,7 @@ describe('Accordion', () => {
 
 	it('applies focus style when accordion is opened', async () => {
 		const wrapper = mount(Accordion, {
-			propsData: {
+			props: {
 				items: defaultItems,
 				headingLevel: 2,
 			},
@@ -185,7 +184,7 @@ describe('Accordion', () => {
 		})
 
 		const wrapper = mount(Accordion, {
-			propsData: {
+			props: {
 				items: defaultItems,
 				headingLevel: 2,
 				groupId: 'test-group',
@@ -209,7 +208,7 @@ describe('Accordion', () => {
 
 	it('applies primary color to the title', () => {
 		const wrapper = mount(Accordion, {
-			propsData: {
+			props: {
 				items: defaultItems,
 				headingLevel: 2,
 			},
@@ -224,7 +223,7 @@ describe('Accordion', () => {
 
 	it('updates tabindex when accordion is opened', async () => {
 		const wrapper = mount(Accordion, {
-			propsData: {
+			props: {
 				items: defaultItems,
 				headingLevel: 2,
 			},
@@ -246,7 +245,7 @@ describe('Accordion', () => {
 
 	it('renders semantic content structure for accessibility', async () => {
 		const wrapper = mount(Accordion, {
-			propsData: {
+			props: {
 				items: [
 					{ id: 'item1', title: 'Section 1', content: 'Contenu de la section 1' },
 					{
@@ -300,7 +299,7 @@ describe('Accordion', () => {
 		}
 
 		const wrapper = mount(Accordion, {
-			propsData: {
+			props: {
 				items: defaultItems,
 				headingLevel: 2,
 				...customOptions,
@@ -336,7 +335,7 @@ describe('Accordion', () => {
 
 	it('uses default colors from config when no custom options are provided', () => {
 		const wrapper = mount(Accordion, {
-			propsData: {
+			props: {
 				items: defaultItems,
 				headingLevel: 2,
 			},
@@ -363,7 +362,7 @@ describe('Accordion', () => {
 
 	it('can open multiple accordions simultaneously', async () => {
 		const wrapper = mount(Accordion, {
-			propsData: {
+			props: {
 				items: defaultItems,
 				headingLevel: 2,
 			},
@@ -387,7 +386,7 @@ describe('Accordion', () => {
 
 	it('transfers focus correctly when clicking on different accordion items', async () => {
 		const wrapper = mount(Accordion, {
-			propsData: {
+			props: {
 				items: defaultItems,
 				headingLevel: 2,
 			},
@@ -417,7 +416,7 @@ describe('Accordion', () => {
 
 		// Monter le composant
 		const wrapper = mount(Accordion, {
-			propsData: {
+			props: {
 				items: defaultItems,
 				headingLevel: 2,
 			},
@@ -434,5 +433,118 @@ describe('Accordion', () => {
 
 		// Restaurer le spy
 		removeEventListenerSpy.mockRestore()
+	})
+
+	describe('v-model support', () => {
+		it('opens items specified in modelValue prop', () => {
+			const wrapper = mount(Accordion, {
+				props: {
+					items: defaultItems,
+					headingLevel: 2,
+					modelValue: ['item2'],
+				},
+			})
+
+			const contents = wrapper.findAll('.sy-accordion-content')
+			expect(contents[1]!.classes()).toContain('sy-accordion-content--open')
+			expect(contents[0]!.classes()).not.toContain('sy-accordion-content--open')
+		})
+
+		it('opens multiple items specified in modelValue', () => {
+			const wrapper = mount(Accordion, {
+				props: {
+					items: defaultItems,
+					headingLevel: 2,
+					modelValue: ['item1', 'item3'],
+				},
+			})
+
+			const contents = wrapper.findAll('.sy-accordion-content')
+			expect(contents[0]!.classes()).toContain('sy-accordion-content--open')
+			expect(contents[1]!.classes()).not.toContain('sy-accordion-content--open')
+			expect(contents[2]!.classes()).toContain('sy-accordion-content--open')
+		})
+
+		it('sets correct aria-expanded for pre-opened items', () => {
+			const wrapper = mount(Accordion, {
+				props: {
+					items: defaultItems,
+					headingLevel: 2,
+					modelValue: ['item1'],
+				},
+			})
+
+			const buttons = wrapper.findAll('.sy-accordion-button')
+			expect(buttons[0]!.attributes('aria-expanded')).toBe('true')
+			expect(buttons[1]!.attributes('aria-expanded')).toBe('false')
+		})
+
+		it('toggles an item and updates the DOM when clicked', async () => {
+			const wrapper = mount(Accordion, {
+				props: {
+					items: defaultItems,
+					headingLevel: 2,
+					modelValue: ['item1'],
+				},
+			})
+
+			// item1 is initially open
+			let contents = wrapper.findAll('.sy-accordion-content')
+			expect(contents[0]!.classes()).toContain('sy-accordion-content--open')
+
+			// Close item1
+			const firstButton = wrapper.find('.sy-accordion-button')
+			await firstButton.trigger('click')
+
+			contents = wrapper.findAll('.sy-accordion-content')
+			expect(contents[0]!.classes()).not.toContain('sy-accordion-content--open')
+		})
+
+		it('opens additional items while keeping existing ones open', async () => {
+			const wrapper = mount(Accordion, {
+				props: {
+					items: defaultItems,
+					headingLevel: 2,
+					modelValue: ['item1'],
+				},
+			})
+
+			// Open item2 as well
+			const buttons = wrapper.findAll('.sy-accordion-button')
+			await buttons[1]!.trigger('click')
+
+			const contents = wrapper.findAll('.sy-accordion-content')
+			expect(contents[0]!.classes()).toContain('sy-accordion-content--open')
+			expect(contents[1]!.classes()).toContain('sy-accordion-content--open')
+		})
+
+		it('defaults to no open items when no modelValue is provided', () => {
+			const wrapper = mount(Accordion, {
+				props: {
+					items: defaultItems,
+					headingLevel: 2,
+					modelValue: [],
+				},
+			})
+
+			const buttons = wrapper.findAll('.sy-accordion-button')
+			buttons.forEach((button) => {
+				expect(button.attributes('aria-expanded')).toBe('false')
+			})
+		})
+
+		it('sets correct tabindex on content region for pre-opened items', () => {
+			const wrapper = mount(Accordion, {
+				props: {
+					items: defaultItems,
+					headingLevel: 2,
+					modelValue: ['item1'],
+				},
+			})
+
+			const regions = wrapper.findAll('[role="region"]')
+			expect(regions[0]!.attributes('tabindex')).toBe('0')
+			expect(regions[1]!.attributes('tabindex')).toBe('-1')
+		})
 	})
 })


### PR DESCRIPTION
## Description

- Permettre de gérer dynamiquement l'ouverture des éléments de l'accordeon
- Rendre optionnel la propriété 'content' des items

## Stories

<!-- Lien de la/les stories pour cette fonctonnalitée -->

## Type de changement

<!-- Supprimez les options non pertinentes. -->

- Nouvelle fonctionnalité
- Correction de bug


## Definition of Done

Avant de proposer une review, vérifiez chaque point de la checklist qui vous concerne et cochez-le s'il est appliqué.


### Evolution ou correctif de composant/template

**Bonne Pratique**

- [x] Ma Pull Request est bien nommée (Composant/template: descriptif issue)
- [x] Ma Pull Request pointe vers la bonne branche
- [x] Linker issue et PR

**Design**

- [x] L'évolution du composant/template respecte les maquettes validées (et l'équipe design est informée des changements)
- [x] Les design tokens sont utilisés

**Fonctionnel**

- [x] Le correctif résout le problème identifié
- [x] Aucun impact sur les usages existants

**Accessibilité spécifique au composant/template**

- [x] Navigation clavier vérifiée
- [x] Restitution lecteur d’écran vérifiée
- [x] Tests a11y mis à jour si nécessaire
- [x] Page accessibilité mise à jour si impact / crée si n’existe pas

**Documentation & Storybook**

- [x] Storybook mis à jour si nécessaire
- [x] Onglet A11Y sans erreur
- [x] La page de documentation accessibilité mise à jour si nécessaire

**Tests**

- [x] Tests mis à jour ou ajoutés pour couvrir le correctif
- [x] Deploy + SKSN Checks

**Fusion de composant/template**

- [ ] Le composant/template n'induit pas de régression dans le composant/template Synapse, Portail Agent ou AmeliPro
- [ ] Ajout des stories propre au thème (penser à filter le menu/props si nécessaire)
- [ ] Ajouter un message dans le composant/template déprécié avec un lien vers le nouveau