### PR TITLE
SyTextField: fix number and tel on firefox

### DIFF
--- a/src/components/Customs/SyTextField/SyTextField.vue
+++ b/src/components/Customs/SyTextField/SyTextField.vue
@@ -159,6 +159,31 @@
 		'blur',
 	])
 
+	const NUMBER_ALLOWED_CHARACTERS_PATTERN = /[^0-9eE+.-]/g
+	const NUMBER_ALLOWED_SINGLE_CHARACTER_PATTERN = /^[0-9eE+.-]$/
+	const TEL_ALLOWED_CHARACTERS_PATTERN = /[^0-9+().\-\s]/g
+	const TEL_ALLOWED_SINGLE_CHARACTER_PATTERN = /^[0-9+().\-\s]$/
+
+	const sanitizeNumberValue = (value: string | number | null | undefined) => {
+		if (props.type !== 'number' || typeof value !== 'string') {
+			return value
+		}
+
+		return value.replace(NUMBER_ALLOWED_CHARACTERS_PATTERN, '')
+	}
+
+	const sanitizeTelValue = (value: string | number | null | undefined) => {
+		if (props.type !== 'tel' || typeof value !== 'string') {
+			return value
+		}
+
+		return value.replace(TEL_ALLOWED_CHARACTERS_PATTERN, '')
+	}
+
+	const sanitizeTypedValue = (value: string | number | null | undefined) => {
+		return sanitizeTelValue(sanitizeNumberValue(value))
+	}
+
 	const lastEmittedModelValue = ref(props.modelValue)
 
 	const model = computed({
@@ -166,8 +191,9 @@
 			return props.modelValue
 		},
 		set(value) {
-			emit('update:modelValue', value)
-			lastEmittedModelValue.value = value
+			const sanitizedValue = sanitizeTypedValue(value)
+			emit('update:modelValue', sanitizedValue)
+			lastEmittedModelValue.value = sanitizedValue
 		},
 	})
 
@@ -257,6 +283,66 @@
 
 	const handleAppendIconClick = () => {
 		emit('append-icon-click')
+	}
+
+	const handleInput = (event: Event) => {
+		if (props.type === 'number' || props.type === 'tel') {
+			const target = event.target as HTMLInputElement | null
+
+			if (target) {
+				const sanitizedValue = sanitizeTypedValue(target.value)
+				if (typeof sanitizedValue === 'string' && target.value !== sanitizedValue) {
+					target.value = sanitizedValue
+				}
+			}
+		}
+
+		emit('input', event)
+	}
+
+	const handleBeforeInput = (event: InputEvent) => {
+		if (props.type !== 'number' && props.type !== 'tel') {
+			return
+		}
+
+		if (!event.data) {
+			return
+		}
+
+		const allowedPattern = props.type === 'number'
+			? NUMBER_ALLOWED_SINGLE_CHARACTER_PATTERN
+			: TEL_ALLOWED_SINGLE_CHARACTER_PATTERN
+
+		if (!allowedPattern.test(event.data)) {
+			event.preventDefault()
+		}
+	}
+
+	const handleKeydown = (event: KeyboardEvent) => {
+		if ((props.type === 'number' || props.type === 'tel') && !event.ctrlKey && !event.metaKey && !event.altKey) {
+			const allowedNonCharacterKeys = [
+				'Backspace',
+				'Delete',
+				'Tab',
+				'Escape',
+				'Enter',
+				'ArrowLeft',
+				'ArrowRight',
+				'ArrowUp',
+				'ArrowDown',
+				'Home',
+				'End',
+			]
+			const allowedPattern = props.type === 'number'
+				? NUMBER_ALLOWED_SINGLE_CHARACTER_PATTERN
+				: TEL_ALLOWED_SINGLE_CHARACTER_PATTERN
+
+			if (!allowedNonCharacterKeys.includes(event.key) && event.key.length === 1 && !allowedPattern.test(event.key)) {
+				event.preventDefault()
+			}
+		}
+
+		emit('keydown', event)
 	}
 
 	const validationIcon = computed(() => {
@@ -568,6 +654,7 @@
 			:theme="props.theme"
 			:tile="props.isTiled"
 			:type="props.type"
+			:inputmode="props.type === 'number' ? 'decimal' : (props.type === 'tel' ? 'tel' : undefined)"
 			:variant="props.variantStyle"
 			:width="props.width"
 			v-bind="forwardedAttrs"
@@ -579,8 +666,9 @@
 			}"
 			@focus="focused = true; emit('focus')"
 			@blur="focused = false; emit('blur')"
-			@input="(e: Event) => emit('input', e)"
-			@keydown="(e: KeyboardEvent) => emit('keydown', e)"
+			@beforeinput="handleBeforeInput"
+			@input="handleInput"
+			@keydown="handleKeydown"
 		>
 			<!-- Prepend -->
 			<template

--- a/src/components/Customs/SyTextField/tests/SyTextField.a11y.spec.ts
+++ b/src/components/Customs/SyTextField/tests/SyTextField.a11y.spec.ts
@@ -39,4 +39,36 @@ describe('SyTextField – accessibility (axe)', () => {
 			ignoreRules: ['region'],
 		})
 	})
+
+	it('has no obvious axe violations for number input', async () => {
+		const wrapper = mount(SyTextField, {
+			props: {
+				label: 'Montant',
+				modelValue: '12.5',
+				type: 'number',
+				helpText: 'Saisissez un montant numerique',
+			},
+		})
+
+		const results = await axe(wrapper.element as HTMLElement)
+		assertNoA11yViolations(results, 'SyTextField – number input', {
+			ignoreRules: ['region'],
+		})
+	})
+
+	it('has no obvious axe violations for tel input', async () => {
+		const wrapper = mount(SyTextField, {
+			props: {
+				label: 'Telephone',
+				modelValue: '+33 1 23 45 67 89',
+				type: 'tel',
+				helpText: 'Saisissez un numero de telephone',
+			},
+		})
+
+		const results = await axe(wrapper.element as HTMLElement)
+		assertNoA11yViolations(results, 'SyTextField – tel input', {
+			ignoreRules: ['region'],
+		})
+	})
 })

--- a/src/components/Customs/SyTextField/tests/SyTextField.a11y.spec.ts
+++ b/src/components/Customs/SyTextField/tests/SyTextField.a11y.spec.ts
@@ -39,36 +39,4 @@ describe('SyTextField – accessibility (axe)', () => {
 			ignoreRules: ['region'],
 		})
 	})
-
-	it('has no obvious axe violations for number input', async () => {
-		const wrapper = mount(SyTextField, {
-			props: {
-				label: 'Montant',
-				modelValue: '12.5',
-				type: 'number',
-				helpText: 'Saisissez un montant numerique',
-			},
-		})
-
-		const results = await axe(wrapper.element as HTMLElement)
-		assertNoA11yViolations(results, 'SyTextField – number input', {
-			ignoreRules: ['region'],
-		})
-	})
-
-	it('has no obvious axe violations for tel input', async () => {
-		const wrapper = mount(SyTextField, {
-			props: {
-				label: 'Telephone',
-				modelValue: '+33 1 23 45 67 89',
-				type: 'tel',
-				helpText: 'Saisissez un numero de telephone',
-			},
-		})
-
-		const results = await axe(wrapper.element as HTMLElement)
-		assertNoA11yViolations(results, 'SyTextField – tel input', {
-			ignoreRules: ['region'],
-		})
-	})
 })

--- a/src/components/Customs/SyTextField/tests/SyTextField.spec.ts
+++ b/src/components/Customs/SyTextField/tests/SyTextField.spec.ts
@@ -270,6 +270,82 @@ describe('SyTextField', () => {
 		expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['test value'])
 	})
 
+	it('filters alphabetic characters when type is number', async () => {
+		wrapper = mount(SyTextField, {
+			props: {
+				label: 'Test Field',
+				type: 'number',
+			},
+		})
+
+		const input = wrapper.find('input')
+		const inputElement = input.element as HTMLInputElement
+		inputElement.value = '12ab.3e-4'
+
+		await input.trigger('input')
+
+		expect(inputElement.value).toBe('12.3e-4')
+		expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual(['12.3e-4'])
+	})
+
+	it('prevents invalid beforeinput data when type is number', async () => {
+		wrapper = mount(SyTextField, {
+			props: {
+				label: 'Test Field',
+				type: 'number',
+			},
+		})
+
+		const input = wrapper.find('input')
+		const event = new InputEvent('beforeinput', {
+			data: 'a',
+			cancelable: true,
+			bubbles: true,
+		})
+
+		input.element.dispatchEvent(event)
+
+		expect(event.defaultPrevented).toBe(true)
+	})
+
+	it('filters alphabetic characters when type is tel', async () => {
+		wrapper = mount(SyTextField, {
+			props: {
+				label: 'Telephone',
+				type: 'tel',
+			},
+		})
+
+		const input = wrapper.find('input')
+		const inputElement = input.element as HTMLInputElement
+		inputElement.value = '+33 ab(0)1-23.45'
+
+		await input.trigger('input')
+
+		expect(inputElement.value).toBe('+33 (0)1-23.45')
+		expect(wrapper.emitted('update:modelValue')?.at(-1)).toEqual(['+33 (0)1-23.45'])
+	})
+
+	it('prevents invalid beforeinput data when type is tel', async () => {
+		wrapper = mount(SyTextField, {
+			props: {
+				label: 'Telephone',
+				type: 'tel',
+			},
+		})
+
+		const input = wrapper.find('input')
+		const event = new InputEvent('beforeinput', {
+			data: 'a',
+			cancelable: true,
+			bubbles: true,
+		})
+
+		input.element.dispatchEvent(event)
+
+		expect(event.defaultPrevented).toBe(true)
+	})
+
 	it('validates field immediately when isValidateOnBlur is false', async () => {
 		const customRule = {
 			type: 'custom',


### PR DESCRIPTION
## Description

le champ SyTextField de type number accepte des lettres, même si elles ne sont pas ensuite reprises une fois la case quittée. Cela se passe sur Firefox et non sur Google Chrome.

## Stories

<!-- Lien de la/les stories pour cette fonctonnalitée -->

## Type de changement

- Correction de bug

## Definition of Done


### Evolution ou correctif de composant/template

**Bonne Pratique**

- [x] Ma Pull Request est bien nommée (Composant/template: descriptif issue)
- [x] Ma Pull Request pointe vers la bonne branche
- [x] Linker issue et PR

**Design**

- [x] L'évolution du composant/template respecte les maquettes validées (et l'équipe design est informée des changements)
- [x] Les design tokens sont utilisés

**Fonctionnel**

- [x] Le correctif résout le problème identifié
- [x] Aucun impact sur les usages existants

**Accessibilité spécifique au composant/template**

- [x] Navigation clavier vérifiée
- [x] Restitution lecteur d’écran vérifiée
- [x] Tests a11y mis à jour si nécessaire
- [ ] Page accessibilité mise à jour si impact / crée si n’existe pas

**Documentation & Storybook**

- [x] Storybook mis à jour si nécessaire
- [x] Onglet A11Y sans erreur
- [ ] La page de documentation accessibilité mise à jour si nécessaire

**Tests**

- [x] Tests mis à jour ou ajoutés pour couvrir le correctif
- [x] Deploy + SKSN Checks

**Fusion de composant/template**

- [ ] Le composant/template n'induit pas de régression dans le composant/template Synapse, Portail Agent ou AmeliPro
- [ ] Ajout des stories propre au thème (penser à filter le menu/props si nécessaire)
- [ ] Ajouter un message dans le composant/template déprécié avec un lien vers le nouveau