### PR TITLE
Fix/uploadworklist undefined map

### DIFF
--- a/src/components/UploadWorkflow/UploadWorkflow.vue
+++ b/src/components/UploadWorkflow/UploadWorkflow.vue
@@ -30,6 +30,7 @@
 			}
 		>(),
 		{
+			uploadList: () => [],
 			sectionTitle: undefined,
 			showFilePreview: false,
 			infoText: '',

--- a/src/components/UploadWorkflow/tests/UploadWorkflow.spec.ts
+++ b/src/components/UploadWorkflow/tests/UploadWorkflow.spec.ts
@@ -35,6 +35,28 @@ describe('UploadWorkflow', () => {
 		expect(wrapper.find('.sy-file-upload').isVisible()).toBeTruthy()
 	})
 
+	it('handles empty upload list without crashing', async () => {
+		const wrapper = mount(UploadWorkflow, {
+			props: {
+				uploadList: [],
+			},
+		})
+
+		expect(wrapper.html()).toMatchSnapshot()
+		expect(wrapper.findAll('.file-item')).toHaveLength(0)
+		expect(wrapper.find('.sy-file-upload').isVisible()).toBeTruthy()
+	})
+
+	it('handles undefined upload list without crashing', async () => {
+		const wrapper = mount(UploadWorkflow, {
+			props: {} as any,
+		})
+
+		expect(wrapper.html()).toMatchSnapshot()
+		expect(wrapper.findAll('.file-item')).toHaveLength(0)
+		expect(wrapper.find('.sy-file-upload').isVisible()).toBeTruthy()
+	})
+
 	it('shows the file in the list when set with the list button', async () => {
 		const wrapper = mount(UploadWorkflow, {
 			props: {

--- a/src/components/UploadWorkflow/tests/UploadWorkflow.spec.ts
+++ b/src/components/UploadWorkflow/tests/UploadWorkflow.spec.ts
@@ -44,17 +44,18 @@ describe('UploadWorkflow', () => {
 
 		expect(wrapper.html()).toMatchSnapshot()
 		expect(wrapper.findAll('.file-item')).toHaveLength(0)
-		expect(wrapper.find('.sy-file-upload').isVisible()).toBeTruthy()
+		expect(wrapper.find('.sy-file-upload').exists()).toBeFalsy()
 	})
 
 	it('handles undefined upload list without crashing', async () => {
 		const wrapper = mount(UploadWorkflow, {
+			/* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 			props: {} as any,
 		})
 
 		expect(wrapper.html()).toMatchSnapshot()
 		expect(wrapper.findAll('.file-item')).toHaveLength(0)
-		expect(wrapper.find('.sy-file-upload').isVisible()).toBeTruthy()
+		expect(wrapper.find('.sy-file-upload').exists()).toBeFalsy()
 	})
 
 	it('shows the file in the list when set with the list button', async () => {

--- a/src/components/UploadWorkflow/tests/__snapshots__/UploadWorkflow.spec.ts.snap
+++ b/src/components/UploadWorkflow/tests/__snapshots__/UploadWorkflow.spec.ts.snap
@@ -1,5 +1,71 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`UploadWorkflow > handles empty upload list without crashing 1`] = `
+<div
+  class="
+    sy-upload-workflow
+    white
+  "
+  style="width: 100%;"
+>
+  <h4 class="
+    mb-2
+    sy-heading
+    text-h6
+  ">
+    Document à nous transmettre
+  </h4>
+  <ul
+    class="upload-list"
+    style="width: 100%;"
+  ></ul>
+  <transition-stub
+    appear="false"
+    css="true"
+    persisted="false"
+  >
+    <!-- v-if -->
+  </transition-stub>
+  <!---->
+  <!---->
+  <!---->
+  <!---->
+</div>
+`;
+
+exports[`UploadWorkflow > handles undefined upload list without crashing 1`] = `
+<div
+  class="
+    sy-upload-workflow
+    white
+  "
+  style="width: 100%;"
+>
+  <h4 class="
+    mb-2
+    sy-heading
+    text-h6
+  ">
+    Document à nous transmettre
+  </h4>
+  <ul
+    class="upload-list"
+    style="width: 100%;"
+  ></ul>
+  <transition-stub
+    appear="false"
+    css="true"
+    persisted="false"
+  >
+    <!-- v-if -->
+  </transition-stub>
+  <!---->
+  <!---->
+  <!---->
+  <!---->
+</div>
+`;
+
 exports[`UploadWorkflow > render the upload list 1`] = `
 <div
   class="

--- a/src/components/UploadWorkflow/useFileList.ts
+++ b/src/components/UploadWorkflow/useFileList.ts
@@ -72,6 +72,9 @@ export default function useFileList(
 	}
 
 	const filledUploadList = computed<FileItem[]>(() => {
+		if (!uploadList.value) {
+			return []
+		}
 		return uploadList.value.map((uploadItem) => {
 			const matchingUploadedItem = findSelectedFile(uploadItem.id)
 			const error = errorSelectedFiles.value.includes(uploadItem.id)


### PR DESCRIPTION
toRef(props, 'uploadList') est passé à useFileList, mais si props.uploadList est undefined ou non initialisé au moment du montage du composant, uploadList.value devient undefined.