### PR TITLE
Build: fix export (Vite 6)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
       "import": "./dist/design-system-v3.js",
       "require": "./dist/design-system-v3.umd.cjs"
     },
-    "./style.css": "./dist/style.css",
+    "./style.css": "./dist/synapse.css",
+    "./synapse.css": "./dist/synapse.css",
     "./vuetifyConfig": {
       "types": "./dist/vuetifyConfig.d.ts",
       "import": "./dist/vuetifyConfig.js",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
       "import": "./dist/design-system-v3.js",
       "require": "./dist/design-system-v3.umd.cjs"
     },
-    "./style.css": "./dist/synapse.css",
     "./synapse.css": "./dist/synapse.css",
     "./vuetifyConfig": {
       "types": "./dist/vuetifyConfig.d.ts",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -94,16 +94,16 @@ export default defineConfig({
 	},
 	build: {
 		lib: {
-				entry: {
-					'design-system-v3': resolve(__dirname, 'src/main.ts'),
-					'vuetifyConfig': resolve(__dirname, 'src/vuetifyConfig.ts'),
-				},
-				name: 'DesignSystemV3',
-				cssFileName: 'synapse',
-				formats: ['es', 'cjs'],
-				fileName: (format, entryAlias) => {
-					if (format === 'cjs') return `${entryAlias}.umd.cjs`
-					return `${entryAlias}.js`
+			entry: {
+				'design-system-v3': resolve(__dirname, 'src/main.ts'),
+				'vuetifyConfig': resolve(__dirname, 'src/vuetifyConfig.ts'),
+			},
+			name: 'DesignSystemV3',
+			cssFileName: 'synapse',
+			formats: ['es', 'cjs'],
+			fileName: (format, entryAlias) => {
+				if (format === 'cjs') return `${entryAlias}.umd.cjs`
+				return `${entryAlias}.js`
 			},
 		},
 		chunkSizeWarningLimit: 4000,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -94,15 +94,16 @@ export default defineConfig({
 	},
 	build: {
 		lib: {
-			entry: {
-				'design-system-v3': resolve(__dirname, 'src/main.ts'),
-				'vuetifyConfig': resolve(__dirname, 'src/vuetifyConfig.ts'),
-			},
-			name: 'DesignSystemV3',
-			formats: ['es', 'cjs'],
-			fileName: (format, entryAlias) => {
-				if (format === 'cjs') return `${entryAlias}.umd.cjs`
-				return `${entryAlias}.js`
+				entry: {
+					'design-system-v3': resolve(__dirname, 'src/main.ts'),
+					'vuetifyConfig': resolve(__dirname, 'src/vuetifyConfig.ts'),
+				},
+				name: 'DesignSystemV3',
+				cssFileName: 'synapse',
+				formats: ['es', 'cjs'],
+				fileName: (format, entryAlias) => {
+					if (format === 'cjs') return `${entryAlias}.umd.cjs`
+					return `${entryAlias}.js`
 			},
 		},
 		chunkSizeWarningLimit: 4000,


### PR DESCRIPTION
## Description

Fix de l'import des styles sur le SK suite à la montée de version Vite 6
https://v6.vite.dev/guide/migration.html

https://v6.vite.dev/guide/migration.html#customize-css-output-file-name-in-library-mode

