### PR TITLE
Module notification: improve export for SK

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
       "import": "./dist/vuetifyConfig.js",
       "require": "./dist/vuetifyConfig.umd.cjs"
     },
+    "./modules/notification": {
+      "types": "./src/modules/notification/index.ts",
+      "default": "./src/modules/notification/index.ts"
+    },
     "./*": {
       "types": "./src/*",
       "default": "./src/*"

--- a/src/stories/GuideDuDev/moduleDeNotification.mdx
+++ b/src/stories/GuideDuDev/moduleDeNotification.mdx
@@ -13,11 +13,12 @@ import '../styles/shared.css';
 ## Importation et utilisation
 
 <Source dark code={`
-import { useNotificationService } from '
-import '../styles/shared.css';@cnamts/synapse'
+import { useNotificationService } from '@cnamts/synapse/modules/notification'
 
 const { notificationQueue, addNotification, removeNotification, clearQueue } = useNotificationService()
 `} />
+
+> L'entrée `@cnamts/synapse/modules/notification` est déclarée explicitement dans les exports du package.
 
 ## Propriétés et méthodes :
 


### PR DESCRIPTION
## Description

Aujourd'hui on doit explicitement préciser sur le SK l'ajout du module de notification dans la config typescript (tsconfig.app.json) : 
`"@cnamts/synapse/modules/notification": ["node_modules/@cnamts/synapse/src/modules/notification/index.ts"]`
cela peux être simplifié par l'export du module

## Type de changement

- Optimisation

<img width="2025" height="1384" alt="Capture d’écran 2026-04-15 à 10 29 27" src="https://github.com/user-attachments/assets/832f51b6-5dce-419b-96a0-0ae43e2c5a70" />
