### PR TITLE
[SySelect]: permettre un meilleur rendu du composant en l'abscence de css

### DIFF
--- a/src/components/Customs/Selects/SySelect/SySelect.vue
+++ b/src/components/Customs/Selects/SySelect/SySelect.vue
@@ -139,7 +139,6 @@
 	const { focused, validate, clearValidation, errors, warnings, successes, hasError, hasWarning, hasSuccess, validationIcon } = useSySelectValidation(props)
 
 	const labelWidth = ref(0)
-	const labelRef = ref<HTMLElement | null>(null)
 	const list = ref<VList | null>(null)
 	const textInput = ref<InstanceType<typeof VTextField> | null>(null)
 	const htmlItemRefs = ref<HTMLElement[]>([])
@@ -189,12 +188,8 @@
 	const inputId = ref(`sy-select-${Math.random().toString(36).substring(7)}`)
 	// text d'aide
 	const helpTextId = computed(() => `${inputId.value}-help`)
-	// messages d'erreur, success avertissement
-	const messagesId = computed(() => `${inputId.value}-sr-messages`)
 	// live region pour le lecteur ecran
 	const liveRegionId = computed(() => `${inputId.value}-live`)
-	// un libellé caché pour la popup/grid
-	const overlayLabelId = computed(() => `${inputId.value}-overlay-label`)
 
 	// Generate unique menu ID for each component instance to avoid conflicts and validation issues
 	const uniqueMenuId = ref(props.menuId === 'sy-select-menu' ? `sy-select-menu-${Math.random().toString(36).substring(7)}` : props.menuId)
@@ -492,10 +487,6 @@
 		if ((showHelpTextAsMessage.value || showHelpTextBelow.value) && props.helpText) {
 			ids.push(helpTextId.value)
 		}
-		// messages affichés
-		if (!props.hideDetails && hasMessages.value) {
-			ids.push(messagesId.value)
-		}
 		// live region si erreur
 		if (hasError.value || errors.value.length > 0) {
 			ids.push(liveRegionId.value)
@@ -766,10 +757,6 @@
 	}
 
 	onMounted(() => {
-		if (labelRef.value) {
-			labelWidth.value = labelRef.value.offsetWidth + 64
-		}
-
 		nextTick(() => {
 			setupAriaAttributes()
 
@@ -875,7 +862,6 @@
 		else {
 			listElement.removeAttribute('aria-multiselectable')
 		}
-		listElement.setAttribute('aria-labelledby', overlayLabelId.value)
 	}
 
 	const focusInput = () => {
@@ -1076,6 +1062,7 @@
 								:icon="validationIcon"
 								:decorative="true"
 								role="presentation"
+								width="24"
 							/>
 							<button
 								v-if="props.clearable && hasSelectionToClear"
@@ -1091,31 +1078,19 @@
 									class="sy-select__clear-icon"
 									:icon="mdiCloseCircle"
 									:decorative="true"
+									width="24"
 								/>
 							</button>
 							<SyIcon
 								class="arrow"
 								:icon="mdiChevronDown"
 								:decorative="true"
+								width="24"
 							/>
 						</template>
 					</VTextField>
 				</div>
-				<span
-					ref="labelRef"
-					class="hidden-label"
-				>{{ label }}</span>
 			</template>
-
-			<!--
-				Libellé caché utilisé pour nommer la popup/grid.
-			-->
-			<span
-				:id="overlayLabelId"
-				class="d-sr-only"
-			>
-				{{ accessibleLabel }}
-			</span>
 
 			<VList
 				:id="uniqueMenuId"
@@ -1123,11 +1098,12 @@
 				class="v-list sy-select-grid"
 				role="listbox"
 				:aria-multiselectable="props.multiple ? 'true' : undefined"
-				:aria-labelledby="overlayLabelId"
+				:aria-labelledby="`${inputId}-label`"
 				:title="accessibleLabel"
 				:style="{
 					minWidth: `${textInput?.$el.offsetWidth}px`
 				}"
+				tag="ul"
 				bg-color="white"
 				tabindex="-1"
 				@keydown.esc.prevent="closeList"
@@ -1141,7 +1117,7 @@
 				@keydown.page-down.prevent="handlePageDownKey"
 				@click.stop
 			>
-				<div
+				<li
 					v-for="(item, index) in formattedItems"
 					:id="`option-${index}`"
 					:key="index"
@@ -1188,7 +1164,7 @@
 							</span>
 						</VListItemTitle>
 					</div>
-				</div>
+				</li>
 			</VList>
 		</VMenu>
 
@@ -1201,14 +1177,7 @@
 		</div>
 
 		<div
-			v-if="!props.hideDetails && hasMessages"
-			:id="messagesId"
-			class="d-sr-only"
-		>
-			{{ hasError ? errors.join(' ') : (hasWarning ? warnings.join(' ') : successes.join(' ')) }}
-		</div>
-
-		<div
+			v-if="props.hideDetails && hasMessages"
 			:id="liveRegionId"
 			class="d-sr-only"
 			aria-live="polite"
@@ -1507,12 +1476,6 @@
 	z-index: auto;
 	text-overflow: ellipsis;
 	white-space: normal;
-}
-
-.hidden-label {
-	visibility: hidden;
-	position: absolute;
-	white-space: nowrap;
 }
 
 .sy-select--with-chips :deep(.v-field__input input) {

--- a/src/components/Customs/SyIcon/SyIcon.vue
+++ b/src/components/Customs/SyIcon/SyIcon.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 	import type { IconValue } from 'vuetify/lib/composables/icons.mjs'
 	import { vRgaaSvgFix } from '@/directives/rgaaSvgFix'
-	import { computed, onMounted, watch } from 'vue'
+	import { computed, onMounted, onUpdated, ref, watch } from 'vue'
 
 	/**
 	 * Composant SyIcon - Affiche une icône avec gestion de l'accessibilité
@@ -32,6 +32,7 @@
 		autoDetectButton?: boolean
 		color?: string
 		size?: string
+		width?: string
 	}>()
 
 	const resolvedDecorative = computed(() => props.decorative ?? true)
@@ -45,10 +46,25 @@
 		}
 	})
 
+	const svg = ref(null)
+
 	// Vérification à l'initialisation du composant
 	onMounted(() => {
 		checkAccessibility(props.icon, resolvedDecorative.value, props.label)
+		setWidth()
 	})
+
+	onUpdated(setWidth)
+
+	function setWidth() {
+		if (svg.value && props.width) {
+			const iconElement = svg.value.$el?.querySelector('svg')
+
+			if (iconElement) {
+				iconElement.setAttribute('width', props.width)
+			}
+		}
+	}
 
 	// Vérification à chaque changement des props concernées
 	watch(
@@ -65,6 +81,7 @@
 
 <template>
 	<v-icon
+		ref="svg"
 		v-rgaa-svg-fix="rgaaSvgFixConfig"
 		:color="props.color"
 		:size="props.size"

--- a/src/components/Customs/SyIcon/SyIcon.vue
+++ b/src/components/Customs/SyIcon/SyIcon.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+	import type { ComponentPublicInstance } from 'vue'
 	import type { IconValue } from 'vuetify/lib/composables/icons.mjs'
 	import { vRgaaSvgFix } from '@/directives/rgaaSvgFix'
 	import { computed, onMounted, onUpdated, ref, watch } from 'vue'
@@ -46,7 +47,7 @@
 		}
 	})
 
-	const svg = ref(null)
+	const svg = ref<ComponentPublicInstance | null>(null)
 
 	// Vérification à l'initialisation du composant
 	onMounted(() => {


### PR DESCRIPTION
Cette PR à pour object de permettre un meilleur rendu du composant SySelect quand le CSS est désactivé. Cela permet en autre de renforcer la conformité du composant vis a vie de la règle 10.2 du RGAA.

Actions effectués :
- Ajout de l'attribut `width` au SVG (cet attribut est valide et conforme dans ce contexte). afin de limiter leurs tailles lorsque le css est désactiver et empêcher de la du coupure visuel entre le champs et la liste de sélection.
-  Suppression du label masqué pour la liste des options. Ce label apparaissait de façon redondante quand le CSS est désactivé, l'attribut `aria-labeledby` permet de conserver le lien sémantique et l'aide au lecteur d'écran sans tripler l'information disponible visuellement.
- Suppression de la duplication du message de status du champs quand la props `hide-details` est à false.
- Formatage des options sous forme de liste pour une meilleur compréhension de la sémantique des éléments.