### PR TITLE
Filtres : corrections de bugs

### DIFF
--- a/src/components/Customs/SyCheckbox/SyCheckbox.vue
+++ b/src/components/Customs/SyCheckbox/SyCheckbox.vue
@@ -3,7 +3,6 @@
 	import type { VCheckbox } from 'vuetify/components'
 	import { useValidation, type ValidationRule } from '@/composables/validation/useValidation'
 	import { useValidatable } from '@/composables/validation/useValidatable'
-	import { locales } from './locales'
 	import { cnamSemanticTokens } from '@/designTokens/tokens/cnam/cnamSemantic'
 
 	const props = withDefaults(
@@ -380,13 +379,6 @@
 			>
 				<slot />
 			</template>
-			<span
-				v-if="messageId && props.required && !props.ariaLabel && !props.ariaLabelledby"
-				:id="messageId"
-				class="d-sr-only"
-			>
-				{{ locales.labelledbyMessage }} <span v-if="props.label">{{ props.label + (props.displayAsterisk ? '*' : '') }}</span>.
-			</span>
 		</VCheckbox>
 	</div>
 </template>

--- a/src/components/Customs/SyCheckbox/locales.ts
+++ b/src/components/Customs/SyCheckbox/locales.ts
@@ -1,3 +1,0 @@
-export const locales = {
-	labelledbyMessage: 'Sélectionner l\'option',
-}

--- a/src/components/FilterInline/FilterInline.stories.ts
+++ b/src/components/FilterInline/FilterInline.stories.ts
@@ -537,6 +537,7 @@ export const FilterCombination: Story = {
 
 				<template #profession="{ props }">
 					<SearchListField
+						label="Profession"
 						v-bind="props"
 						:items="professionList"
 					/>
@@ -583,6 +584,7 @@ export const FilterCombination: Story = {
 
 				<template #profession="{ props }">
 					<SearchListField
+						label="Profession"
 						v-bind="props"
 						:items="professionList"
 						color="primary"

--- a/src/components/FilterInline/FilterInline.vue
+++ b/src/components/FilterInline/FilterInline.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 	import useFilterable, { type FilterProp } from '@/composables/useFilterable/useFilterable'
 	import { mdiChevronDown, mdiChevronUp } from '@mdi/js'
-	import { toRef } from 'vue'
+	import { toRef, watch } from 'vue'
 	import ChipList from '../ChipList/ChipList.vue'
 	import { locales as defaultLocales } from './locales'
 	import SyIcon from '@/components/Customs/SyIcon/SyIcon.vue'
@@ -20,14 +20,20 @@
 
 	const {
 		filters,
-		updateValue,
 		removeChip,
 		resetFilter,
 		getChips,
 		getFilterCount,
 		formatFilterName,
-	} = useFilterable(toRef(props, 'modelValue'), emits)
+	} = useFilterable(toRef(props, 'modelValue'))
 
+	watch(filters, (newFilters) => {
+		if (JSON.stringify(newFilters) === JSON.stringify(props.modelValue)) {
+			// a new array or object do not mean a new value
+			return
+		}
+		emits('update:modelValue', filters.value)
+	}, { deep: true })
 </script>
 
 <template>
@@ -88,7 +94,6 @@
 						'onUpdate:modelValue': (value: unknown) => {
 							if (value !== filter.value) {
 								filter.value = value
-								updateValue()
 							}
 						},
 					}"

--- a/src/components/FilterInline/FilterInline.vue
+++ b/src/components/FilterInline/FilterInline.vue
@@ -15,7 +15,7 @@
 	})
 
 	const emits = defineEmits<{
-		'update:modelValue': (value: FilterProp) => void
+		(e: 'update:modelValue', value: FilterProp): void
 	}>()
 
 	const {

--- a/src/components/FilterSideBar/FilterSideBar.stories.ts
+++ b/src/components/FilterSideBar/FilterSideBar.stories.ts
@@ -254,6 +254,7 @@ export const Default: Story = {
 
 				<template #profession="{ props }">
 					<SearchListField
+						label="Profession"
 						v-bind="props"
 						label="Profession"
 						:items="professionList"
@@ -602,6 +603,7 @@ export const FilterCombination: Story = {
 
 				<template #profession="{ props }">
 					<SearchListField
+						label="Profession"
 						v-bind="props"
 						:items="professionList"
 					/>
@@ -703,6 +705,7 @@ export const FilterCombination: Story = {
 
 				<template #profession="{ props }">
 					<SearchListField
+						label="Profession"
 						v-bind="props"
 						:items="professionList"
 					/>

--- a/src/components/FilterSideBar/FilterSideBar.vue
+++ b/src/components/FilterSideBar/FilterSideBar.vue
@@ -23,7 +23,7 @@
 	})
 
 	const emits = defineEmits<{
-		'update:modelValue': (value: FilterProp) => void
+		(e: 'update:modelValue', value: FilterProp): void
 	}>()
 
 	const {

--- a/src/components/FilterSideBar/FilterSideBar.vue
+++ b/src/components/FilterSideBar/FilterSideBar.vue
@@ -28,14 +28,13 @@
 
 	const {
 		filters,
-		updateValue,
 		removeChip,
 		resetFilter,
 		getChips,
 		getFilterCount,
 		formatFilterName,
 		resetAllFilters,
-	} = useFilterable(toRef(props, 'modelValue'), emits)
+	} = useFilterable(toRef(props, 'modelValue'))
 
 	const drawer = ref(false)
 
@@ -57,7 +56,7 @@
 	}
 
 	function applyFilters(): void {
-		updateValue()
+		emits('update:modelValue', filters.value)
 		drawer.value = false
 	}
 
@@ -76,6 +75,12 @@
 			svg.removeAttribute('role')
 		})
 	})
+
+	function resetAll(): void {
+		resetAllFilters()
+		emits('update:modelValue', filters.value)
+	}
+
 </script>
 
 <template>
@@ -175,7 +180,7 @@
 								<slot
 									:name="`${formatFilterName(filter.name)}`"
 									:props="{
-										modelValue: filter.value as any,
+										modelValue: filter.value,
 										'onUpdate:modelValue': (value: unknown) =>{
 											(filter.value = value)},
 									}"
@@ -207,7 +212,7 @@
 							class="sy-filters-side-bar__reset-btn mb-4"
 							type="reset"
 							:aria-label="locales.resetAriaLabel"
-							@click.stop="resetAllFilters"
+							@click.stop="resetAll"
 						>
 							{{ locales.reset }}
 						</VBtn>

--- a/src/components/SearchListField/SearchListField.vue
+++ b/src/components/SearchListField/SearchListField.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 	import { ref, computed, watch } from 'vue'
 	import { mdiMagnify } from '@mdi/js'
+	import { useId } from 'vue'
 	import type { PropType } from 'vue'
 	import type { SearchListItem } from './types'
 	import { locales as defaultLocales } from './locales'
@@ -11,7 +12,7 @@
 
 	const props = defineProps({
 		modelValue: {
-			type: Array as PropType<unknown[]>,
+			type: Array as PropType<unknown[] | undefined | null>,
 			default: () => [],
 		},
 		items: {
@@ -52,7 +53,7 @@
 	watch(
 		() => props.modelValue,
 		(newValue) => {
-			internalValue.value = newValue
+			internalValue.value = Array.isArray(newValue) ? [...newValue] : []
 		}, { immediate: true },
 	)
 
@@ -93,6 +94,8 @@
 	const emitChangeEvent = (value: unknown[]) => {
 		emit('update:modelValue', [...value])
 	}
+
+	const id = useId()
 
 	defineExpose({
 		filteredItems,
@@ -154,23 +157,16 @@
 						'suggestion-item--selected': !!internalValue.find(el => el === (props.returnObject ? item : item.value)),
 					}"
 				>
-					<!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
-					<label
-						class="label"
-						:for="`checkbox-${slugify(item.label)}`"
-					>
-						<SyCheckbox
-							:id="`checkbox-${slugify(item.label)}`"
-							hide-details
-							density="compact"
-							class="ml-2"
-							:model-value="!!internalValue.find(el => el === (props.returnObject ? item : item.value))"
-							@update:model-value="(e: boolean)=>toggleCheckbox(item, e)"
-						/>
-						<span>
-							{{ item.label }}
-						</span>
-					</label>
+					<SyCheckbox
+						:id="`checkbox-${slugify(item.label)}-${id}`"
+						:name="`checkbox-${slugify(item.label)}-${id}`"
+						:label="item.label"
+						hide-details
+						density="compact"
+						class="ml-2"
+						:model-value="!!internalValue.find(el => el === (props.returnObject ? item : item.value))"
+						@update:model-value="(e: boolean) => toggleCheckbox(item, e)"
+					/>
 				</li>
 			</ul>
 		</fieldset>

--- a/src/components/SearchListField/SearchListField.vue
+++ b/src/components/SearchListField/SearchListField.vue
@@ -157,16 +157,24 @@
 						'suggestion-item--selected': !!internalValue.find(el => el === (props.returnObject ? item : item.value)),
 					}"
 				>
-					<SyCheckbox
-						:id="`checkbox-${slugify(item.label)}-${id}`"
-						:name="`checkbox-${slugify(item.label)}-${id}`"
-						:label="item.label"
-						hide-details
-						density="compact"
-						class="ml-2"
-						:model-value="!!internalValue.find(el => el === (props.returnObject ? item : item.value))"
-						@update:model-value="(e: boolean) => toggleCheckbox(item, e)"
-					/>
+					<!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
+					<label
+						class="label"
+						:for="`checkbox-${slugify(item.label)}-${id}`"
+					>
+						<SyCheckbox
+							:id="`checkbox-${slugify(item.label)}-${id}`"
+							:name="`checkbox-${slugify(item.label)}-${id}`"
+							hide-details
+							density="compact"
+							class="ml-2"
+							:model-value="!!internalValue.find(el => el === (props.returnObject ? item : item.value))"
+							@update:model-value="(e: boolean)=>toggleCheckbox(item, e)"
+						/>
+						<span>
+							{{ item.label }}
+						</span>
+					</label>
 				</li>
 			</ul>
 		</fieldset>

--- a/src/components/SearchListField/tests/SearchListField.spec.ts
+++ b/src/components/SearchListField/tests/SearchListField.spec.ts
@@ -69,6 +69,56 @@ describe('SearchListField.vue', () => {
 		).toBe(false)
 	})
 
+	it('supports null modelValue and can select an item', async () => {
+		const wrapper = mount(SearchListField, {
+			props: {
+				label: 'Filtrer la liste des Items',
+				items: [
+					{
+						label: 'Item 1',
+						value: 1,
+					},
+					{
+						label: 'Item 2',
+						value: 2,
+					},
+				],
+				modelValue: null,
+			},
+		})
+
+		const listItem = wrapper.find('[data-test-id="suggestions-list"] li')
+		await listItem.find('input[type="checkbox"]').trigger('click')
+		await wrapper.vm.$nextTick()
+
+		expect(wrapper.emitted('update:modelValue')).toEqual([[[1]]])
+	})
+
+	it('supports undefined modelValue and can select an item', async () => {
+		const wrapper = mount(SearchListField, {
+			props: {
+				label: 'Filtrer la liste des Items',
+				items: [
+					{
+						label: 'Item 1',
+						value: 1,
+					},
+					{
+						label: 'Item 2',
+						value: 2,
+					},
+				],
+				modelValue: undefined,
+			},
+		})
+
+		const listItem = wrapper.find('[data-test-id="suggestions-list"] li')
+		await listItem.find('input[type="checkbox"]').trigger('click')
+		await wrapper.vm.$nextTick()
+
+		expect(wrapper.emitted('update:modelValue')).toEqual([[[1]]])
+	})
+
 	it('selects an item', async () => {
 		const wrapper = mount(SearchListField, {
 			props: {
@@ -392,6 +442,83 @@ describe('SearchListField.vue', () => {
 			await wrapper.vm.$nextTick()
 
 			expect(emittedEvents![1]).toEqual([[]])
+		})
+	})
+
+	describe('reset and immutability', () => {
+		it('clears internalValue when modelValue is reset to undefined after selections', async () => {
+			const wrapper = mount(SearchListField, {
+				props: {
+					label: 'Test',
+					items: [
+						{ label: 'Item 1', value: 1 },
+						{ label: 'Item 2', value: 2 },
+					],
+				},
+			})
+
+			// Select item 1
+			const checkboxes = wrapper.findAll('[data-test-id="suggestions-list"] input[type="checkbox"]')
+			await checkboxes[0].trigger('click')
+			await wrapper.vm.$nextTick()
+
+			// Simulate parent syncing modelValue back
+			await wrapper.setProps({ modelValue: [1] })
+
+			// Reset: parent sets modelValue to undefined (filter reset)
+			await wrapper.setProps({ modelValue: undefined })
+
+			// Select item 2
+			await checkboxes[1].trigger('click')
+			await wrapper.vm.$nextTick()
+
+			const emitted = wrapper.emitted('update:modelValue')!
+			// Last emit should only contain [2], not [1, 2]
+			expect(emitted[emitted.length - 1]).toEqual([[2]])
+		})
+
+		it('does not mutate the modelValue prop array when selecting items', async () => {
+			const modelValue = [1]
+			const wrapper = mount(SearchListField, {
+				props: {
+					label: 'Test',
+					items: [
+						{ label: 'Item 1', value: 1 },
+						{ label: 'Item 2', value: 2 },
+					],
+					modelValue,
+				},
+			})
+
+			await wrapper.findAll('[data-test-id="suggestions-list"] input[type="checkbox"]')[1].trigger('click')
+			await wrapper.vm.$nextTick()
+
+			// Original prop array must not be mutated
+			expect(modelValue).toEqual([1])
+			// Emitted value should include both items
+			expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([[1, 2]])
+		})
+
+		it('does not mutate the modelValue prop array when deselecting items', async () => {
+			const modelValue = [1, 2]
+			const wrapper = mount(SearchListField, {
+				props: {
+					label: 'Test',
+					items: [
+						{ label: 'Item 1', value: 1 },
+						{ label: 'Item 2', value: 2 },
+					],
+					modelValue,
+				},
+			})
+
+			await wrapper.findAll('[data-test-id="suggestions-list"] input[type="checkbox"]')[0].trigger('click')
+			await wrapper.vm.$nextTick()
+
+			// Original prop array must not be mutated
+			expect(modelValue).toEqual([1, 2])
+			// Emitted value should only contain item 2
+			expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([[2]])
 		})
 	})
 })

--- a/src/composables/useFilterable/useFilterable.spec.ts
+++ b/src/composables/useFilterable/useFilterable.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import useFilterable, { type FilterItem, type FilterProp } from './useFilterable'
 import type { ChipItem } from '@/components/ChipList/types'
 import { nextTick, ref } from 'vue'
@@ -6,10 +6,7 @@ import { nextTick, ref } from 'vue'
 describe('Filterable', () => {
 	describe('formatFilterName', () => {
 		it('preserves existing behavior for names with spaces', () => {
-			const { formatFilterName } = useFilterable(
-				ref([]),
-				() => {},
-			)
+			const { formatFilterName } = useFilterable(ref([]))
 
 			const name = formatFilterName('Test Name')
 			expect(name).toBe('test-name')
@@ -19,10 +16,7 @@ describe('Filterable', () => {
 		})
 
 		it('preserves existing behavior for names with special characters', () => {
-			const { formatFilterName } = useFilterable(
-				ref([]),
-				() => {},
-			)
+			const { formatFilterName } = useFilterable(ref([]))
 
 			const nameWithSpecialChars = formatFilterName('Filter@Name#Test')
 			expect(nameWithSpecialChars).toBe('filternametest')
@@ -32,10 +26,7 @@ describe('Filterable', () => {
 		})
 
 		it('fixes camelCase issue by preserving case for single words', () => {
-			const { formatFilterName } = useFilterable(
-				ref([]),
-				() => {},
-			)
+			const { formatFilterName } = useFilterable(ref([]))
 
 			const camelCaseName = formatFilterName('totoCase')
 			expect(camelCaseName).toBe('totoCase')
@@ -48,10 +39,7 @@ describe('Filterable', () => {
 		})
 
 		it('handles edge cases correctly', () => {
-			const { formatFilterName } = useFilterable(
-				ref([]),
-				() => {},
-			)
+			const { formatFilterName } = useFilterable(ref([]))
 
 			// Single lowercase word
 			expect(formatFilterName('name')).toBe('name')
@@ -69,10 +57,7 @@ describe('Filterable', () => {
 
 	describe('getChips', () => {
 		it('uses the formatChip function to compute the chip', () => {
-			const { getChips, getFilterCount } = useFilterable(
-				ref([]),
-				() => {},
-			)
+			const { getChips, getFilterCount } = useFilterable(ref([]))
 
 			const filter = {
 				name: 'Test',
@@ -100,10 +85,7 @@ describe('Filterable', () => {
 		})
 
 		it('returns an empty array when the value is an empty string', () => {
-			const { getChips, getFilterCount } = useFilterable(
-				ref([]),
-				() => {},
-			)
+			const { getChips, getFilterCount } = useFilterable(ref([]))
 
 			const filter = {
 				name: 'Test',
@@ -118,10 +100,7 @@ describe('Filterable', () => {
 		})
 
 		it('returns the correct text when the value is a string', () => {
-			const { getChips, getFilterCount } = useFilterable(
-				ref([]),
-				() => {},
-			)
+			const { getChips, getFilterCount } = useFilterable(ref([]))
 
 			const filter = {
 				name: 'Test',
@@ -141,10 +120,7 @@ describe('Filterable', () => {
 		})
 
 		it('returns the correct text when the value is a number', () => {
-			const { getChips, getFilterCount } = useFilterable(
-				ref([]),
-				() => {},
-			)
+			const { getChips, getFilterCount } = useFilterable(ref([]))
 
 			const filter = {
 				name: 'Test',
@@ -164,10 +140,7 @@ describe('Filterable', () => {
 		})
 
 		it('returns the correct text when the value is a period field object', () => {
-			const { getChips, getFilterCount } = useFilterable(
-				ref([]),
-				() => {},
-			)
+			const { getChips, getFilterCount } = useFilterable(ref([]))
 
 			const filter = {
 				name: 'Test',
@@ -193,10 +166,7 @@ describe('Filterable', () => {
 		})
 
 		it('returns an empty array when the value is a period field object with null values', () => {
-			const { getChips, getFilterCount } = useFilterable(
-				ref([]),
-				() => {},
-			)
+			const { getChips, getFilterCount } = useFilterable(ref([]))
 
 			const filter = {
 				name: 'Test',
@@ -214,10 +184,7 @@ describe('Filterable', () => {
 		})
 
 		it('returns a chip when only from is set', () => {
-			const { getChips, getFilterCount } = useFilterable(
-				ref([]),
-				() => {},
-			)
+			const { getChips, getFilterCount } = useFilterable(ref([]))
 
 			const filter = {
 				name: 'Test',
@@ -235,10 +202,7 @@ describe('Filterable', () => {
 		})
 
 		it('returns a chip when only to is set', () => {
-			const { getChips, getFilterCount } = useFilterable(
-				ref([]),
-				() => {},
-			)
+			const { getChips, getFilterCount } = useFilterable(ref([]))
 
 			const filter = {
 				name: 'Test',
@@ -256,10 +220,7 @@ describe('Filterable', () => {
 		})
 
 		it('returns the correct text when the value is an object', () => {
-			const { getChips, getFilterCount } = useFilterable(
-				ref([]),
-				() => {},
-			)
+			const { getChips, getFilterCount } = useFilterable(ref([]))
 
 			const filter = {
 				name: 'Test',
@@ -290,10 +251,7 @@ describe('Filterable', () => {
 		})
 
 		it('returns the correct text when the value is an array', () => {
-			const { getChips, getFilterCount } = useFilterable(
-				ref([]),
-				() => {},
-			)
+			const { getChips, getFilterCount } = useFilterable(ref([]))
 
 			const filter = {
 				name: 'Test',
@@ -317,10 +275,7 @@ describe('Filterable', () => {
 		})
 
 		it('returns the correct text when the value is an array of objects', () => {
-			const { getChips, getFilterCount } = useFilterable(
-				ref([]),
-				() => {},
-			)
+			const { getChips, getFilterCount } = useFilterable(ref([]))
 
 			const filter = {
 				name: 'Test',
@@ -355,10 +310,7 @@ describe('Filterable', () => {
 		})
 
 		it('returns the correct text when the value is an array of objects with text properties', () => {
-			const { getChips, getFilterCount } = useFilterable(
-				ref([]),
-				() => {},
-			)
+			const { getChips, getFilterCount } = useFilterable(ref([]))
 
 			const filter = {
 				name: 'Test',
@@ -393,10 +345,7 @@ describe('Filterable', () => {
 		})
 
 		it('returns the correct text when the value is an array of objects with text and value properties', () => {
-			const { getChips, getFilterCount } = useFilterable(
-				ref([]),
-				() => {},
-			)
+			const { getChips, getFilterCount } = useFilterable(ref([]))
 
 			const filter = {
 				name: 'Test',
@@ -435,10 +384,7 @@ describe('Filterable', () => {
 		})
 
 		it('returns an empty array when the value is undefined', () => {
-			const { getChips, getFilterCount } = useFilterable(
-				ref([]),
-				() => {},
-			)
+			const { getChips, getFilterCount } = useFilterable(ref([]))
 
 			const filter = {} as FilterItem
 
@@ -452,10 +398,7 @@ describe('Filterable', () => {
 
 	describe('removeChip', () => {
 		it('removes the chip from the filter', () => {
-			const { removeChip } = useFilterable(
-				ref([]),
-				() => {},
-			)
+			const { removeChip } = useFilterable(ref([]))
 
 			const filter = {
 				name: 'Test',
@@ -473,10 +416,7 @@ describe('Filterable', () => {
 		})
 
 		it('removes the chip from the filter when the value is a number', () => {
-			const { removeChip } = useFilterable(
-				ref([]),
-				() => {},
-			)
+			const { removeChip } = useFilterable(ref([]))
 
 			const filter = {
 				name: 'Test',
@@ -494,10 +434,7 @@ describe('Filterable', () => {
 		})
 
 		it('removes the chip from the filter when the value is an object', () => {
-			const { removeChip } = useFilterable(
-				ref([]),
-				() => {},
-			)
+			const { removeChip } = useFilterable(ref([]))
 
 			const filter = {
 				name: 'Test',
@@ -524,10 +461,7 @@ describe('Filterable', () => {
 		})
 
 		it('removes the chip from the filter when the value is a period field object', () => {
-			const { removeChip } = useFilterable(
-				ref([]),
-				() => {},
-			)
+			const { removeChip } = useFilterable(ref([]))
 
 			const periodFilter = {
 				name: 'Test',
@@ -551,10 +485,7 @@ describe('Filterable', () => {
 		})
 
 		it('removes the chip from the filter when the value is a period field object with null values', () => {
-			const { removeChip } = useFilterable(
-				ref([]),
-				() => {},
-			)
+			const { removeChip } = useFilterable(ref([]))
 
 			const periodFilter = {
 				name: 'Test',
@@ -578,10 +509,7 @@ describe('Filterable', () => {
 		})
 
 		it('removes the chip from the filter when the value is an array', () => {
-			const { removeChip } = useFilterable(
-				ref([]),
-				() => {},
-			)
+			const { removeChip } = useFilterable(ref([]))
 
 			const arrayFilter = {
 				name: 'Test',
@@ -599,10 +527,7 @@ describe('Filterable', () => {
 		})
 
 		it('removes the chip from the filter when the value is an array of objects', () => {
-			const { removeChip } = useFilterable(
-				ref([]),
-				() => {},
-			)
+			const { removeChip } = useFilterable(ref([]))
 
 			const arrayFilter = {
 				name: 'Test',
@@ -633,10 +558,7 @@ describe('Filterable', () => {
 		})
 
 		it('removes the chip from the filter when the value is an empty array', () => {
-			const { removeChip } = useFilterable(
-				ref([]),
-				() => {},
-			)
+			const { removeChip } = useFilterable(ref([]))
 
 			const arrayFilter = {
 				name: 'Test',
@@ -654,10 +576,7 @@ describe('Filterable', () => {
 		})
 
 		it('removes the chip from the filter when the value is an array of strings', () => {
-			const { removeChip } = useFilterable(
-				ref([]),
-				() => {},
-			)
+			const { removeChip } = useFilterable(ref([]))
 
 			const arrayFilter = {
 				name: 'Test',
@@ -677,10 +596,7 @@ describe('Filterable', () => {
 
 	describe('resetFilter', () => {
 		it('resets the filter', () => {
-			const { resetFilter } = useFilterable(
-				ref([]),
-				() => {},
-			)
+			const { resetFilter } = useFilterable(ref([]))
 
 			const filter = {
 				name: 'Test',
@@ -694,42 +610,89 @@ describe('Filterable', () => {
 	})
 
 	describe('resetAllFilters', () => {
-		it('resets all filters', async () => {
-			const filters = ref<FilterProp>([])
-			const emitsFunction = vi.fn()
-			const { resetAllFilters } = useFilterable(
-				filters,
-				emitsFunction,
-			)
-
-			filters.value = [
-				{
-					name: 'Test',
-					value: 'test',
-				},
-				{
-					name: 'Test 2',
-					value: 'test 2',
-				},
-			]
-
-			await nextTick()
+		it('sets all filter values to undefined', async () => {
+			const model = ref<FilterProp>([
+				{ name: 'Test', value: 'test' },
+				{ name: 'Test 2', value: 'test 2' },
+			])
+			const { filters, resetAllFilters } = useFilterable(model)
 
 			resetAllFilters()
 
-			expect(emitsFunction).toHaveBeenCalledTimes(1)
-			const emittedCall = emitsFunction.mock.calls[0]
-			expect(emittedCall?.[0]).toBe('update:modelValue')
+			expect(filters.value.every(f => f.value === undefined)).toBe(true)
+		})
+	})
 
-			// Use JSON serialization for robust comparison in CI environments
-			const emittedArray = emittedCall?.[1]
-			const expectedArray = [
-				{ name: 'Test', value: undefined },
-				{ name: 'Test 2', value: undefined },
+	describe('model sync (full replacement)', () => {
+		it('initializes filters with a deep copy of the model on mount', () => {
+			const model = ref<FilterProp>([
+				{ name: 'folder', value: ['cardio'] },
+			])
+
+			const { filters } = useFilterable(model)
+
+			expect(filters.value).toEqual([{ name: 'folder', value: ['cardio'] }])
+			// Ensure it is a deep copy, not the same object reference
+			expect(filters.value[0]).not.toBe(model.value[0])
+		})
+
+		it('replaces local pending state when model updates another filter externally', async () => {
+			const model = ref<FilterProp>([
+				{ name: 'folder', value: undefined },
+				{ name: 'profession', value: undefined },
+			])
+
+			const { filters } = useFilterable(model)
+
+			// Simulate a local pending selection in FilterSideBar (not yet applied)
+			filters.value.find(f => f.name === 'profession')!.value = ['infirmier']
+
+			// FilterInline updates 'folder' in the shared model
+			model.value = [
+				{ name: 'folder', value: ['cardiologie'] },
+				{ name: 'profession', value: undefined },
 			]
+			await nextTick()
 
-			// Compare as JSON strings to avoid reference/prototype issues
-			expect(JSON.stringify(emittedArray)).toBe(JSON.stringify(expectedArray))
+			// Current behavior: full model deep-copy on external change resets local pending state
+			expect(filters.value.find(f => f.name === 'profession')?.value).toBeUndefined()
+			// 'folder' must reflect the external change
+			expect(filters.value.find(f => f.name === 'folder')?.value).toEqual(['cardiologie'])
+		})
+
+		it('replaces local state when the model externally changes the same filter', async () => {
+			const model = ref<FilterProp>([
+				{ name: 'folder', value: ['old-value'] },
+			])
+
+			const { filters } = useFilterable(model)
+
+			// User has a local pending selection (not yet applied)
+			filters.value.find(f => f.name === 'folder')!.value = ['local-pending']
+
+			// External update changes the same filter
+			model.value = [{ name: 'folder', value: ['new-external'] }]
+			await nextTick()
+
+			expect(filters.value.find(f => f.name === 'folder')?.value).toEqual(['new-external'])
+		})
+
+		it('replaces local pending state even when model content is identical', async () => {
+			const model = ref<FilterProp>([
+				{ name: 'folder', value: undefined },
+			])
+
+			const { filters } = useFilterable(model)
+
+			// User has local pending state
+			filters.value.find(f => f.name === 'folder')!.value = ['local']
+
+			// Re-assign the model with the same content (e.g. echo from own emit)
+			model.value = [{ name: 'folder', value: undefined }]
+			await nextTick()
+
+			// Current behavior: update is applied from model, local pending state is replaced
+			expect(filters.value.find(f => f.name === 'folder')?.value).toBeUndefined()
 		})
 	})
 })

--- a/src/composables/useFilterable/useFilterable.ts
+++ b/src/composables/useFilterable/useFilterable.ts
@@ -1,4 +1,4 @@
-import { ref, watch, type Ref } from 'vue'
+import { ref, toRaw, watch, type Ref } from 'vue'
 import type { ChipItem } from '@/components/ChipList/types'
 import slugify from 'slugify'
 import { deepCopy } from '@/utils/functions/deepCopy'
@@ -17,7 +17,7 @@ export default function useFilterable(model: Ref<FilterProp>) {
 	const filters = ref<FilterProp>([])
 
 	watch(model, (newFilters) => {
-		filters.value = deepCopy(newFilters)
+		filters.value = deepCopy(toRaw(newFilters))
 	}, { deep: true, immediate: true })
 
 	function getFilterCount(filter: FilterItem): number {

--- a/src/composables/useFilterable/useFilterable.ts
+++ b/src/composables/useFilterable/useFilterable.ts
@@ -13,7 +13,7 @@ export type FilterItem = {
 
 export type FilterProp = FilterItem[]
 
-export default function useFilterable(model: Ref<FilterProp>, emits) {
+export default function useFilterable(model: Ref<FilterProp>) {
 	const filters = ref<FilterProp>([])
 
 	watch(model, (newFilters) => {
@@ -172,7 +172,6 @@ export default function useFilterable(model: Ref<FilterProp>, emits) {
 				: undefined
 
 			filter.value = newValue
-			updateValue()
 
 			return
 		}
@@ -187,7 +186,6 @@ export default function useFilterable(model: Ref<FilterProp>, emits) {
 
 			if (isPeriodField) {
 				filter.value = undefined
-				updateValue()
 
 				return
 			}
@@ -197,7 +195,7 @@ export default function useFilterable(model: Ref<FilterProp>, emits) {
 			if (hasSelectStructure) {
 				// For single select objects, clear the entire value
 				filter.value = undefined
-				updateValue()
+
 				return
 			}
 
@@ -205,29 +203,20 @@ export default function useFilterable(model: Ref<FilterProp>, emits) {
 			delete typedValue[chipValue]
 			filter.value = typedValue
 		}
-		updateValue()
 	}
 
 	function resetFilter(filter: FilterItem): void {
 		filter.value = undefined
-		updateValue()
 	}
 
 	function resetAllFilters(): void {
-		filters.value.forEach((filter) => {
-			filter.value = undefined
+		filters.value.forEach((filter: FilterItem) => {
+			resetFilter(filter)
 		})
-
-		updateValue()
-	}
-
-	function updateValue(): void {
-		emits('update:modelValue', filters.value)
 	}
 
 	return {
 		filters,
-		updateValue,
 		removeChip,
 		resetFilter,
 		resetAllFilters,

--- a/src/utils/functions/deepCopy/index.ts
+++ b/src/utils/functions/deepCopy/index.ts
@@ -1,17 +1,20 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { toRaw } from 'vue'
+
 type UnknownValue = any
 
 /** Deep copy an object or an array without reference */
 export function deepCopy<T = any>(o: UnknownValue): T {
+	const value = toRaw(o)
 	let copy = o
 	let k
 
-	if (o && typeof o === 'object') {
-		copy = Object.prototype.toString.call(o) === '[object Array]' ? [] : {}
+	if (value && typeof value === 'object') {
+		copy = Object.prototype.toString.call(value) === '[object Array]' ? [] : {}
 
-		for (k in o) {
-			if (o[k] !== undefined) {
-				copy[k] = deepCopy(o[k])
+		for (k in value) {
+			if (value[k] !== undefined) {
+				copy[k] = deepCopy(value[k])
 			}
 		}
 	}

--- a/src/utils/functions/deepCopy/index.ts
+++ b/src/utils/functions/deepCopy/index.ts
@@ -1,19 +1,16 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { toRaw } from 'vue'
-
 type UnknownValue = any
 
 /** Deep copy an object or an array without reference */
 export function deepCopy<T = any>(o: UnknownValue): T {
-	const value = toRaw(o)
-	let copy = value
+	let copy = o
 
-	if (value && typeof value === 'object') {
-		copy = Array.isArray(value) ? [] : {}
+	if (o && typeof o === 'object') {
+		copy = Array.isArray(o) ? [] : {}
 
-		for (const k of Object.keys(value)) {
-			if (value[k] !== undefined) {
-				copy[k] = deepCopy(value[k])
+		for (const k of Object.keys(o)) {
+			if (o[k] !== undefined) {
+				copy[k] = deepCopy(o[k])
 			}
 		}
 	}

--- a/src/utils/functions/deepCopy/index.ts
+++ b/src/utils/functions/deepCopy/index.ts
@@ -6,13 +6,12 @@ type UnknownValue = any
 /** Deep copy an object or an array without reference */
 export function deepCopy<T = any>(o: UnknownValue): T {
 	const value = toRaw(o)
-	let copy = o
-	let k
+	let copy = value
 
 	if (value && typeof value === 'object') {
-		copy = Object.prototype.toString.call(value) === '[object Array]' ? [] : {}
+		copy = Array.isArray(value) ? [] : {}
 
-		for (k in value) {
+		for (const k of Object.keys(value)) {
 			if (value[k] !== undefined) {
 				copy[k] = deepCopy(value[k])
 			}


### PR DESCRIPTION
Fixe de plusieurs problèmes au niveau des filtres : 
- les boutons permettant de vider un filtres de toutes ses valeurs déclenchait automatiquement l’émission d'un événement update:modelValue dans le SySelect. cf issue #2235
- Le composant SearchListField avait tendance à muter directement le tableau passé en paramètre. utilisation d'une shallow copy
- Le composant SearchListField ne supportait pas les valeurs null et undefined en entré ce qui causait des problèmes avec les filtres
- Les stories comportant le composant SearchlistField ne possédait pas de labels, cela causais des warnings
- Le composant SyCheckbox possédait des Id générés qui causaient des duplications dans certains cas, et notamment des problèmes lors de l'usage de plusieurs filtres. Ajout d'ID générées.
- Autres optimisations et ajouts de tests.
