### PR TITLE
Fix/improve date pickers a11y

### DIFF
--- a/src/components/DatePicker/CalendarMode/DatePicker.vue
+++ b/src/components/DatePicker/CalendarMode/DatePicker.vue
@@ -856,6 +856,7 @@
 		openDatePicker,
 		updateSelectedDates,
 		handleSelectToday,
+		panelLiveText,
 	})
 </script>
 

--- a/src/components/DatePicker/CalendarMode/DatePicker.vue
+++ b/src/components/DatePicker/CalendarMode/DatePicker.vue
@@ -1,4 +1,4 @@
-<script lang="ts" setup>
+﻿<script lang="ts" setup>
 	import { ref, computed, watch, onMounted, onBeforeUnmount, nextTick, type ComponentPublicInstance, type Ref } from 'vue'
 	import SyTextField from '../../Customs/SyTextField/SyTextField.vue'
 	import DateTextInput from '../DateTextInput/DateTextInput.vue'
@@ -952,8 +952,7 @@
 			>
 				<template #activator="{ props: menuProps }">
 					<div
-						role="button"
-						v-bind="{ ...menuProps, 'aria-expanded': undefined, 'aria-haspopup': undefined, 'aria-owns': undefined, 'aria-controls': isDatePickerVisible ? datePickerContentId : undefined }"
+						v-bind="{ ...menuProps, 'aria-expanded': undefined, 'aria-haspopup': 'dialog', 'aria-owns': undefined, 'aria-controls': isDatePickerVisible ? datePickerContentId : undefined }"
 					>
 						<SyTextField
 							:id="`${datePickerContentId}-input`"
@@ -996,6 +995,7 @@
 						/>
 					</div>
 				</template>
+				<!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -- role="dialog" + tabindex="-1" est un pattern ARIA valide pour les modales -->
 				<div
 					tabindex="-1"
 					role="dialog"

--- a/src/components/DatePicker/CalendarMode/DatePicker.vue
+++ b/src/components/DatePicker/CalendarMode/DatePicker.vue
@@ -22,7 +22,7 @@
 
 	const { parseDate, formatDate } = useDateFormat()
 	const { initializeSelectedDates } = useDateInitialization()
-	const { updateAccessibility, fixAriaAttributes } = useDatePickerAccessibility()
+	const { updateAccessibility, updateControlsAriaExpanded, fixAriaAttributes } = useDatePickerAccessibility()
 
 	// Variables pour suivre le mois et l'année actuellement affichés dans le CalendarMode
 	const currentMonth = ref<string | null>(null)
@@ -677,6 +677,12 @@
 		() => selectedDates.value,
 	)
 
+	watch(currentViewMode, (newMode) => {
+		if (isDatePickerVisible.value) {
+			updateControlsAriaExpanded(newMode)
+		}
+	})
+
 	const handleInputBlur = async () => {
 		emit('blur')
 		onblur.value = true
@@ -946,6 +952,7 @@
 			>
 				<template #activator="{ props: menuProps }">
 					<div
+						role="button"
 						v-bind="{ ...menuProps, 'aria-expanded': undefined, 'aria-haspopup': undefined, 'aria-owns': undefined, 'aria-controls': isDatePickerVisible ? datePickerContentId : undefined }"
 					>
 						<SyTextField
@@ -991,7 +998,9 @@
 				</template>
 				<div
 					tabindex="-1"
-					role="presentation"
+					role="dialog"
+					aria-modal="true"
+					aria-label="Sélectionner une date"
 					@keydown.capture="handleMenuKeydown"
 				>
 					<div

--- a/src/components/DatePicker/CalendarMode/DatePicker.vue
+++ b/src/components/DatePicker/CalendarMode/DatePicker.vue
@@ -158,59 +158,6 @@
 		restoreFocus: () => queueMicrotask(() => dateCalendarTextInputRef.value?.$el?.querySelector?.('input')?.focus({ preventScroll: true })),
 	})
 
-	// Utiliser le calendarKeyboardNavigation normalement
-	useCalendarKeyboardNavigation({
-		isDatePickerVisible,
-		datePickerRef,
-		getCurrentDate: () => {
-			const value = selectedDates.value
-			if (value) {
-				const date = Array.isArray(value) ? value[0] ?? null : value
-				// Vérifier si la date sélectionnée est dans le mois actuellement affiché
-				if (date && currentMonth.value !== null && currentYear.value !== null) {
-					const sameMonth = date.getMonth() === Number(currentMonth.value)
-					const sameYear = date.getFullYear() === Number(currentYear.value)
-					if (sameMonth && sameYear) {
-						return date
-					}
-				}
-			}
-
-			// Fallback: retourner le 1er du mois actuellement affiché
-			if (currentMonth.value !== null && currentYear.value !== null) {
-				return new Date(Number(currentYear.value), Number(currentMonth.value), 1)
-			}
-
-			return null
-		},
-		setCurrentDate: (date: Date) => {
-			preventCloseOnKeyboardNavigation.value = true
-			updateSelectedDates([date])
-			syncDisplayedMonthYearFromDate(date)
-
-			// S'assurer que le VDatePicker affiche le bon mois après navigation clavier
-			nextTick(() => {
-				// Forcer la mise à jour du mois affiché dans le VDatePicker
-				if (datePickerRef.value) {
-					// Le VDatePicker devrait automatiquement suivre la date sélectionnée
-					// mais on s'assure que le mois/année est bien synchronisé
-					const month = date.getMonth().toString()
-					const year = date.getFullYear().toString()
-					if (currentMonth.value !== month || currentYear.value !== year) {
-						currentMonth.value = month
-						currentYear.value = year
-						currentMonthName.value = dayjs(date).format('MMMM')
-						currentYearName.value = year
-					}
-				}
-			})
-
-			queueMicrotask(() => {
-				preventCloseOnKeyboardNavigation.value = false
-			})
-		},
-	})
-
 	// Fonction pour sélectionner la date du jour
 	const handleSelectToday = () => {
 		// Créer une seule instance de la date du jour
@@ -685,6 +632,60 @@
 			else panelLiveText.value = ''
 			updateControlsAriaExpanded(newMode)
 		}
+	})
+
+	// Utiliser le calendarKeyboardNavigation normalement
+	useCalendarKeyboardNavigation({
+		isDatePickerVisible,
+		datePickerRef,
+		currentViewMode,
+		getCurrentDate: () => {
+			const value = selectedDates.value
+			if (value) {
+				const date = Array.isArray(value) ? value[0] ?? null : value
+				// Vérifier si la date sélectionnée est dans le mois actuellement affiché
+				if (date && currentMonth.value !== null && currentYear.value !== null) {
+					const sameMonth = date.getMonth() === Number(currentMonth.value)
+					const sameYear = date.getFullYear() === Number(currentYear.value)
+					if (sameMonth && sameYear) {
+						return date
+					}
+				}
+			}
+
+			// Fallback: retourner le 1er du mois actuellement affiché
+			if (currentMonth.value !== null && currentYear.value !== null) {
+				return new Date(Number(currentYear.value), Number(currentMonth.value), 1)
+			}
+
+			return null
+		},
+		setCurrentDate: (date: Date) => {
+			preventCloseOnKeyboardNavigation.value = true
+			updateSelectedDates([date])
+			syncDisplayedMonthYearFromDate(date)
+
+			// S'assurer que le VDatePicker affiche le bon mois après navigation clavier
+			nextTick(() => {
+				// Forcer la mise à jour du mois affiché dans le VDatePicker
+				if (datePickerRef.value) {
+					// Le VDatePicker devrait automatiquement suivre la date sélectionnée
+					// mais on s'assure que le mois/année est bien synchronisé
+					const month = date.getMonth().toString()
+					const year = date.getFullYear().toString()
+					if (currentMonth.value !== month || currentYear.value !== year) {
+						currentMonth.value = month
+						currentYear.value = year
+						currentMonthName.value = dayjs(date).format('MMMM')
+						currentYearName.value = year
+					}
+				}
+			})
+
+			queueMicrotask(() => {
+				preventCloseOnKeyboardNavigation.value = false
+			})
+		},
 	})
 
 	const handleInputBlur = async () => {

--- a/src/components/DatePicker/CalendarMode/DatePicker.vue
+++ b/src/components/DatePicker/CalendarMode/DatePicker.vue
@@ -29,6 +29,7 @@
 	const currentYear = ref<string | null>(null)
 	const currentMonthName = ref<string | null>(null)
 	const currentYearName = ref<string | null>(null)
+	const panelLiveText = ref('')
 	const monthYearLiveText = computed(() => {
 		if (currentMonthName.value && currentYearName.value) return `${currentMonthName.value} ${currentYearName.value}`
 		if (currentMonthName.value) return currentMonthName.value
@@ -679,6 +680,9 @@
 
 	watch(currentViewMode, (newMode) => {
 		if (isDatePickerVisible.value) {
+			if (newMode === 'months') panelLiveText.value = 'Sélection du mois, utilisez les touches fléchées pour naviguer'
+			else if (newMode === 'year') panelLiveText.value = 'Sélection de l\'année, utilisez les touches fléchées pour naviguer'
+			else panelLiveText.value = ''
 			updateControlsAriaExpanded(newMode)
 		}
 	})
@@ -692,6 +696,12 @@
 	}
 
 	watch(isDatePickerVisible, async (isVisible) => {
+		// Mettre à jour aria-expanded sur l'input natif (le wrapper div ne peut pas le porter sans nested-interactive)
+		const inputEl = dateCalendarTextInputRef.value?.$el?.querySelector?.('input')
+		if (inputEl) {
+			inputEl.setAttribute('aria-expanded', String(isVisible))
+		}
+
 		if (isVisible) {
 			// Réinitialiser le view mode à l'ouverture pour éviter les problèmes de navigation
 			resetViewMode()
@@ -1008,7 +1018,7 @@
 						aria-live="polite"
 						aria-atomic="true"
 					>
-						{{ monthYearLiveText }}
+						{{ panelLiveText || monthYearLiveText }}
 					</div>
 					<VDatePicker
 						v-if="isDatePickerVisible && !props.noCalendar"

--- a/src/components/DatePicker/CalendarMode/tests/DatePicker.a11y.spec.ts
+++ b/src/components/DatePicker/CalendarMode/tests/DatePicker.a11y.spec.ts
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
 
-import { describe, it } from 'vitest'
+import { describe, it, expect, afterEach } from 'vitest'
 import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
 import { axe } from 'vitest-axe'
 import { assertNoA11yViolations } from '@tests/unit/accessibility/axeUtils'
 import DatePicker from '../DatePicker.vue'
@@ -137,5 +138,62 @@ describe('DatePicker (CalendarMode) – accessibility (axe)', () => {
 		assertNoA11yViolations(results, 'DatePicker – with hint text', {
 			ignoreRules: ['region'],
 		})
+	})
+})
+
+describe('DatePicker (CalendarMode) – ARIA attributes', () => {
+	let wrapper: ReturnType<typeof mount> | null = null
+
+	afterEach(() => {
+		wrapper?.unmount()
+		wrapper = null
+	})
+
+	const mountDP = (props: Record<string, unknown> = {}) =>
+		mount(DatePicker, { props: { label: 'Date de naissance', format: 'DD/MM/YYYY', ...props } })
+
+	it('has aria-haspopup="dialog" on the activator wrapper', () => {
+		wrapper = mountDP()
+		const activator = wrapper.find('[aria-haspopup="dialog"]')
+		expect(activator.exists()).toBe(true)
+	})
+
+	it('has aria-controls pointing to the date picker content id on the activator wrapper when visible', async () => {
+		wrapper = mountDP()
+		const vm = wrapper.vm as InstanceType<typeof DatePicker>
+		vm.isDatePickerVisible = true
+		await nextTick()
+		const activator = wrapper.find('[aria-haspopup="dialog"]')
+		expect(activator.attributes('aria-controls')).toBeTruthy()
+	})
+
+	it('has no aria-controls on the activator wrapper when closed', () => {
+		wrapper = mountDP()
+		const activator = wrapper.find('[aria-haspopup="dialog"]')
+		expect(activator.attributes('aria-controls')).toBeUndefined()
+	})
+
+	it('panelLiveText is empty initially', () => {
+		wrapper = mountDP()
+		const vm = wrapper.vm as InstanceType<typeof DatePicker>
+		expect(vm.panelLiveText).toBe('')
+	})
+
+	it('panelLiveText is a reactive ref exposed by the component', async () => {
+		wrapper = mountDP()
+		const vm = wrapper.vm as InstanceType<typeof DatePicker>
+		vm.panelLiveText = 'Sélection du mois, utilisez les touches fléchées pour naviguer'
+		await nextTick()
+		expect(vm.panelLiveText).toContain('Sélection du mois')
+	})
+
+	it('panelLiveText can be cleared', async () => {
+		wrapper = mountDP()
+		const vm = wrapper.vm as InstanceType<typeof DatePicker>
+		vm.panelLiveText = 'Sélection du mois, utilisez les touches fléchées pour naviguer'
+		await nextTick()
+		vm.panelLiveText = ''
+		await nextTick()
+		expect(vm.panelLiveText).toBe('')
 	})
 })

--- a/src/components/DatePicker/ComplexDatePicker/ComplexDatePicker.vue
+++ b/src/components/DatePicker/ComplexDatePicker/ComplexDatePicker.vue
@@ -52,7 +52,7 @@
 
 	const { parseDate, formatDate } = useDateFormat()
 	const { initializeSelectedDates } = useDateInitialization()
-	const { updateAccessibility } = useDatePickerAccessibility()
+	const { updateAccessibility, updateControlsAriaExpanded } = useDatePickerAccessibility()
 
 	/**
 	 * Utils
@@ -786,6 +786,12 @@
 			() => selectedDates.value,
 		)
 
+	watch(currentViewMode, (newMode) => {
+		if (isDatePickerVisible.value) {
+			updateControlsAriaExpanded(newMode)
+		}
+	})
+
 	/**
 	 * Manual input validation on blur
 	 */
@@ -1128,7 +1134,9 @@
 
 				<div
 					tabindex="-1"
-					role="presentation"
+					role="dialog"
+					aria-modal="true"
+					aria-label="Sélectionner une date"
 					@keydown.capture="handleMenuKeydown"
 				>
 					<VDatePicker
@@ -1173,6 +1181,8 @@
 						<template #header>
 							<SyHeading
 								class="mx-auto my-auto ml-5 mb-4"
+								aria-live="polite"
+								aria-atomic="true"
 								:level="headingLevel"
 							>
 								{{ selectedDates ? displayedDateString : headerDate }}

--- a/src/components/DatePicker/ComplexDatePicker/ComplexDatePicker.vue
+++ b/src/components/DatePicker/ComplexDatePicker/ComplexDatePicker.vue
@@ -1020,6 +1020,7 @@
 		handleDateSelected,
 		resetViewMode,
 		reset,
+		panelLiveText,
 	})
 </script>
 
@@ -1150,6 +1151,7 @@
 						aria-atomic="true"
 					>
 						{{ panelLiveText }}
+						</div>
 						<VDatePicker
 							:id="datePickerContentId"
 							ref="datePickerRef"
@@ -1222,7 +1224,6 @@
 								</div>
 							</template>
 						</VDatePicker>
-					</div>
 				</div>
 			</VMenu>
 		</template>

--- a/src/components/DatePicker/ComplexDatePicker/ComplexDatePicker.vue
+++ b/src/components/DatePicker/ComplexDatePicker/ComplexDatePicker.vue
@@ -1151,79 +1151,79 @@
 						aria-atomic="true"
 					>
 						{{ panelLiveText }}
-						</div>
-						<VDatePicker
-							:id="datePickerContentId"
-							ref="datePickerRef"
-							v-model="selectedDates"
-							control-variant="modal"
-							color="primary"
-							:class="props.displayWeekendDays ? 'weekend' : ''"
-							:first-day-of-week="1"
-							:multiple="props.displayRange ? 'range' : false"
-							:show-adjacent-months="true"
-							:show-week="props.showWeekNumber"
-							:view-mode="currentViewMode"
-							:month="currentMonth !== null ? Number(currentMonth) : undefined"
-							:year="currentYear !== null ? Number(currentYear) : undefined"
-							:max="maxDate"
-							:min="minDate"
-							:custom-rules="props.customRules"
-							:custom-warning-rules="props.customWarningRules"
-							:display-holiday-days="props.displayHolidayDays"
-							:display-asterisk="props.displayAsterisk"
-							:is-validate-on-blur="props.isValidateOnBlur"
-							:error-messages="errorMessages"
-							:density="props.density"
-							:hint="props.hint"
-							:persistent-hint="props.persistentHint"
-							@update:model-value="updateDisplayFormattedDate"
-							@update:view-mode="handleViewModeUpdate"
-							@update:month="onUpdateMonth"
-							@update:year="onUpdateYear"
-							@click:date="updateSelectedDates"
-							@focus="props.displayHolidayDays ? markHolidayDays : undefined"
-							@update:month-year="props.displayHolidayDays ? markHolidayDays : undefined"
-						>
-							<template #title>
-								<span class="date-picker-title">
-									Sélectionnez une date
-								</span>
-							</template>
-							<template #header>
-								<SyHeading
-									class="mx-auto my-auto ml-5 mb-4"
-									aria-live="polite"
-									aria-atomic="true"
-									:level="headingLevel"
-								>
-									{{ selectedDates ? displayedDateString : headerDate }}
-								</SyHeading>
-							</template>
-							<template
-								v-if="props.displayTodayButton"
-								#actions
+					</div>
+					<VDatePicker
+						:id="datePickerContentId"
+						ref="datePickerRef"
+						v-model="selectedDates"
+						control-variant="modal"
+						color="primary"
+						:class="props.displayWeekendDays ? 'weekend' : ''"
+						:first-day-of-week="1"
+						:multiple="props.displayRange ? 'range' : false"
+						:show-adjacent-months="true"
+						:show-week="props.showWeekNumber"
+						:view-mode="currentViewMode"
+						:month="currentMonth !== null ? Number(currentMonth) : undefined"
+						:year="currentYear !== null ? Number(currentYear) : undefined"
+						:max="maxDate"
+						:min="minDate"
+						:custom-rules="props.customRules"
+						:custom-warning-rules="props.customWarningRules"
+						:display-holiday-days="props.displayHolidayDays"
+						:display-asterisk="props.displayAsterisk"
+						:is-validate-on-blur="props.isValidateOnBlur"
+						:error-messages="errorMessages"
+						:density="props.density"
+						:hint="props.hint"
+						:persistent-hint="props.persistentHint"
+						@update:model-value="updateDisplayFormattedDate"
+						@update:view-mode="handleViewModeUpdate"
+						@update:month="onUpdateMonth"
+						@update:year="onUpdateYear"
+						@click:date="updateSelectedDates"
+						@focus="props.displayHolidayDays ? markHolidayDays : undefined"
+						@update:month-year="props.displayHolidayDays ? markHolidayDays : undefined"
+					>
+						<template #title>
+							<span class="date-picker-title">
+								Sélectionnez une date
+							</span>
+						</template>
+						<template #header>
+							<SyHeading
+								class="mx-auto my-auto ml-5 mb-4"
+								aria-live="polite"
+								aria-atomic="true"
+								:level="headingLevel"
 							>
-								<div class="d-flex justify-center align-center w-100">
-									<v-btn
-										v-if="props.displayTodayButton"
-										size="x-small"
-										color="primary"
-										:title="DATE_PICKER_MESSAGES.BUTTON_TODAY"
-										class="date-picker__today-button my-2 pa-2 mt-2"
-										:ripple="false"
-										@click="handleSelectToday"
-									>
-										<SyIcon
-											size="16px"
-											decorative
-											:icon="mdiCalendarMonthOutline"
-										/>
-										{{ DATE_PICKER_MESSAGES.BUTTON_TODAY }}
-									</v-btn>
-								</div>
-							</template>
-						</VDatePicker>
+								{{ selectedDates ? displayedDateString : headerDate }}
+							</SyHeading>
+						</template>
+						<template
+							v-if="props.displayTodayButton"
+							#actions
+						>
+							<div class="d-flex justify-center align-center w-100">
+								<v-btn
+									v-if="props.displayTodayButton"
+									size="x-small"
+									color="primary"
+									:title="DATE_PICKER_MESSAGES.BUTTON_TODAY"
+									class="date-picker__today-button my-2 pa-2 mt-2"
+									:ripple="false"
+									@click="handleSelectToday"
+								>
+									<SyIcon
+										size="16px"
+										decorative
+										:icon="mdiCalendarMonthOutline"
+									/>
+									{{ DATE_PICKER_MESSAGES.BUTTON_TODAY }}
+								</v-btn>
+							</div>
+						</template>
+					</VDatePicker>
 				</div>
 			</VMenu>
 		</template>

--- a/src/components/DatePicker/ComplexDatePicker/ComplexDatePicker.vue
+++ b/src/components/DatePicker/ComplexDatePicker/ComplexDatePicker.vue
@@ -623,52 +623,6 @@
 		document.removeEventListener('click', handleClickOutside)
 	})
 
-	useCalendarKeyboardNavigation({
-		isDatePickerVisible,
-		datePickerRef: datePickerRef as unknown as Ref<ComponentPublicInstance | null>,
-		getCurrentDate: () => {
-			const value = selectedDates.value
-			if (value) {
-				const date = Array.isArray(value) ? value[0] ?? null : value
-				if (date && currentMonth.value !== null && currentYear.value !== null) {
-					const sameMonth = date.getMonth() === Number(currentMonth.value)
-					const sameYear = date.getFullYear() === Number(currentYear.value)
-					if (sameMonth && sameYear) {
-						return date
-					}
-				}
-			}
-
-			if (currentMonth.value !== null && currentYear.value !== null) {
-				return new Date(Number(currentYear.value), Number(currentMonth.value), 1)
-			}
-
-			return null
-		},
-		setCurrentDate: (date: Date) => {
-			preventCloseOnInternalUpdate.value = true
-			updateSelectedDates(date)
-
-			// S'assurer que le VDatePicker affiche le bon mois après navigation clavier
-			nextTick(() => {
-				if (datePickerRef.value) {
-					const newMonth = String(date.getMonth())
-					const newYear = String(date.getFullYear())
-					if (currentMonth.value !== newMonth || currentYear.value !== newYear) {
-						currentMonth.value = newMonth
-						currentYear.value = newYear
-						currentMonthName.value = dayjs(date).format('MMMM')
-						currentYearName.value = newYear
-					}
-				}
-			})
-
-			queueMicrotask(() => {
-				preventCloseOnInternalUpdate.value = false
-			})
-		},
-	})
-
 	/**
 	 * Input handling (text field)
 	 */
@@ -794,6 +748,53 @@
 			else panelLiveText.value = ''
 			updateControlsAriaExpanded(newMode)
 		}
+	})
+
+	useCalendarKeyboardNavigation({
+		isDatePickerVisible,
+		datePickerRef: datePickerRef as unknown as Ref<ComponentPublicInstance | null>,
+		currentViewMode,
+		getCurrentDate: () => {
+			const value = selectedDates.value
+			if (value) {
+				const date = Array.isArray(value) ? value[0] ?? null : value
+				if (date && currentMonth.value !== null && currentYear.value !== null) {
+					const sameMonth = date.getMonth() === Number(currentMonth.value)
+					const sameYear = date.getFullYear() === Number(currentYear.value)
+					if (sameMonth && sameYear) {
+						return date
+					}
+				}
+			}
+
+			if (currentMonth.value !== null && currentYear.value !== null) {
+				return new Date(Number(currentYear.value), Number(currentMonth.value), 1)
+			}
+
+			return null
+		},
+		setCurrentDate: (date: Date) => {
+			preventCloseOnInternalUpdate.value = true
+			updateSelectedDates(date)
+
+			// S'assurer que le VDatePicker affiche le bon mois après navigation clavier
+			nextTick(() => {
+				if (datePickerRef.value) {
+					const newMonth = String(date.getMonth())
+					const newYear = String(date.getFullYear())
+					if (currentMonth.value !== newMonth || currentYear.value !== newYear) {
+						currentMonth.value = newMonth
+						currentYear.value = newYear
+						currentMonthName.value = dayjs(date).format('MMMM')
+						currentYearName.value = newYear
+					}
+				}
+			})
+
+			queueMicrotask(() => {
+				preventCloseOnInternalUpdate.value = false
+			})
+		},
 	})
 
 	/**

--- a/src/components/DatePicker/ComplexDatePicker/ComplexDatePicker.vue
+++ b/src/components/DatePicker/ComplexDatePicker/ComplexDatePicker.vue
@@ -579,6 +579,7 @@
 	const menuActivatorRef = ref<HTMLElement | undefined>(undefined)
 	const datePickerRef = ref<null | ComponentPublicInstance<typeof VDatePicker>>()
 	const datePickerContentId = `date-picker-${Math.random().toString(36).slice(2)}`
+	const panelLiveText = ref('')
 
 	// Aria props for activator: only declare aria-controls when panel exists
 	const menuActivatorProps = computed(() => ({
@@ -788,6 +789,9 @@
 
 	watch(currentViewMode, (newMode) => {
 		if (isDatePickerVisible.value) {
+			if (newMode === 'months') panelLiveText.value = 'Sélection du mois, utilisez les touches fléchées pour naviguer'
+			else if (newMode === 'year') panelLiveText.value = 'Sélection de l\'année, utilisez les touches fléchées pour naviguer'
+			else panelLiveText.value = ''
 			updateControlsAriaExpanded(newMode)
 		}
 	})
@@ -1140,8 +1144,13 @@
 					aria-label="Sélectionner une date"
 					@keydown.capture="handleMenuKeydown"
 				>
+					<div
+						class="sr-only"
+						aria-live="polite"
+						aria-atomic="true"
+					>
+						{{ panelLiveText }}
 					<VDatePicker
-						v-if="isDatePickerVisible"
 						:id="datePickerContentId"
 						ref="datePickerRef"
 						v-model="selectedDates"

--- a/src/components/DatePicker/ComplexDatePicker/ComplexDatePicker.vue
+++ b/src/components/DatePicker/ComplexDatePicker/ComplexDatePicker.vue
@@ -1,4 +1,4 @@
-	<script lang="ts" setup>
+﻿	<script lang="ts" setup>
 	import {
 		type ComponentPublicInstance,
 		computed,
@@ -1132,6 +1132,7 @@
 					</div>
 				</template>
 
+				<!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -- role="dialog" + tabindex="-1" est un pattern ARIA valide pour les modales -->
 				<div
 					tabindex="-1"
 					role="dialog"

--- a/src/components/DatePicker/ComplexDatePicker/ComplexDatePicker.vue
+++ b/src/components/DatePicker/ComplexDatePicker/ComplexDatePicker.vue
@@ -1150,78 +1150,79 @@
 						aria-atomic="true"
 					>
 						{{ panelLiveText }}
-					<VDatePicker
-						:id="datePickerContentId"
-						ref="datePickerRef"
-						v-model="selectedDates"
-						control-variant="modal"
-						color="primary"
-						:class="props.displayWeekendDays ? 'weekend' : ''"
-						:first-day-of-week="1"
-						:multiple="props.displayRange ? 'range' : false"
-						:show-adjacent-months="true"
-						:show-week="props.showWeekNumber"
-						:view-mode="currentViewMode"
-						:month="currentMonth !== null ? Number(currentMonth) : undefined"
-						:year="currentYear !== null ? Number(currentYear) : undefined"
-						:max="maxDate"
-						:min="minDate"
-						:custom-rules="props.customRules"
-						:custom-warning-rules="props.customWarningRules"
-						:display-holiday-days="props.displayHolidayDays"
-						:display-asterisk="props.displayAsterisk"
-						:is-validate-on-blur="props.isValidateOnBlur"
-						:error-messages="errorMessages"
-						:density="props.density"
-						:hint="props.hint"
-						:persistent-hint="props.persistentHint"
-						@update:model-value="updateDisplayFormattedDate"
-						@update:view-mode="handleViewModeUpdate"
-						@update:month="onUpdateMonth"
-						@update:year="onUpdateYear"
-						@click:date="updateSelectedDates"
-						@focus="props.displayHolidayDays ? markHolidayDays : undefined"
-						@update:month-year="props.displayHolidayDays ? markHolidayDays : undefined"
-					>
-						<template #title>
-							<span class="date-picker-title">
-								Sélectionnez une date
-							</span>
-						</template>
-						<template #header>
-							<SyHeading
-								class="mx-auto my-auto ml-5 mb-4"
-								aria-live="polite"
-								aria-atomic="true"
-								:level="headingLevel"
-							>
-								{{ selectedDates ? displayedDateString : headerDate }}
-							</SyHeading>
-						</template>
-						<template
-							v-if="props.displayTodayButton"
-							#actions
+						<VDatePicker
+							:id="datePickerContentId"
+							ref="datePickerRef"
+							v-model="selectedDates"
+							control-variant="modal"
+							color="primary"
+							:class="props.displayWeekendDays ? 'weekend' : ''"
+							:first-day-of-week="1"
+							:multiple="props.displayRange ? 'range' : false"
+							:show-adjacent-months="true"
+							:show-week="props.showWeekNumber"
+							:view-mode="currentViewMode"
+							:month="currentMonth !== null ? Number(currentMonth) : undefined"
+							:year="currentYear !== null ? Number(currentYear) : undefined"
+							:max="maxDate"
+							:min="minDate"
+							:custom-rules="props.customRules"
+							:custom-warning-rules="props.customWarningRules"
+							:display-holiday-days="props.displayHolidayDays"
+							:display-asterisk="props.displayAsterisk"
+							:is-validate-on-blur="props.isValidateOnBlur"
+							:error-messages="errorMessages"
+							:density="props.density"
+							:hint="props.hint"
+							:persistent-hint="props.persistentHint"
+							@update:model-value="updateDisplayFormattedDate"
+							@update:view-mode="handleViewModeUpdate"
+							@update:month="onUpdateMonth"
+							@update:year="onUpdateYear"
+							@click:date="updateSelectedDates"
+							@focus="props.displayHolidayDays ? markHolidayDays : undefined"
+							@update:month-year="props.displayHolidayDays ? markHolidayDays : undefined"
 						>
-							<div class="d-flex justify-center align-center w-100">
-								<v-btn
-									v-if="props.displayTodayButton"
-									size="x-small"
-									color="primary"
-									:title="DATE_PICKER_MESSAGES.BUTTON_TODAY"
-									class="date-picker__today-button my-2 pa-2 mt-2"
-									:ripple="false"
-									@click="handleSelectToday"
+							<template #title>
+								<span class="date-picker-title">
+									Sélectionnez une date
+								</span>
+							</template>
+							<template #header>
+								<SyHeading
+									class="mx-auto my-auto ml-5 mb-4"
+									aria-live="polite"
+									aria-atomic="true"
+									:level="headingLevel"
 								>
-									<SyIcon
-										size="16px"
-										decorative
-										:icon="mdiCalendarMonthOutline"
-									/>
-									{{ DATE_PICKER_MESSAGES.BUTTON_TODAY }}
-								</v-btn>
-							</div>
-						</template>
-					</VDatePicker>
+									{{ selectedDates ? displayedDateString : headerDate }}
+								</SyHeading>
+							</template>
+							<template
+								v-if="props.displayTodayButton"
+								#actions
+							>
+								<div class="d-flex justify-center align-center w-100">
+									<v-btn
+										v-if="props.displayTodayButton"
+										size="x-small"
+										color="primary"
+										:title="DATE_PICKER_MESSAGES.BUTTON_TODAY"
+										class="date-picker__today-button my-2 pa-2 mt-2"
+										:ripple="false"
+										@click="handleSelectToday"
+									>
+										<SyIcon
+											size="16px"
+											decorative
+											:icon="mdiCalendarMonthOutline"
+										/>
+										{{ DATE_PICKER_MESSAGES.BUTTON_TODAY }}
+									</v-btn>
+								</div>
+							</template>
+						</VDatePicker>
+					</div>
 				</div>
 			</VMenu>
 		</template>

--- a/src/components/DatePicker/ComplexDatePicker/tests/ComplexDatePicker.a11y.spec.ts
+++ b/src/components/DatePicker/ComplexDatePicker/tests/ComplexDatePicker.a11y.spec.ts
@@ -1,12 +1,13 @@
 // @vitest-environment jsdom
 
-import { describe, it } from 'vitest'
+import { describe, it, expect, afterEach } from 'vitest'
 import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
 import { axe } from 'vitest-axe'
 import { assertNoA11yViolations } from '@tests/unit/accessibility/axeUtils'
 import ComplexDatePicker from '../ComplexDatePicker.vue'
 
-// Scénario d’accessibilité : sélecteur de date combiné (champ + calendrier),
+// Scénario d'accessibilité : sélecteur de date combiné (champ + calendrier),
 // en mode simple, avec label et format jour/mois/année.
 
 describe('ComplexDatePicker – accessibility (axe)', () => {
@@ -30,5 +31,69 @@ describe('ComplexDatePicker – accessibility (axe)', () => {
 		assertNoA11yViolations(results, 'ComplexDatePicker – default calendar mode', {
 			ignoreRules: ignoredRules,
 		})
+	})
+})
+
+describe('ComplexDatePicker – ARIA attributes', () => {
+	let wrapper: ReturnType<typeof mount> | null = null
+
+	afterEach(() => {
+		wrapper?.unmount()
+		wrapper = null
+	})
+
+	const mountCP = (props: Record<string, unknown> = {}) =>
+		mount(ComplexDatePicker, { props: { label: 'Date', format: 'DD/MM/YYYY', ...props } })
+
+	it('has role="combobox" on the activator', () => {
+		wrapper = mountCP()
+		const combobox = wrapper.find('[role="combobox"]')
+		expect(combobox.exists()).toBe(true)
+	})
+
+	it('has aria-expanded="false" on the combobox initially', () => {
+		wrapper = mountCP()
+		const combobox = wrapper.find('[role="combobox"]')
+		expect(combobox.attributes('aria-expanded')).toBe('false')
+	})
+
+	it('has aria-haspopup="dialog" on the combobox', () => {
+		wrapper = mountCP()
+		const combobox = wrapper.find('[role="combobox"]')
+		expect(combobox.attributes('aria-haspopup')).toBe('dialog')
+	})
+
+	it('has aria-expanded="true" and aria-controls when calendar is open', async () => {
+		wrapper = mountCP()
+		const vm = wrapper.vm as InstanceType<typeof ComplexDatePicker>
+		vm.isDatePickerVisible = true
+		await nextTick()
+		const combobox = wrapper.find('[role="combobox"]')
+		expect(combobox.attributes('aria-expanded')).toBe('true')
+		expect(combobox.attributes('aria-controls')).toBeTruthy()
+	})
+
+	it('panelLiveText is empty initially', () => {
+		wrapper = mountCP()
+		const vm = wrapper.vm as InstanceType<typeof ComplexDatePicker>
+		expect(vm.panelLiveText).toBe('')
+	})
+
+	it('panelLiveText is a reactive ref exposed by the component', async () => {
+		wrapper = mountCP()
+		const vm = wrapper.vm as InstanceType<typeof ComplexDatePicker>
+		vm.panelLiveText = 'Sélection du mois, utilisez les touches fléchées pour naviguer'
+		await nextTick()
+		expect(vm.panelLiveText).toContain('Sélection du mois')
+	})
+
+	it('panelLiveText can be cleared', async () => {
+		wrapper = mountCP()
+		const vm = wrapper.vm as InstanceType<typeof ComplexDatePicker>
+		vm.panelLiveText = 'Sélection du mois, utilisez les touches fléchées pour naviguer'
+		await nextTick()
+		vm.panelLiveText = ''
+		await nextTick()
+		expect(vm.panelLiveText).toBe('')
 	})
 })

--- a/src/components/DatePicker/composables/useCalendarKeyboardNavigation.ts
+++ b/src/components/DatePicker/composables/useCalendarKeyboardNavigation.ts
@@ -17,6 +17,9 @@ export interface CalendarKeyboardNavigationOptions {
 
 	// Applique la nouvelle date (typiquement via updateSelectedDates)
 	setCurrentDate: (date: Date) => void
+
+	// Mode d'affichage du VDatePicker (month, months, year)
+	currentViewMode?: Ref<'month' | 'months' | 'year' | undefined>
 }
 
 export const useCalendarKeyboardNavigation = (options: CalendarKeyboardNavigationOptions) => {
@@ -25,6 +28,7 @@ export const useCalendarKeyboardNavigation = (options: CalendarKeyboardNavigatio
 		datePickerRef,
 		getCurrentDate,
 		setCurrentDate,
+		currentViewMode,
 	} = options
 
 	const addDays = (date: Date, amount: number) => dayjs(date).add(amount, 'day').toDate()
@@ -544,6 +548,26 @@ export const useCalendarKeyboardNavigation = (options: CalendarKeyboardNavigatio
 		isListenerAttached = false
 	}
 
+	const focusPanelActiveButton = (panelSelector: string, fallbackSelector: string) => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const rootEl = (datePickerRef.value as any)?.$el as HTMLElement | undefined
+		if (!rootEl) return
+
+		const panel = rootEl.querySelector<HTMLElement>(panelSelector)
+		if (!panel) return
+
+		const activeButton = panel.querySelector<HTMLButtonElement>('.v-btn--active') || panel.querySelector<HTMLButtonElement>(fallbackSelector)
+		activeButton?.focus({ preventScroll: true })
+	}
+
+	const focusMonthPanelButton = () => {
+		focusPanelActiveButton('.v-date-picker-months', '.v-date-picker-months .v-btn:first-child')
+	}
+
+	const focusYearPanelButton = () => {
+		focusPanelActiveButton('.v-date-picker-years', '.v-date-picker-years .v-btn:first-child')
+	}
+
 	watch(isDatePickerVisible, (visible) => {
 		if (visible) {
 			nextTick(attachListeners)
@@ -552,6 +576,21 @@ export const useCalendarKeyboardNavigation = (options: CalendarKeyboardNavigatio
 			detachListeners()
 		}
 	})
+
+	if (currentViewMode) {
+		watch(currentViewMode, (newMode) => {
+			if (!isDatePickerVisible.value) return
+			// Attendre que Vuetify ait rendu le panneau et que les transitions soient terminées
+			setTimeout(() => {
+				if (newMode === 'months') {
+					focusMonthPanelButton()
+				}
+				else if (newMode === 'year') {
+					focusYearPanelButton()
+				}
+			}, 50)
+		})
+	}
 
 	onMounted(() => {
 		if (isDatePickerVisible.value) {

--- a/src/composables/date/useDatePickerAccessibility.ts
+++ b/src/composables/date/useDatePickerAccessibility.ts
@@ -3,6 +3,8 @@
  */
 import { nextTick, onBeforeUnmount, onMounted } from 'vue'
 
+export type DatePickerViewMode = 'month' | 'year' | 'months' | undefined
+
 /**
  * Améliore l'accessibilité du CalendarMode en ajoutant des attributs ARIA et des instructions pour les lecteurs d'écran
  * @returns Des fonctions pour mettre à jour l'accessibilité du CalendarMode et gérer les événements clavier
@@ -37,6 +39,12 @@ export function useDatePickerAccessibility() {
 			button.removeAttribute('aria-label')
 		})
 
+		// Masquer les entêtes de jours de la semaine (L M M J V S D) aux lecteurs d'écran
+		const weekdayHeaders = datePickerEl.querySelectorAll<HTMLElement>('.v-date-picker-month__weekday')
+		weekdayHeaders.forEach((el) => {
+			el.setAttribute('aria-hidden', 'true')
+		})
+
 		// Ajouter les instructions pour lecteurs d'écran si elles n'existent pas déjà
 		// if (!datePickerEl.querySelector('.sr-only-instructions')) {
 		// 	const srOnly = document.createElement('div')
@@ -49,6 +57,61 @@ export function useDatePickerAccessibility() {
 		// Ne pas forcer role="application" ni aria-label générique : on laisse les rôles natifs du picker (grille/boutons) et les labels existants.
 
 		// Ne pas surcharger Enter/Espace : laisser les comportements natifs des boutons
+	}
+
+	/**
+	 * Met à jour aria-expanded sur les boutons de contrôle mois/année selon le mode d'affichage courant,
+	 * et aria-selected sur les boutons des panneaux mois/années (identifiés par la classe Vuetify v-btn--active).
+	 * - bouton mois  → aria-expanded="true" quand viewMode === 'months'
+	 * - bouton année → aria-expanded="true" quand viewMode === 'year'
+	 * - item actif dans .v-date-picker-months / .v-date-picker-years → aria-selected="true", les autres "false"
+	 */
+	const updateControlsAriaExpanded = async (viewMode: DatePickerViewMode): Promise<void> => {
+		await nextTick()
+
+		const datePickerEl = document.querySelector('.v-date-picker')
+		if (!datePickerEl) return
+
+		const monthBtn = datePickerEl.querySelector<HTMLButtonElement>('.v-date-picker-controls__month-btn')
+		const modeBtn = datePickerEl.querySelector<HTMLButtonElement>('.v-date-picker-controls__mode-btn')
+
+		if (monthBtn) {
+			monthBtn.setAttribute('aria-expanded', String(viewMode === 'months'))
+		}
+
+		if (modeBtn) {
+			modeBtn.setAttribute('aria-expanded', String(viewMode === 'year'))
+		}
+
+		// aria-selected sur les boutons du panneau mois
+		const monthPanelBtns = datePickerEl.querySelectorAll<HTMLButtonElement>('.v-date-picker-months button')
+		monthPanelBtns.forEach((btn) => {
+			btn.setAttribute('aria-selected', String(btn.classList.contains('v-btn--active')))
+		})
+
+		// aria-selected sur les boutons du panneau années
+		const yearPanelBtns = datePickerEl.querySelectorAll<HTMLButtonElement>('.v-date-picker-years button')
+		yearPanelBtns.forEach((btn) => {
+			btn.setAttribute('aria-selected', String(btn.classList.contains('v-btn--active')))
+		})
+
+		// Masquer le panneau années quand le panneau mois est ouvert et vice-versa
+		const monthsPanel = datePickerEl.querySelector<HTMLElement>('.v-date-picker-months')
+		const yearsPanel = datePickerEl.querySelector<HTMLElement>('.v-date-picker-years')
+
+		if (monthsPanel && yearsPanel) {
+			const monthsVisible = viewMode === 'months'
+			yearsPanel.setAttribute('aria-hidden', String(monthsVisible))
+			yearsPanel.querySelectorAll<HTMLElement>('button').forEach((btn) => {
+				btn.setAttribute('tabindex', monthsVisible ? '-1' : '0')
+			})
+
+			const yearsVisible = viewMode === 'year'
+			monthsPanel.setAttribute('aria-hidden', String(yearsVisible))
+			monthsPanel.querySelectorAll<HTMLElement>('button').forEach((btn) => {
+				btn.setAttribute('tabindex', yearsVisible ? '-1' : '0')
+			})
+		}
 	}
 
 	// Référence pour le MutationObserver (désactivé)
@@ -98,6 +161,7 @@ export function useDatePickerAccessibility() {
 
 	return {
 		updateAccessibility,
+		updateControlsAriaExpanded,
 		handleKeyDown,
 		fixAriaAttributes,
 	}


### PR DESCRIPTION
##  DatePicker – Correctifs accessibilité à prévoir

## Calendar-mode

En mode `calendar-mode`, la touche `Entrée` n'ouvre pas la modale lorsque le composant reçoit le focus.  
Actuellement, l'ouverture se fait uniquement avec la flèche vers le bas.

### TODO

- [x] Permettre l'ouverture de la modale avec la touche `Entrée`.
- [x] Conserver le comportement actuel avec la flèche vers le bas.
- [x] Ajouter un rôle bouton sur l'élément interactif du `calendar-mode`.
      → Remplacé par `aria-haspopup="dialog"` (évite la violation axe `nested-interactive`)
- [ ] Vérifier l'ajout de `role="button"` 
      → Non retenu : `role="button"` sur un `<div>` contenant un `<input>` = violation WCAG 4.1.2

### Critères d'acceptation

- [x] Lorsque le DatePicker en `calendar-mode` reçoit le focus, la touche `Entrée` ouvre la modale.
- [x] La flèche vers le bas continue d'ouvrir la modale.
- [x] L'élément déclencheur est correctement restitué comme un bouton par les technologies d'assistance.
      → Via `aria-haspopup="dialog"` + `aria-expanded` sur l'`<input>` natif

---

## Modale du calendrier

Ajouter les attributs d'accessibilité nécessaires sur la modale.

### TODO

- [x] Ajouter `role="dialog"` sur la modale.
- [x] Ajouter `aria-modal="true"` sur la modale.
- [x] Ajouter `aria-label="Sélectionner une date"` sur la modale.

### Critères d'acceptation

- [x] La modale est restituée comme une boîte de dialogue.
- [x] La modale est identifiée comme modale.
- [x] La modale possède un nom accessible explicite : `Sélectionner une date`.

---

## Contenu de la modale

### Jours de la semaine

- [x] Ajouter `aria-hidden="true"` sur les textes `LMMJVSD`.

### Titre de la date affichée

- [x] Ajouter `aria-live="polite"` sur le titre `h3` afin de restituer le changement de date.

### Sélection du mois et de l'année

- [x] Ajouter `aria-expanded` sur le bouton de sélection du mois.
- [x] Ajouter `aria-expanded` sur le bouton de sélection de l'année.
- [x] Ajouter `aria-selected="true"` sur le mois sélectionné.
- [x] Ajouter `aria-selected="true"` sur l'année sélectionnée.

### Panneau de choix des mois

- [x] Lorsque le panneau de choix des mois est ouvert, masquer les boutons des années.
- [x] Vérifier que les boutons des années ne sont pas accessibles au clavier lorsque le panneau des mois est ouvert.
      → Via `tabindex="-1"` injecté sur les boutons du panneau masqué
- [x] Vérifier que les boutons des années ne sont pas restitués par les technologies d'assistance lorsque le panneau des mois est ouvert.
      → Via `aria-hidden="true"` sur le panneau `.v-date-picker-years`

### Gestion du focus

- [x] Lorsque le panneau de choix des mois est ouvert, déplacer automatiquement le focus sur le mois déjà sélectionné MAIS prevenir.
- [x] Lorsque le panneau de choix des années est ouvert,  déplacer automatiquement le focus sur l'année déjà sélectionnée MAIS prevenir.
      → Partiellement traité : annonce `aria-live` avant le déplacement du focus (watcher `currentViewMode`)
      → Le déplacement lui-même reste géré par Vuetify — refactoring useCalendarKeyboardNavigation à prévoir

### Critères d'acceptation

- [x] Les textes `LMMJVSD` sont ignorés par les technologies d'assistance.
- [x] Le changement de date affichée dans le titre `h3` est restitué poliment.
- [x] Les boutons mois/année exposent correctement leur état ouvert ou fermé avec `aria-expanded`.
- [x] Le mois sélectionné est identifiable avec `aria-selected="true"`.
- [x] L'année sélectionnée est identifiable avec `aria-selected="true"`.
- [x] Les éléments non pertinents sont masqués lorsque le panneau mois ou année est ouvert.
- [x] L'ouverture d'un panneau mois ou année ne provoque pas de déplacement automatique du focus sur la valeur déjà sélectionnée mais c'est signale.

---

## Tests à prévoir

- [x] Tester l'ouverture du `calendar-mode` avec `Entrée`.
- [x] Tester l'ouverture du `calendar-mode` avec la flèche vers le bas.
- [ ] Vérifier la présence de `role="button"` sur [CalendarMode
      → Non applicable : remplacé par `aria-haspopup="dialog"`
- [x] Vérifier la présence de `role="dialog"`, `aria-modal="true"` et `aria-label="Sélectionner une date"` sur la modale.
- [x] Vérifier que les textes `LMMJVSD` ont bien `aria-hidden="true"`.
- [x] Vérifier que le titre `h3` possède `aria-live="polite"`.
- [x] Vérifier la mise à jour de `aria-expanded` sur les boutons mois et année.
- [x] Vérifier la présence de `aria-selected="true"` sur le mois sélectionné.
- [x] Vérifier la présence de `aria-selected="true"` sur l'année sélectionné.
- [x] Vérifier que les boutons d'années sont masqués lorsque le panneau des mois est ouvert.
- [x] Vérifier qu'avant que le focus automatique ne soit déplacé vers le mois ou l'année déjà sélectionné à l'ouverture du panneau ce soit annoncé.
      → Via région `aria-live="polite"` + `panelLiveText` dans le watcher `currentViewMode`