### PR TITLE
Doc prevenir les utilisateurs ayant des comptes EMU 

### DIFF
--- a/src/stories/Demarrer/SignalerUneAnomalie.mdx
+++ b/src/stories/Demarrer/SignalerUneAnomalie.mdx
@@ -18,6 +18,12 @@ Ce guide vous explique comment rédiger correctement une anomalie.
 
 ## Créer une anomalie
 
+N'importe qui peut créer une issue sur ce dépôt public : il suffit d'un compte GitHub **non managé** (c'est-à-dire un compte personnel classique, hors *GitHub Enterprise Managed Users* — « EMU »).
+
+Les comptes managés (Enterprise Managed Users) ne peuvent ni créer de contenu public ni collaborer en dehors de leur entreprise
+([restrictions sur la gestion des dépôts — doc GitHub](https://docs.github.com/en/enterprise-cloud@latest/admin/managing-iam/understanding-iam-for-enterprises/abilities-and-restrictions-of-managed-user-accounts#interactions) ;
+[The Enterprise Challenge: Collaboration Friction for Managed Users — devactivity](https://devactivity.com/insights/streamlining-enterprise-collaboration-the-call-for-external-access-for-github-managed-users/)),
+
 <Story of={ComponentStories.AnomalieGraphique}/>
 
 <Story of={ComponentStories.AnomalieFonctionnelle}/>


### PR DESCRIPTION
Les utilisateurs ayant des comptes GitHub EMU ne peuvent pas interagir avec les dépôts externes à leur entreprise. Il est nécessaire de les en prévenir, car le message d’erreur délivré par GitHub n’est pas intelligible.
