### PR TITLE
Remove dependency overrides from package.json and move rollup overrid…

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,39 +147,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "overrides": {
-    "esbuild": ">=0.28.1",
-    "parse5": "7.1.2",
-    "npm": "^11.8.1",
-    "undici": ">=6.27.0 <8",
-    "rollup": "^4.59.0",
-    "immutable": ">=5.1.5"
-  },
-  "pnpm": {
-    "overrides": {
-      "esbuild": ">=0.28.1",
-      "undici": ">=6.27.0 <8",
-      "glob": ">=10.5.0",
-      "js-yaml": ">=4.1.1",
-      "parse5": "7.1.2",
-      "npm": "^11.8.1",
-      "minimatch": ">=10.2.3",
-      "immutable": ">=5.1.5",
-      "flatted": ">=3.4.2",
-      "handlebars": ">=4.7.9",
-      "lodash": ">=4.18.0",
-      "follow-redirects": ">=1.16.0",
-      "uuid": ">=14.0.0",
-      "@cypress/request>uuid": "8.3.2",
-      "postcss": ">=8.5.10",
-      "fast-uri": ">=4.1.1",
-      "js-cookie": ">=3.0.7",
-      "qs": ">=6.15.2",
-      "tmp": ">=0.2.6"
-    },
-    "patchedDependencies": {
-      "vuetify@3.12.2": "patches/vuetify@3.12.2.patch"
-    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,7 @@ overrides:
   js-cookie: '>=3.0.7'
   qs: '>=6.15.2'
   tmp: '>=0.2.6'
+  rollup: ^4.59.0
 
 patchedDependencies:
   vuetify@3.12.2:
@@ -1174,7 +1175,7 @@ packages:
     resolution: {integrity: sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+      rollup: ^4.59.0
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -1431,7 +1432,7 @@ packages:
     resolution: {integrity: sha512-NILLxDqpA/JR/AazGWpsz+4fadJwRU4uhHephGtYpVOWnQA/DkJfKT6zpcJVq8+QA8A2zKMLX3GVKsXIrxjuDA==}
     peerDependencies:
       esbuild: '>=0.28.1'
-      rollup: '*'
+      rollup: ^4.59.0
       storybook: ^10.4.6
       vite: '*'
       webpack: '*'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,24 @@
+overrides:
+  esbuild: ">=0.28.1"
+  undici: ">=6.27.0 <8"
+  glob: ">=10.5.0"
+  js-yaml: ">=4.1.1"
+  parse5: "7.1.2"
+  npm: "^11.8.1"
+  minimatch: ">=10.2.3"
+  immutable: ">=5.1.5"
+  flatted: ">=3.4.2"
+  handlebars: ">=4.7.9"
+  lodash: ">=4.18.0"
+  follow-redirects: ">=1.16.0"
+  uuid: ">=14.0.0"
+  "@cypress/request>uuid": "8.3.2"
+  postcss: ">=8.5.10"
+  fast-uri: ">=4.1.1"
+  js-cookie: ">=3.0.7"
+  qs: ">=6.15.2"
+  tmp: ">=0.2.6"
+  rollup: "^4.59.0"
+
+patchedDependencies:
+  vuetify@3.12.2: patches/vuetify@3.12.2.patch


### PR DESCRIPTION
## Correctif appliqué :

- Création de pnpm-workspace.yaml — nouveau fichier contenant tous les overrides (fusion de overrides + pnpm.overrides) et patchedDependencies (patch Vuetify)
- Suppression du champ pnpm et du champ overrides de package.json — plus de duplication, tout est au nouvel emplacement canonique
- Régénération du lockfile — pnpm install a réécrit pnpm-lock.yaml avec les 20 overrides et le patch Vuetify correctement appliqués

## Fichiers modifiés :

- pnpm-workspace.yaml (nouveau) — overrides + patchedDependencies
- package.json — suppression des champs overrides et pnpm

## Preuves que le correctif fonctionne:

1. Overrides présents dans le lockfile — les 20 overrides sont écrits dans pnpm-lock.yaml sous la section overrides:, preuve que pnpm les a lus et appliqués.
2. Patch Vuetify appliqué — patchedDependencies avec le hash et le chemin du patch sont dans le lockfile.
3. Versions résolues conformes aux restrictions :
esbuild | >=0.28.1 | 0.28.1
undici | >=6.27.0 <8 | 7.28.0
lodash | >=4.18.0 | 4.18.1
postcss | >=8.5.10 | 8.5.22
qs | >=6.15.2 | 6.15.3
4. @cypress/request>uuid — l'override ciblé 8.3.2 est bien présent dans le lockfile.
5. Champ pnpm supprimé de package.json — le seul "pnpm" restant est dans engines (contrôle de version du runtime, pas des overrides).
6. pnpm-workspace.yaml créé — c'est le nouvel emplacement canonique lu par pnpm 10.

