### PR TITLE
A11y: Fix homeLink focus

### DIFF
--- a/src/components/HeaderBar/HeaderLogo/HeaderLogo.vue
+++ b/src/components/HeaderBar/HeaderLogo/HeaderLogo.vue
@@ -121,7 +121,7 @@
 	}
 
 	// cursor: pointer uniquement quand le conteneur est interactif (a, router-link)
-	a&,
+	&:is(a),
 	&[href] {
 		cursor: pointer;
 	}

--- a/src/components/HeaderBar/HeaderLogo/HeaderLogo.vue
+++ b/src/components/HeaderBar/HeaderLogo/HeaderLogo.vue
@@ -42,12 +42,35 @@
 			if (hasRouterLink) {
 				return 'router-link'
 			}
-			return 'div'
+			// Sans vue-router, on retombe sur un vrai `<a href>` : un `<div>` serait cliquable
+			// visuellement (cursor: pointer) mais ni focusable ni activable au clavier (RGAA 7.3).
+			return 'a'
 		}
 		if (props.homeLink?.href) {
 			return 'a'
 		}
 		return 'div'
+	})
+
+	// `href` de repli utilisé quand `to` est fourni mais que vue-router n'est pas disponible.
+	// On résout les formes sérialisables de `RouteLocationRaw` ; pour une route nommée, seul le
+	// router sait construire l'URL, on retombe donc sur `href` puis sur la racine du site.
+	const fallbackHomeHref = computed(() => {
+		const to = props.homeLink?.to
+
+		if (typeof to === 'string') {
+			return to
+		}
+
+		if (to && typeof to === 'object' && 'path' in to && typeof to.path === 'string') {
+			return to.path
+		}
+
+		return props.homeLink?.href ?? '/'
+	})
+
+	const homeHref = computed(() => {
+		return props.homeLink?.to ? fallbackHomeHref.value : props.homeLink?.href
 	})
 </script>
 
@@ -55,8 +78,8 @@
 	<component
 		:is="routeType"
 		v-bind="{
-			to: 'to' in homeLink ? homeLink?.to : undefined,
-			href: 'href' in homeLink ? homeLink?.href : undefined,
+			to: routeType === 'router-link' ? homeLink?.to : undefined,
+			href: routeType === 'a' ? homeHref : undefined,
 			'aria-label': 'aria-label' in homeLink ? homeLink?.['aria-label'] : undefined,
 		}"
 		class="logo"

--- a/src/components/HeaderBar/HeaderLogo/HeaderLogo.vue
+++ b/src/components/HeaderBar/HeaderLogo/HeaderLogo.vue
@@ -1,9 +1,9 @@
 <script lang="ts" setup>
-	import { computed, getCurrentInstance } from 'vue'
 	import type { RouteLocationRaw } from 'vue-router'
 	import { useTheme } from 'vuetify'
 	import { logoDesktop as logoDesktopUrl, logoMobile as logoMobileUrl } from '@/assets/logos'
 	import SyHeading from '@/components/SyHeading/SyHeading.vue'
+	import { useHomeLinkFallback } from '@/composables/useHomeLinkFallback'
 	import { headerBreakpoint } from '../consts'
 
 	type PropsType = {
@@ -35,43 +35,7 @@
 	const primary = theme.current.value.colors.primary
 	const desktopLogoMediaQuery = `(min-width: ${headerBreakpoint}px)`
 
-	const routeType = computed(() => {
-		if (props.homeLink?.to) {
-			const componentsRegistered = getCurrentInstance()?.appContext?.components
-			const hasRouterLink = componentsRegistered && 'RouterLink' in componentsRegistered
-			if (hasRouterLink) {
-				return 'router-link'
-			}
-			// Sans vue-router, on retombe sur un vrai `<a href>` : un `<div>` serait cliquable
-			// visuellement (cursor: pointer) mais ni focusable ni activable au clavier (RGAA 7.3).
-			return 'a'
-		}
-		if (props.homeLink?.href) {
-			return 'a'
-		}
-		return 'div'
-	})
-
-	// `href` de repli utilisé quand `to` est fourni mais que vue-router n'est pas disponible.
-	// On résout les formes sérialisables de `RouteLocationRaw` ; pour une route nommée, seul le
-	// router sait construire l'URL, on retombe donc sur `href` puis sur la racine du site.
-	const fallbackHomeHref = computed(() => {
-		const to = props.homeLink?.to
-
-		if (typeof to === 'string') {
-			return to
-		}
-
-		if (to && typeof to === 'object' && 'path' in to && typeof to.path === 'string') {
-			return to.path
-		}
-
-		return props.homeLink?.href ?? '/'
-	})
-
-	const homeHref = computed(() => {
-		return props.homeLink?.to ? fallbackHomeHref.value : props.homeLink?.href
-	})
+	const { containerComponent: routeType, homeHref } = useHomeLinkFallback(() => props.homeLink)
 </script>
 
 <template>
@@ -148,13 +112,18 @@
 	line-height: 1.45;
 	font-family: Cabin, Arial, Helvetica, sans-serif;
 	text-decoration: none;
-	cursor: pointer;
 
 	// Ring DS au focus clavier (remplace l'outline navigateur par défaut)
 	&:focus-visible {
 		outline: 2px solid rgb(var(--v-theme-primary));
 		outline-offset: 3px;
 		border-radius: 4px;
+	}
+
+	// cursor: pointer uniquement quand le conteneur est interactif (a, router-link)
+	a&,
+	&[href] {
+		cursor: pointer;
 	}
 }
 

--- a/src/components/HeaderBar/HeaderLogo/tests/HeaderLogo.spec.ts
+++ b/src/components/HeaderBar/HeaderLogo/tests/HeaderLogo.spec.ts
@@ -97,7 +97,7 @@ describe('HeaderLogo', () => {
 		expect(wrapper.find('router-link-stub').attributes('to')).toBe('/')
 	})
 
-	// Régression #2441 : sans `RouterLink` enregistré, le conteneur retombait sur un `<div>` —
+	// sans `RouterLink` enregistré, le conteneur retombait sur un `<div>` —
 	// visuellement cliquable (cursor: pointer) mais impossible à atteindre au clavier (RGAA 7.3).
 	// On vérifie qu'un vrai `<a href>` est rendu à la place.
 	it('render a focusable anchor when there is no `RouterLink` component registered', async () => {

--- a/src/components/HeaderBar/HeaderLogo/tests/HeaderLogo.spec.ts
+++ b/src/components/HeaderBar/HeaderLogo/tests/HeaderLogo.spec.ts
@@ -97,19 +97,55 @@ describe('HeaderLogo', () => {
 		expect(wrapper.find('router-link-stub').attributes('to')).toBe('/')
 	})
 
-	it('render a div when there there is no `RouterLink` component registered', async () => {
+	// Régression #2441 : sans `RouterLink` enregistré, le conteneur retombait sur un `<div>` —
+	// visuellement cliquable (cursor: pointer) mais impossible à atteindre au clavier (RGAA 7.3).
+	// On vérifie qu'un vrai `<a href>` est rendu à la place.
+	it('render a focusable anchor when there is no `RouterLink` component registered', async () => {
 		const wrapper = mount(HeaderLogo, {
 			props: {
 				ariaLabel: 'Test aria label',
 				logoAlt: 'Test aria label',
 				headingLevelTitle: 2,
 				homeLink: {
-					to: '/',
+					to: '/accueil',
+				},
+			},
+		})
+		const link = wrapper.find('.logo')
+
+		expect(link.element.tagName).toBe('A')
+		expect(link.attributes('href')).toBe('/accueil')
+	})
+
+	it('resolves the fallback href from an object route location', async () => {
+		const wrapper = mount(HeaderLogo, {
+			props: {
+				logoAlt: 'Test aria label',
+				headingLevelTitle: 2,
+				homeLink: {
+					to: { path: '/accueil' },
 				},
 			},
 		})
 
-		expect(wrapper.find('.logo').element.tagName).toBe('DIV')
+		expect(wrapper.find('.logo').attributes('href')).toBe('/accueil')
+	})
+
+	it('falls back to homeLink.href for a named route that only the router can resolve', async () => {
+		const wrapper = mount(HeaderLogo, {
+			props: {
+				logoAlt: 'Test aria label',
+				headingLevelTitle: 2,
+				homeLink: {
+					to: { name: 'home' },
+					href: '/racine',
+				},
+			},
+		})
+		const link = wrapper.find('.logo')
+
+		expect(link.element.tagName).toBe('A')
+		expect(link.attributes('href')).toBe('/racine')
 	})
 
 	it('render a div when the homeLink properties `to` and `href` are both set to `undefined`', async () => {

--- a/src/components/HeaderBar/HeaderLogo/tests/HeaderLogo.spec.ts
+++ b/src/components/HeaderBar/HeaderLogo/tests/HeaderLogo.spec.ts
@@ -103,11 +103,11 @@ describe('HeaderLogo', () => {
 	it('render a focusable anchor when there is no `RouterLink` component registered', async () => {
 		const wrapper = mount(HeaderLogo, {
 			props: {
-				ariaLabel: 'Test aria label',
 				logoAlt: 'Test aria label',
 				headingLevelTitle: 2,
 				homeLink: {
 					to: '/accueil',
+					'aria-label': 'Test aria label',
 				},
 			},
 		})

--- a/src/components/HeaderBar/HeaderLogo/tests/HeaderLogo.spec.ts
+++ b/src/components/HeaderBar/HeaderLogo/tests/HeaderLogo.spec.ts
@@ -106,7 +106,7 @@ describe('HeaderLogo', () => {
 				logoAlt: 'Test aria label',
 				headingLevelTitle: 2,
 				homeLink: {
-					to: '/accueil',
+					'to': '/accueil',
 					'aria-label': 'Test aria label',
 				},
 			},

--- a/src/components/LogoBrandSection/LogoBrandSection.vue
+++ b/src/components/LogoBrandSection/LogoBrandSection.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 	import { LogoSize } from '@/components/Logo/LogoSize'
 	import { cnamLightTheme } from '@/designTokens/tokens/cnam/cnamLightTheme'
-	import { computed, getCurrentInstance } from 'vue'
+	import { computed } from 'vue'
 	import type { RouteLocationRaw } from 'vue-router'
 	import Logo from '../Logo/Logo.vue'
 	import { dividerDimensionsMapping } from './dividerDimensionsMapping'
@@ -10,6 +10,7 @@
 	import type { Theme } from './types'
 	import SyHeading from '@/components/SyHeading/SyHeading.vue'
 	import { useLocales } from '@/composables/useLocales'
+	import { useHomeLinkFallback } from '@/composables/useHomeLinkFallback'
 	import type { DeepPartial } from '@/utils/locales/mergeLocales'
 
 	const props = withDefaults(
@@ -114,43 +115,7 @@
 		)
 	})
 
-	const logoContainerComponent = computed(() => {
-		if (props.homeLink?.to) {
-			const componentsRegistered = getCurrentInstance()?.appContext?.components
-			const hasRouterLink = componentsRegistered && 'RouterLink' in componentsRegistered
-			if (hasRouterLink) {
-				return 'router-link'
-			}
-			// Sans vue-router, on retombe sur un vrai `<a href>` : un `<div>` serait cliquable
-			// visuellement (cursor: pointer) mais ni focusable ni activable au clavier (RGAA 7.3).
-			return 'a'
-		}
-		if (props.homeLink?.href) {
-			return 'a'
-		}
-		return 'div'
-	})
-
-	// `href` de repli utilisé quand `to` est fourni mais que vue-router n'est pas disponible.
-	// On résout les formes sérialisables de `RouteLocationRaw` ; pour une route nommée, seul le
-	// router sait construire l'URL, on retombe donc sur `href` puis sur la racine du site.
-	const fallbackHomeHref = computed(() => {
-		const to = props.homeLink?.to
-
-		if (typeof to === 'string') {
-			return to
-		}
-
-		if (to && typeof to === 'object' && 'path' in to && typeof to.path === 'string') {
-			return to.path
-		}
-
-		return props.homeLink?.href ?? '/'
-	})
-
-	const homeHref = computed(() => {
-		return props.homeLink?.to ? fallbackHomeHref.value : props.homeLink?.href
-	})
+	const { containerComponent: logoContainerComponent, homeHref } = useHomeLinkFallback(() => props.homeLink)
 
 	// Le libellé du lien d'accueil : sans `ariaLabel`, on n'annonce que le libellé générique
 	// (une concaténation naïve produisait « undefined Retour vers accueil du site »).
@@ -354,7 +319,9 @@
 		flex: none;
 	}
 
-	.vd-home-link {
+	// cursor: pointer uniquement quand le conteneur est interactif (a, router-link)
+	a.vd-home-link,
+	.vd-home-link[href] {
 		cursor: pointer;
 	}
 }

--- a/src/components/LogoBrandSection/LogoBrandSection.vue
+++ b/src/components/LogoBrandSection/LogoBrandSection.vue
@@ -121,12 +121,43 @@
 			if (hasRouterLink) {
 				return 'router-link'
 			}
-			return 'div'
+			// Sans vue-router, on retombe sur un vrai `<a href>` : un `<div>` serait cliquable
+			// visuellement (cursor: pointer) mais ni focusable ni activable au clavier (RGAA 7.3).
+			return 'a'
 		}
 		if (props.homeLink?.href) {
 			return 'a'
 		}
 		return 'div'
+	})
+
+	// `href` de repli utilisé quand `to` est fourni mais que vue-router n'est pas disponible.
+	// On résout les formes sérialisables de `RouteLocationRaw` ; pour une route nommée, seul le
+	// router sait construire l'URL, on retombe donc sur `href` puis sur la racine du site.
+	const fallbackHomeHref = computed(() => {
+		const to = props.homeLink?.to
+
+		if (typeof to === 'string') {
+			return to
+		}
+
+		if (to && typeof to === 'object' && 'path' in to && typeof to.path === 'string') {
+			return to.path
+		}
+
+		return props.homeLink?.href ?? '/'
+	})
+
+	const homeHref = computed(() => {
+		return props.homeLink?.to ? fallbackHomeHref.value : props.homeLink?.href
+	})
+
+	// Le libellé du lien d'accueil : sans `ariaLabel`, on n'annonce que le libellé générique
+	// (une concaténation naïve produisait « undefined Retour vers accueil du site »).
+	const homeLinkLabel = computed(() => {
+		return [props.homeLink?.ariaLabel, locales.value.homeLinkLabel]
+			.filter(Boolean)
+			.join(' ')
 	})
 
 	const secondaryLogoCtnComponent = computed(() => {
@@ -208,14 +239,14 @@
 		<component
 			:is="logoContainerComponent"
 			:to="logoContainerComponent === 'router-link' ? homeLink?.to : undefined"
-			:href="logoContainerComponent === 'a' ? homeLink?.href : undefined"
+			:href="logoContainerComponent === 'a' ? homeHref : undefined"
 			class="vd-home-link"
 		>
 			<Logo
 				:hide-signature="hideSignature"
 				:hide-organism="isCompteAmeliMobile"
 				:risque-pro="isRisquePro"
-				:aria-label="homeLink?.ariaLabel + ' ' + locales.homeLinkLabel"
+				:aria-label="homeLinkLabel"
 				:avatar="avatar"
 				:size="logoSize"
 				:class="{ 'mr-2': avatar }"
@@ -242,7 +273,7 @@
 				v-if="secondaryLogo"
 				:aria-label="secondaryLogoLabel"
 				:to="secondaryLogoCtnComponent === 'router-link' ? homeLink?.to : undefined"
-				:href="secondaryLogoCtnComponent === 'a' ? homeLink?.href : undefined"
+				:href="secondaryLogoCtnComponent === 'a' ? homeHref : undefined"
 				class="vd-home-link"
 			>
 				<img

--- a/src/components/LogoBrandSection/accessibilite/Accessibility.mdx
+++ b/src/components/LogoBrandSection/accessibilite/Accessibility.mdx
@@ -27,8 +27,8 @@ import {
 	<CriteriaSection>
 		<CriteriaCard title="Liens et navigation">
 			<ul>
-				<li><strong>Composant dynamique</strong> : Détecte automatiquement <code>router-link</code>, <code>&lt;a&gt;</code> ou <code>&lt;div&gt;</code> selon <code>homeLink</code>.</li>
-				<li><strong>Label du lien principal</strong> : <code>ariaLabel</code> concaténé avec " Retour vers accueil du site".</li>
+				<li><strong>Composant dynamique</strong> : Détecte automatiquement <code>router-link</code>, <code>&lt;a&gt;</code> ou <code>&lt;div&gt;</code> selon <code>homeLink</code>. Avec <code>homeLink.to</code> mais sans <code>vue-router</code> enregistré, le repli est un <code>&lt;a href&gt;</code> (et non un <code>&lt;div&gt;</code>) afin de rester focusable et activable au clavier (RGAA 7.3).</li>
+				<li><strong>Label du lien principal</strong> : <code>ariaLabel</code> concaténé avec " Retour vers accueil du site" (le libellé générique seul si <code>ariaLabel</code> n'est pas fourni).</li>
 				<li><strong>Label du logo secondaire</strong> : Calculé avec <code>homeLinkPrefix</code> et <code>alt</code> du logo.</li>
 				<li><strong>Lien secondaire</strong> : Uniquement pour les thèmes <code>ameli-pro</code> et <code>ameli</code>.</li>
 			</ul>

--- a/src/components/LogoBrandSection/tests/LogoBrandSection.a11y.spec.ts
+++ b/src/components/LogoBrandSection/tests/LogoBrandSection.a11y.spec.ts
@@ -37,4 +37,27 @@ describe('LogoBrandSection – accessibility (axe)', () => {
 
 		wrapper.unmount()
 	})
+
+	it('has no axe violations when falling back to a real <a> without vue-router', async () => {
+		const wrapper = mount(LogoBrandSection, {
+			props: {
+				headingLevelTitle: 1,
+				headingLevelSubtitle: 2,
+				theme: 'default',
+				serviceTitle: 'Service Title',
+				homeLink: {
+					to: '/accueil',
+					ariaLabel: 'Accueil du site',
+				},
+			},
+			attachTo: document.body,
+		})
+
+		const results = await axe(wrapper.element as HTMLElement)
+		assertNoA11yViolations(results, 'LogoBrandSection – fallback anchor without vue-router', {
+			ignoreRules: ['region'],
+		})
+
+		wrapper.unmount()
+	})
 })

--- a/src/components/LogoBrandSection/tests/LogoBrandSection.focus.spec.ts
+++ b/src/components/LogoBrandSection/tests/LogoBrandSection.focus.spec.ts
@@ -16,6 +16,46 @@ describe('LogoBrandSection - Focus', () => {
 		expect(link.attributes('href')).toBe('/')
 	})
 
+	// Régression #2441 : avec `homeLink.to` et sans vue-router enregistré, le conteneur retombait
+	// sur un `<div>` — visuellement cliquable (cursor: pointer) mais impossible à atteindre au
+	// clavier (RGAA 7.3). On vérifie qu'un vrai `<a href>` est rendu à la place.
+	it('falls back to a real focusable anchor when homeLink.to is set without vue-router', () => {
+		const wrapper = mount(LogoBrandSection, {
+			props: { homeLink: { to: '/accueil' } },
+		})
+		const link = wrapper.find('.vd-home-link')
+
+		expect(link.element.tagName).toBe('A')
+		expect(link.attributes('href')).toBe('/accueil')
+	})
+
+	it('resolves the fallback href from an object route location', () => {
+		const wrapper = mount(LogoBrandSection, {
+			props: { homeLink: { to: { path: '/accueil' } } },
+		})
+
+		expect(wrapper.find('.vd-home-link').attributes('href')).toBe('/accueil')
+	})
+
+	it('falls back to homeLink.href for a named route that only the router can resolve', () => {
+		const wrapper = mount(LogoBrandSection, {
+			props: { homeLink: { to: { name: 'home' }, href: '/racine' } },
+		})
+		const link = wrapper.find('.vd-home-link')
+
+		expect(link.element.tagName).toBe('A')
+		expect(link.attributes('href')).toBe('/racine')
+	})
+
+	it('keeps using RouterLink when it is registered', () => {
+		const wrapper = mount(LogoBrandSection, {
+			global: { stubs: { RouterLink: true } },
+			props: { homeLink: { to: '/accueil' } },
+		})
+
+		expect(wrapper.find('router-link-stub').attributes('to')).toBe('/accueil')
+	})
+
 	it('renders a non-focusable div container when homeLink has no href/to', () => {
 		const wrapper = mount(LogoBrandSection, {
 			props: { homeLink: {} },

--- a/src/components/LogoBrandSection/tests/LogoBrandSection.focus.spec.ts
+++ b/src/components/LogoBrandSection/tests/LogoBrandSection.focus.spec.ts
@@ -16,7 +16,7 @@ describe('LogoBrandSection - Focus', () => {
 		expect(link.attributes('href')).toBe('/')
 	})
 
-	// Régression #2441 : avec `homeLink.to` et sans vue-router enregistré, le conteneur retombait
+	// avec `homeLink.to` et sans vue-router enregistré, le conteneur retombait
 	// sur un `<div>` — visuellement cliquable (cursor: pointer) mais impossible à atteindre au
 	// clavier (RGAA 7.3). On vérifie qu'un vrai `<a href>` est rendu à la place.
 	it('falls back to a real focusable anchor when homeLink.to is set without vue-router', () => {

--- a/src/components/LogoBrandSection/tests/LogoBrandSection.spec.ts
+++ b/src/components/LogoBrandSection/tests/LogoBrandSection.spec.ts
@@ -361,4 +361,30 @@ describe('LogoBrandSection', () => {
 
 		expect(wrapper.findAll('.vd-home-link')[1]?.element.tagName).toBe('DIV')
 	})
+
+	it('uses only the generic label when ariaLabel is not provided', () => {
+		const wrapper = mount(LogoBrandSection, {
+			global: {
+				stubs: ['RouterLink', 'Logo'],
+			},
+			props: {
+				homeLink: { href: '/' },
+			},
+		})
+
+		expect(wrapper.find('logo-stub').attributes('arialabel')).toBe('Retour vers accueil du site')
+	})
+
+	it('concatenates ariaLabel with the generic label when provided', () => {
+		const wrapper = mount(LogoBrandSection, {
+			global: {
+				stubs: ['RouterLink', 'Logo'],
+			},
+			props: {
+				homeLink: { href: '/', ariaLabel: 'Accueil CNAM' },
+			},
+		})
+
+		expect(wrapper.find('logo-stub').attributes('arialabel')).toBe('Accueil CNAM Retour vers accueil du site')
+	})
 })

--- a/src/components/LogoBrandSection/tests/__snapshots__/LogoBrandSection.spec.ts.snap
+++ b/src/components/LogoBrandSection/tests/__snapshots__/LogoBrandSection.spec.ts.snap
@@ -14,7 +14,7 @@ exports[`LogoBrandSection > renders correctly 1`] = `
     href="/"
   >
     <logo-stub
-    arialabel="undefined Retour vers accueil du site"
+    arialabel="Retour vers accueil du site"
     avatar="false"
     class=""
     dark="false"

--- a/src/composables/index.ts
+++ b/src/composables/index.ts
@@ -12,3 +12,6 @@ export * from './usePagination'
 
 // Locales
 export * from './useLocales'
+
+// Home link fallback
+export * from './useHomeLinkFallback'

--- a/src/composables/useHomeLinkFallback.ts
+++ b/src/composables/useHomeLinkFallback.ts
@@ -1,0 +1,74 @@
+import { computed, getCurrentInstance } from 'vue'
+import type { ComputedRef } from 'vue'
+import type { RouteLocationRaw } from 'vue-router'
+
+export interface HomeLink {
+	'to'?: RouteLocationRaw
+	'href'?: string
+	'ariaLabel'?: string
+	'aria-label'?: string
+}
+
+export interface UseHomeLinkFallbackReturn {
+	/** Type de conteneur à rendre : 'router-link', 'a' ou 'div' */
+	containerComponent: ComputedRef<'router-link' | 'a' | 'div'>
+	/** `href` résolu pour un `<a>` (repli quand vue-router n'est pas disponible, ou `href` direct) */
+	homeHref: ComputedRef<string | undefined>
+}
+
+/**
+ * Détermine le conteneur du lien d'accueil (`router-link`, `<a>` ou `<div>`)
+ * et résout le `href` de repli quand `to` est fourni sans vue-router.
+ *
+ * Sans vue-router, on retombe sur un vrai `<a href>` : un `<div>` serait cliquable
+ * visuellement (cursor: pointer) mais ni focusable ni activable au clavier (RGAA 7.3).
+ *
+ * On résout les formes sérialisables de `RouteLocationRaw` (string et `{ path }`) ;
+ * pour une route nommée, seul le router sait construire l'URL, on retombe donc
+ * sur `href` puis sur la racine du site.
+ *
+ * Note : `query` et `hash` des routes objets ne sont pas sérialisés dans le fallback
+ * car seul `path` peut être utilisé comme `href` sans router.
+ */
+export function useHomeLinkFallback(homeLink: () => HomeLink | undefined): UseHomeLinkFallbackReturn {
+	const instance = getCurrentInstance()
+
+	const containerComponent = computed<'router-link' | 'a' | 'div'>(() => {
+		const link = homeLink()
+
+		if (link?.to) {
+			const componentsRegistered = instance?.appContext?.components
+			const hasRouterLink = componentsRegistered && 'RouterLink' in componentsRegistered
+			if (hasRouterLink) {
+				return 'router-link'
+			}
+			return 'a'
+		}
+		if (link?.href) {
+			return 'a'
+		}
+		return 'div'
+	})
+
+	const homeHref = computed<string | undefined>(() => {
+		const link = homeLink()
+
+		if (!link?.to) {
+			return link?.href
+		}
+
+		const to = link.to
+
+		if (typeof to === 'string') {
+			return to
+		}
+
+		if (to && typeof to === 'object' && 'path' in to && typeof to.path === 'string') {
+			return to.path
+		}
+
+		return link.href ?? '/'
+	})
+
+	return { containerComponent, homeHref }
+}


### PR DESCRIPTION
## Description

Ajoute le focus si `homeLink={ to: '/'}`

Composants impactés : LogoBrandSection / HeaderLogo

## Stories

<!-- Lien de la/les stories pour cette fonctonnalitée -->

## Type de changement

<!-- Supprimez les options non pertinentes. -->

- Nouvelle fonctionnalité
- Correction de bug
- Changement cassant
- Refactoring
- Maintenance
- Documentation
- Ce changement nécessite une mise à jour de la documentation

## Definition of Done

Avant de proposer une review, vérifiez chaque point de la checklist qui vous concerne et cochez-le s'il est appliqué.

### Nouveau composant/template

**Bonne Pratique**

- [ ] Ma Pull Request est bien nommée (Composant/template: descriptif du composant/template)
- [ ] Ma Pull Request pointe vers la bonne branche
- [ ] Linker la demande de création du composant/template et PR

**Design**

- [ ] Le composant/template respecte les maquettes validées
- [ ] Les design tokens sont utilisés

**Fonctionnel**

- [ ] Le composant/template est fonctionnel dans les cas d’usage définis
- [ ] Le composant/template est responsive (mobile, tablet, desktop)

**Accessibilité spécifique au composant/template**

- [ ] La navigation clavier couvre tous les éléments interactifs
- [ ] La restitution lecteur d’écran est correcte
- [ ] Les règles a11y spécifiques sont documentées
- [ ] Les tests a11y automatisés sont présents

**Documentation & Storybook**

- [ ] Une story est créée avec exemples d’usage
- [ ] L’onglet A11Y Storybook est présent et sans erreur
- [ ] Une page de documentation accessibilité est créée

**Tests**

- [ ] Des tests prouvent le bon fonctionnement du composant/template
- [ ] Deploy + SKSN Checks

---

### Evolution ou correctif de composant/template

**Bonne Pratique**

- [ ] Ma Pull Request est bien nommée (Composant/template: descriptif issue)
- [ ] Ma Pull Request pointe vers la bonne branche
- [ ] Linker issue et PR

**Design**

- [ ] L'évolution du composant/template respecte les maquettes validées (et l'équipe design est informée des changements)
- [ ] Les design tokens sont utilisés

**Fonctionnel**

- [ ] Le correctif résout le problème identifié
- [ ] Aucun impact sur les usages existants

**Accessibilité spécifique au composant/template**

- [ ] Navigation clavier vérifiée
- [ ] Restitution lecteur d’écran vérifiée
- [ ] Tests a11y mis à jour si nécessaire
- [ ] Page accessibilité mise à jour si impact / crée si n’existe pas

**Documentation & Storybook**

- [ ] Storybook mis à jour si nécessaire
- [ ] Onglet A11Y sans erreur
- [ ] La page de documentation accessibilité mise à jour si nécessaire

**Tests**

- [ ] Tests mis à jour ou ajoutés pour couvrir le correctif
- [ ] Deploy + SKSN Checks

**Fusion de composant/template**

- [ ] Le composant/template n'induit pas de régression dans le composant/template Synapse, Portail Agent ou AmeliPro
- [ ] Ajout des stories propre au thème (penser à filter le menu/props si nécessaire)
- [ ] Ajouter un message dans le composant/template déprécié avec un lien vers le nouveau