### PR TITLE
Storybook: add alphabetical sorting for controls and argTypes in doc

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -99,7 +99,10 @@ const preview: Preview = {
 		interactions: {
 			disable: true,
 		},
-		docs: { controls: { sort: 'alpha' } },
+		docs: {
+			controls: { sort: 'alpha' },
+			argTypes: { sort: 'alpha' },
+		},
 		options: {
 			storySort: {
 				method: 'alpha',
@@ -158,6 +161,7 @@ const preview: Preview = {
 				date: /Date$/i,
 			},
 			disableSaveFromUI: true,
+			sort: 'alpha',
 		},
 		backgrounds: {
 			options: {


### PR DESCRIPTION
## Tri alphabétique des props dans les pages Docs Storybook

### Problème
Depuis la montée de version vers Storybook 10, les props ne sont plus triées par ordre alphabétique dans les pages de documentation Storybook.

### Cause
Storybook 10 a séparé les blocs de documentation en deux entités distinctes avec des configurations de tri indépendantes :

Bloc Controls → parameters.docs.controls.sort
Bloc ArgTypes → parameters.docs.argTypes.sort
La configuration existante ne couvrait que parameters.docs.controls.sort, laissant le bloc ArgTypes (qui rend la table des props dans les pages Docs) avec sa valeur par défaut 'none'.

### Solution
Ajout du tri alphabétique (sort: 'alpha') aux trois niveaux de configuration dans preview.ts :
- parameters.controls.sort → panneau Controls de l'onglet Canvas
- parameters.docs.controls.sort → bloc Controls dans les pages Docs
- parameters.docs.argTypes.sort → bloc ArgTypes (table des props) dans les pages Docs