### PR TITLE
[NotificationBar] Modification du style pour centrer les notifications

### DIFF
--- a/src/components/NotificationBar/Notification/Notification.vue
+++ b/src/components/NotificationBar/Notification/Notification.vue
@@ -111,7 +111,6 @@
 		display: flex;
 		align-items: center;
 		width: 100%;
-		transform: translateX(-50%);
 		padding: var(--v-gap-2) var(--v-gap-4);
 		margin-block: var(--v-gap-1);
 		gap: var(--v-gap-2) var(--v-gap-4);

--- a/src/components/NotificationBar/NotificationBar.vue
+++ b/src/components/NotificationBar/NotificationBar.vue
@@ -150,8 +150,10 @@
 .notification-bar-transition {
 	width: min(calc(100% - 16px), 960px);
 	position: fixed;
+	left: 0;
+	right: 0;
+	margin: auto;
 	z-index: 2000;
-	left: 50%;
 }
 
 /* Fade transition for notifications */


### PR DESCRIPTION
Modification de style pour centrer les notification afin de ne pas bloqué l'interaction avec les éléments se situant sur la droite de la notification a un z-index inférieur.